### PR TITLE
Add plugin.json to root .claude-plugin/ for marketplace distribution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "excalidraw",
+  "description": "Excalidraw diagramming toolkit — auto-diagram any codebase, architecture diagrams, data flows, with PNG/SVG/URL export",
+  "version": "0.2.0"
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` at the repository root (copies existing file from `plugins/excalidraw/.claude-plugin/`)
- Required by the Claude Code marketplace CI, which validates plugin structure at the repo root level
- The existing `marketplace.json` is already in place — this is the only missing piece for marketplace distribution

No functional changes to the plugin itself.