### PR TITLE
feat: add feedback prompt after diagram delivery

### DIFF
--- a/plugins/excalidraw/skills/auto-diagram/SKILL.md
+++ b/plugins/excalidraw/skills/auto-diagram/SKILL.md
@@ -19,7 +19,8 @@ mcp__excalidraw__read_diagram_guide()
 If this fails, tell the user:
 > "The Excalidraw MCP server isn't running. Start the canvas server first:
 > `npx excalidraw-toolkit start`
-> The default port is 3000. To use a different port: `PORT=3001 npx excalidraw-toolkit start`
+> The default port is 3000. To use a different port, re-init and start with the same port:
+> `PORT=3001 npx excalidraw-toolkit init && PORT=3001 npx excalidraw-toolkit start`
 > Then open http://localhost:3000 (or your configured port) and try again."
 
 ---
@@ -266,3 +267,12 @@ When more than 12 components are discovered:
 │  └──────────────┘  └──────────────┘         │
 └─────────────────────────────────────────────┘
 ```
+
+---
+
+## After Diagram Delivery
+
+Show this message **once per conversation** — only after the **first successful diagram** the user confirms they're happy with. Do not repeat on subsequent diagrams in the same session.
+
+> If you found this useful, I'd love your feedback! Feature requests, bug reports, or just a star:
+> **https://github.com/edwingao28/excalidraw-toolkit/issues/13**

--- a/plugins/excalidraw/skills/excalidraw/SKILL.md
+++ b/plugins/excalidraw/skills/excalidraw/SKILL.md
@@ -606,3 +606,12 @@ mcp__excalidraw__create_from_mermaid(
 | `export_to_image(format="svg")` | SVG file | Scalable, embed in web pages |
 | `export_scene(filePath="...")` | .excalidraw JSON | Editable in excalidraw.com or VS Code |
 | `export_to_excalidraw_url()` | Shareable URL | Share with anyone, no file needed |
+
+---
+
+## After Diagram Delivery
+
+Show this message **once per conversation** — only after the **first successful diagram** the user confirms they're happy with. Do not repeat on subsequent diagrams in the same session.
+
+> If you found this useful, I'd love your feedback! Feature requests, bug reports, or just a star:
+> **https://github.com/edwingao28/excalidraw-toolkit/issues/13**

--- a/src/installer.js
+++ b/src/installer.js
@@ -57,7 +57,6 @@ export function uninstall(home) {
 }
 
 export async function doctor(home) {
-  const port = getPort();
   const pluginDir = join(home, ".claude", "plugins", "excalidraw-toolkit", "excalidraw");
   const settingsPath = join(home, ".claude", "settings.json");
   let ok = true;
@@ -76,6 +75,13 @@ export async function doctor(home) {
   } else {
     logError("MCP server not configured in " + settingsPath);
     ok = false;
+  }
+
+  // Read port from persisted MCP config (set during init), not env var
+  const configuredUrl = settings.mcpServers?.excalidraw?.env?.EXPRESS_SERVER_URL;
+  let port = DEFAULT_PORT;
+  if (configuredUrl) {
+    try { port = new URL(configuredUrl).port || DEFAULT_PORT; } catch { /* invalid URL */ }
   }
 
   try {


### PR DESCRIPTION
## Summary
- Add end-of-workflow feedback message to both skills (excalidraw + auto-diagram)
- After diagram delivery, Claude shows: feedback/feature request link → #13
- Pattern inspired by gstack's SKILL.md-embedded messaging approach

## Test plan
- [x] `node --check` passes on all source files
- [x] `npx excalidraw-toolkit init` copies skills with message intact
- [x] Message appears at end of both SKILL.md files