### PR TITLE
fix: register MCP at ~/.claude.json, npx shell on Windows, plugin root path (#15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "excalidraw-toolkit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Excalidraw diagramming toolkit for Claude Code — auto-diagram any codebase, architecture diagrams, data flows, with PNG/SVG export",
   "type": "module",
   "license": "MIT",

--- a/plugins/excalidraw/.mcp.json
+++ b/plugins/excalidraw/.mcp.json
@@ -3,7 +3,7 @@
     "excalidraw": {
       "command": "node",
       "args": [
-        "<HOME>/.claude/plugins/excalidraw-toolkit/excalidraw/mcp-bridge.mjs"
+        "${CLAUDE_PLUGIN_ROOT}/mcp-bridge.mjs"
       ],
       "env": {
         "EXPRESS_SERVER_URL": "http://localhost:3000"

--- a/plugins/excalidraw/mcp-bridge.mjs
+++ b/plugins/excalidraw/mcp-bridge.mjs
@@ -22,7 +22,13 @@ if (binPath) {
   const child = spawn("node", [realPath], { stdio: "inherit", env: process.env });
   child.on("exit", (code) => process.exit(code ?? 0));
 } else {
-  // Not globally installed — npx handles download, no symlink issue
-  const child = spawn("npx", ["-y", "mcp-excalidraw-server"], { stdio: "inherit", env: process.env });
+  // Not globally installed — npx handles download, no symlink issue.
+  // shell: true is required on Windows because `npx` resolves to npx.cmd,
+  // which Node's spawn cannot execute directly. See GitHub #15.
+  const child = spawn("npx", ["-y", "mcp-excalidraw-server"], {
+    stdio: "inherit",
+    env: process.env,
+    shell: process.platform === "win32",
+  });
   child.on("exit", (code) => process.exit(code ?? 0));
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -2,7 +2,7 @@ import { execSync, spawn } from "child_process";
 import { existsSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { copyDir, logError, logSuccess, mergeMcpServers, readJsonSafe, removeMcpServers } from "./utils.js";
+import { copyDir, logError, logSuccess, logWarn, mergeMcpServers, readJsonSafe, removeMcpServers } from "./utils.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -24,6 +24,7 @@ function getMcpConfig(home, port) {
   const bridgePath = join(home, ".claude", "plugins", "excalidraw-toolkit", "excalidraw", "mcp-bridge.mjs");
   return {
     excalidraw: {
+      type: "stdio",
       command: "node",
       args: [bridgePath],
       env: { EXPRESS_SERVER_URL: `http://localhost:${port}` },
@@ -31,34 +32,53 @@ function getMcpConfig(home, port) {
   };
 }
 
+// Claude Code's user-scope MCP registry. `~/.claude/settings.json` is NOT
+// read for MCP servers — see https://github.com/edwingao28/excalidraw-skill/issues/15.
+function userMcpConfigPath(home) {
+  return join(home, ".claude.json");
+}
+
+// Old (incorrect) location used before #15 was fixed. Cleaned up on install/uninstall
+// so doctor doesn't get confused by stale entries.
+function legacyMcpConfigPath(home) {
+  return join(home, ".claude", "settings.json");
+}
+
 export function install(home) {
   const port = getPort();
   const pluginDir = join(home, ".claude", "plugins", "excalidraw-toolkit", "excalidraw");
-  const settingsPath = join(home, ".claude", "settings.json");
+  const mcpConfigPath = userMcpConfigPath(home);
 
   copyDir(PLUGINS_SOURCE, pluginDir, { exclude: ["."] });
   logSuccess("Copied skills to " + pluginDir);
 
-  mergeMcpServers(settingsPath, getMcpConfig(home, port));
-  logSuccess("Registered MCP server in " + settingsPath);
+  mergeMcpServers(mcpConfigPath, getMcpConfig(home, port));
+  logSuccess("Registered MCP server in " + mcpConfigPath);
+
+  // Sweep stale entries from the pre-#15 location.
+  if (existsSync(legacyMcpConfigPath(home))) {
+    removeMcpServers(legacyMcpConfigPath(home), ["excalidraw"]);
+  }
 }
 
 export function uninstall(home) {
   const pluginDir = join(home, ".claude", "plugins", "excalidraw-toolkit");
-  const settingsPath = join(home, ".claude", "settings.json");
 
   if (existsSync(pluginDir)) {
     rmSync(pluginDir, { recursive: true, force: true });
     logSuccess("Removed " + pluginDir);
   }
 
-  removeMcpServers(settingsPath, ["excalidraw"]);
-  logSuccess("Removed MCP server from settings");
+  removeMcpServers(userMcpConfigPath(home), ["excalidraw"]);
+  if (existsSync(legacyMcpConfigPath(home))) {
+    removeMcpServers(legacyMcpConfigPath(home), ["excalidraw"]);
+  }
+  logSuccess("Removed MCP server registration");
 }
 
 export async function doctor(home) {
   const pluginDir = join(home, ".claude", "plugins", "excalidraw-toolkit", "excalidraw");
-  const settingsPath = join(home, ".claude", "settings.json");
+  const mcpConfigPath = userMcpConfigPath(home);
   let ok = true;
 
   const skillPath = join(pluginDir, "skills", "excalidraw", "SKILL.md");
@@ -69,16 +89,25 @@ export async function doctor(home) {
     ok = false;
   }
 
-  const settings = readJsonSafe(settingsPath);
-  if (settings.mcpServers?.excalidraw) {
-    logSuccess("MCP server configured in settings.json");
+  const mcpConfig = readJsonSafe(mcpConfigPath);
+  if (mcpConfig.mcpServers?.excalidraw) {
+    logSuccess("MCP server registered in " + mcpConfigPath);
   } else {
-    logError("MCP server not configured in " + settingsPath);
+    logError("MCP server not registered in " + mcpConfigPath);
+    console.error("    Run: npx excalidraw-toolkit init");
     ok = false;
   }
 
+  // Warn (don't fail) on a stale entry from the pre-#15 location: Claude Code
+  // ignores it for MCP, so it can't break the installation — just noise.
+  const legacy = readJsonSafe(legacyMcpConfigPath(home));
+  if (legacy.mcpServers?.excalidraw) {
+    logWarn("Stale MCP entry in " + legacyMcpConfigPath(home) + " (ignored by Claude Code)");
+    console.warn("    Run: npx excalidraw-toolkit init  (will clean it up)");
+  }
+
   // Read port from persisted MCP config (set during init), not env var
-  const configuredUrl = settings.mcpServers?.excalidraw?.env?.EXPRESS_SERVER_URL;
+  const configuredUrl = mcpConfig.mcpServers?.excalidraw?.env?.EXPRESS_SERVER_URL;
   let port = DEFAULT_PORT;
   if (configuredUrl) {
     try { port = new URL(configuredUrl).port || DEFAULT_PORT; } catch { /* invalid URL */ }

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,3 +50,7 @@ export function logSuccess(msg) {
 export function logError(msg) {
   console.error(`  \u2717 ${msg}`);
 }
+
+export function logWarn(msg) {
+  console.warn(`  \u26a0 ${msg}`);
+}


### PR DESCRIPTION
## Summary

Fixes the three install-path bugs from #15. Following the README's `npx excalidraw-toolkit init/start` flow on Windows left the canvas running but Claude Code with no usable `excalidraw` MCP server. Three independent issues compounded:

- **`init` wrote MCP config to the wrong file.** `~/.claude/settings.json` is not Claude Code's user MCP registry — `~/.claude.json` is. Installer now writes to `~/.claude.json` with the proper schema (`type: "stdio"`, `command`, `args`, `env`). `doctor` reads from the new location, warns if a stale entry exists in the old one, and `install`/`uninstall` sweep the legacy file.
- **`mcp-bridge` `npx` fallback couldn't launch on Windows.** `spawn("npx", ...)` doesn't resolve `npx.cmd` without a shell. Added `shell: process.platform === "win32"`.
- **Plugin `.mcp.json` used a literal `<HOME>`.** Claude Code does not substitute this. Switched to `${CLAUDE_PLUGIN_ROOT}/mcp-bridge.mjs`, which is the documented placeholder for plugin-bundled paths.

## Test plan

Verified end-to-end in a sandbox `HOME` (real `~/.claude.json` untouched):

- [x] `init` writes `~/.claude.json` with the correct stdio schema
- [x] `start` clones, builds, and serves the canvas (HTTP 200 on :3000)
- [x] `doctor` — all checks pass
- [x] MCP bridge: `initialize` + `tools/list` over stdio returns the full Excalidraw tool catalog (proves the bridge launches `mcp-excalidraw-server` via `npx -y`)
- [x] `uninstall` removes plugin dir and MCP entry; legacy stale entry simulated and confirmed to be cleaned on `init` and flagged by `doctor`
- [ ] Windows: not tested locally — covered by the `shell: process.platform === "win32"` branch per the issue's reproduction

Closes #15