### PR TITLE
[Editing]: apply scoped style changes with native review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
           node-version: 24
       - run: npm install --global npm@12.0.2
       - run: npm ci
-      - run: npm run build:canvas
-      - run: npm run build:runtime
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
       - run: node scripts/check-canvas-fonts.mjs --install-browser
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,50 @@ Run configuration tests with `npm test`. They use temporary home directories and
 
 ## What You Get
 
+### Scoped edits to saved diagrams
+
+Install the pinned renderer once, then inspect a native file to obtain its hash, element IDs, and supported operations:
+
+```bash
+excalidraw-toolkit setup-preview
+excalidraw-toolkit inspect architecture.excalidraw
+```
+
+Save a request as `edit.json`, using the returned `baseHash` and target ID:
+
+```json
+{
+  "requestId": "recolor-api-001",
+  "baseHash": "<hash from inspect>",
+  "operations": [
+    { "op": "setStyle", "targetId": "api", "style": { "backgroundColor": "#a5d8ff" } }
+  ]
+}
+```
+
+```bash
+excalidraw-toolkit edit architecture.excalidraw --request edit.json --output results
+excalidraw-toolkit preview results/recolor-api-001/receipt.json
+```
+
+The command returns a receipt linking `before.excalidraw`, `after.excalidraw`, and
+before/after PNG previews. It preserves the input bytes, image assets, unknown
+metadata, deleted elements, IDs, order, and every field outside the requested
+style properties. Native rendering consumes a separate copy of each scene.
+
+Supported edits currently change fill or stroke colors on rectangles, ellipses,
+and diamonds. Use hex RGB/RGBA colors or `transparent`. Other element types pass
+through unchanged; targeting them or requesting other operations fails explicitly.
+
+A retry with the same request ID and payload returns its existing verified
+bundle. Different payloads under that ID conflict. Failed attempts can be retried;
+interrupted attempts recover in a new attempt after their owner exits. Concurrent
+attempts return `REQUEST_BUSY`; keep the result directory on the same host.
+If the source changed before a new attempt, inspect it again and create a new
+request. A completed retry always returns its recorded result, even if the source
+subsequently changed. Inspect the previews and reopen the delivered native file
+before adopting it; the command does not overwrite an open editor's file.
+
 ### Auto-Diagram — Zero-Config Codebase Visualization
 
 Just say **"diagram this repo"**. No description needed.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,9 +10,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
 
-const { values, positionals } = parseArgs({ options: { home: { type: "string" }, json: { type: "boolean" }, "no-open": { type: "boolean" }, help: { type: "boolean", short: "h" }, version: { type: "boolean", short: "v" } }, allowPositionals: true });
+const { values, positionals } = parseArgs({ options: { home: { type: "string" }, json: { type: "boolean" }, "no-open": { type: "boolean" }, request: { type: "string" }, output: { type: "string" }, port: { type: "string" }, title: { type: "string" }, help: { type: "boolean", short: "h" }, version: { type: "boolean", short: "v" } }, allowPositionals: true });
 const home = resolve(values.home || homedir());
-const command = values.version ? "version" : positionals[0];
+const command = values.help ? "help" : values.version ? "version" : positionals[0];
 
 function printUsage() {
   console.log(`
@@ -26,6 +26,10 @@ Usage:
   npx ${pkg.name} uninstall  Remove skills and MCP config
   npx ${pkg.name} doctor     Check installation health and prerequisites
   npx ${pkg.name} status     Report canvas identity, ownership, and MCP capabilities
+  npx ${pkg.name} setup-preview  Install the pinned Chromium renderer
+  npx ${pkg.name} inspect <scene>  Read native IDs, input hash, and supported operations
+  npx ${pkg.name} edit <scene> --request <json> --output <directory>
+  npx ${pkg.name} preview <scene-or-receipt>  Review and export a native file
   npx ${pkg.name} version    Print version
 
 Options: --home <directory> (isolated installation), --json, --no-open
@@ -36,6 +40,18 @@ async function main() {
   const { install, uninstall, doctor, start, stop } = await import("../src/installer.js");
 
   switch (command) {
+    case "setup-preview": {
+      const {setupPreview} = await import("../src/render.js");
+      console.log(JSON.stringify(await setupPreview(), null, 2));
+      break;
+    }
+    case "inspect":
+    case "edit":
+    case "preview": {
+      const { sceneCommand } = await import("../src/commands.js");
+      console.log(JSON.stringify(await sceneCommand(command, positionals[1], values), null, 2));
+      break;
+    }
     case "init":
     case "update":
       console.log(`\n${pkg.name} v${pkg.version} — installing for Claude Code...\n`);
@@ -88,6 +104,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(JSON.stringify({ ok: false, error: err.message }));
+  console.error(JSON.stringify({ ok: false, code: err.code, error: err.message }));
   process.exit(1);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,18 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.30.0"
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "playwright": "1.63.0"
       },
       "bin": {
         "excalidraw-toolkit": "bin/cli.js"
       },
       "devDependencies": {
+        "@excalidraw/excalidraw": "0.18.1",
         "esbuild": "0.25.6",
-        "mcp-excalidraw-server": "2.0.0"
+        "mcp-excalidraw-server": "2.0.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
       },
       "engines": {
         "node": ">=20"
@@ -5314,6 +5318,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/png-chunk-text": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "excalidraw-toolkit",
   "version": "0.2.0",
-  "description": "Excalidraw diagramming toolkit for Claude Code — auto-diagram any codebase, architecture diagrams, data flows, with PNG/SVG export",
+  "description": "Excalidraw diagramming toolkit for Claude Code \u2014 auto-diagram any codebase, architecture diagrams, data flows, with PNG/SVG export",
   "type": "module",
   "license": "MIT",
   "bin": {
@@ -12,14 +12,17 @@
     "src",
     "plugins",
     "dist/canvas",
-    "dist/runtime"
+    "dist/runtime",
+    "dist/preview"
   ],
   "scripts": {
     "test": "node --test",
     "prepublishOnly": "node --check bin/cli.js && node --check src/installer.js && node --check src/utils.js && node --check src/config.js && npm test",
     "build:canvas": "node scripts/build-canvas.mjs",
     "build:runtime": "node scripts/build-runtime.mjs",
-    "prepack": "npm run build:canvas && npm run build:runtime"
+    "prepack": "npm run build && node scripts/check-preview-package.mjs",
+    "build:preview": "node scripts/build-preview.mjs",
+    "build": "npm run build:canvas && npm run build:runtime && npm run build:preview"
   },
   "keywords": [
     "excalidraw",
@@ -39,11 +42,15 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.30.0"
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "playwright": "1.63.0"
   },
   "devDependencies": {
     "mcp-excalidraw-server": "2.0.0",
-    "esbuild": "0.25.6"
+    "esbuild": "0.25.6",
+    "@excalidraw/excalidraw": "0.18.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "overrides": {
     "nanoid@3.3.3": "3.3.18",

--- a/plugins/excalidraw/skills/excalidraw/SKILL.md
+++ b/plugins/excalidraw/skills/excalidraw/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: excalidraw
-description: Generate architecture diagrams on a live Excalidraw canvas when the user provides specific components, a sample diagram, or a textual description of what to draw. Use for data flow diagrams, parameter threading traces, call chain visualizations, exporting .excalidraw files to PNG/SVG, or converting existing .excalidraw files to image formats. Do NOT use for zero-config codebase analysis — use the auto-diagram skill instead.
+description: Edit saved native Excalidraw diagrams with scoped file operations, or generate diagrams from specified components, a sample, or a description. Use for diagram edits, data flows, parameter traces, and PNG/SVG exports. For codebase discovery, use auto-diagram.
 ---
 
 # Excalidraw Diagram Generator (MCP Edition)
 
-Create diagrams on a **live Excalidraw canvas** using MCP tools. The canvas runs in a browser and updates in real time.
+For an existing saved diagram, use the file workflow below. For a new diagram, use the live canvas workflow that follows it.
+
+## Edit an existing saved diagram
+
+Use the installed toolkit CLI's absolute path from the project setup. In the commands below, replace `CLI` with `node "/absolute/path/to/excalidraw-toolkit/bin/cli.js"`; do not assume a global command or fetch an unpublished feature from the registry.
+
+1. Run `CLI inspect "/absolute/path/input.excalidraw"`. Read the returned capabilities, IDs, labels, and bindings. Resolve the requested target by ID; duplicate visible labels require inspection or clarification.
+2. Write a JSON request containing a new `requestId`, the inspected `baseHash`, and supported `operations`. For example, `{"op":"setStyle","targetId":"shape-id","style":{"backgroundColor":"#a5d8ff"}}`. Use only element types and properties supported by the returned capabilities. Report an unsupported request without rebuilding the scene.
+3. Run `CLI edit "/absolute/path/input.excalidraw" --request "/absolute/path/request.json" --output "/absolute/path/results"`. Retry the same recorded request with the same ID and payload. A changed request needs a new ID; stale input needs fresh inspection.
+4. Read the returned receipt and inspect both PNG previews. Check the requested change and preserved surrounding content. Return the edited native file, preview, original snapshot, and receipt paths. A failed or busy command is not a completed edit; report missing visual verification explicitly.
+
+This workflow writes an edited copy and retains the original bytes. Keep existing saved scenes on this route. Do not clear a live canvas or regenerate the scene to implement an unsupported edit. The remaining steps apply to new diagrams.
 
 ---
 

--- a/scripts/build-preview.mjs
+++ b/scripts/build-preview.mjs
@@ -1,0 +1,11 @@
+import { build } from 'esbuild';
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+// npm omits symlinked output directories; unlink one without changing its target.
+rmSync('dist/preview', { recursive: true, force: true });
+await build({ entryPoints: ['src/web/preview.jsx'], bundle: true, conditions: ['production'], minify: true, splitting: true, format: 'esm', outdir: 'dist/preview', define: { 'process.env.NODE_ENV': '"production"' }, loader: { '.woff2': 'file', '.woff': 'file', '.ttf': 'file' } });
+const native = dirname(require.resolve('@excalidraw/excalidraw'));
+mkdirSync('dist/preview/fonts', { recursive: true });
+cpSync(join(native, 'fonts'), 'dist/preview/fonts', { recursive: true });

--- a/scripts/check-preview-package.mjs
+++ b/scripts/check-preview-package.mjs
@@ -1,0 +1,23 @@
+// Inspect npm's actual file selection without rerunning prepack or creating a tarball.
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+const output = 'dist/preview';
+if (!lstatSync(output).isDirectory()) throw new Error('PACKED_PREVIEW: output must be a real directory');
+const expected = readdirSync(output, { recursive: true }).filter(path => {
+  const stat = lstatSync(join(output, path));
+  if (stat.isSymbolicLink()) throw new Error(`PACKED_PREVIEW: symlinked asset ${path}`);
+  return stat.isFile();
+}).map(path => `${output}/${path.replaceAll('\\', '/')}`);
+for (const file of ['preview.js', 'preview.css', 'fonts/Virgil/Virgil-Regular.woff2']) {
+  if (!expected.includes(`${output}/${file}`)) throw new Error(`PACKED_PREVIEW: missing built asset ${file}`);
+}
+const result = JSON.parse(execFileSync('npm', ['pack', '--dry-run', '--ignore-scripts', '--json'], {
+  encoding: 'utf8', shell: process.platform === 'win32', maxBuffer: 16 * 1024 * 1024,
+}));
+// npm 11 returns an array; npm 12 keys entries by package identity.
+const packages = Array.isArray(result) ? result : Object.values(result);
+const files = new Set(packages.flatMap(pkg => (pkg.files ?? []).map(file => file.path)));
+const missing = expected.filter(path => !files.has(path));
+if (missing.length) throw new Error(`PACKED_PREVIEW: npm omitted ${missing.length} preview files, including ${missing.slice(0, 3).join(', ')}`);
+console.log(`Packed preview selection: ${expected.length} built files included`);

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,0 +1,35 @@
+import {readFileSync} from 'node:fs';
+import {basename, resolve} from 'node:path';
+import {inspectScene, editScene, validateScene, verifyReceipt} from './scene.js';
+import {renderScene, servePreview} from './render.js';
+import {openBrowser} from './runtime.js';
+
+function readJSON(path) {
+  return JSON.parse(readFileSync(resolve(path), 'utf8'));
+}
+
+export async function sceneCommand(command, inputPath, values) {
+  if (!inputPath) throw new Error('INPUT_REQUIRED: provide a native scene or preview receipt path');
+  if (command === 'inspect') return inspectScene(inputPath);
+  if (command === 'edit') {
+    if (!values.request || !values.output) throw new Error('REQUEST_REQUIRED: provide --request <json> and --output <directory>');
+    return editScene({...readJSON(values.request), inputPath, outputDir: values.output}, {renderScene});
+  }
+  let scene = readJSON(inputPath);
+  let beforeScene;
+  let changes;
+  if (scene?.type !== 'excalidraw') {
+    const verified = await verifyReceipt(inputPath);
+    changes = verified.receipt.changes;
+    beforeScene = verified.beforeScene;
+    scene = verified.afterScene;
+  }
+  validateScene(scene);
+  if (beforeScene) validateScene(beforeScene);
+  const port = values.port === undefined ? 0 : Number(values.port);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) throw new Error('PORT_INVALID: use an integer from 0 to 65535');
+  const preview = await servePreview(scene, {beforeScene, changes, title: values.title || basename(inputPath).replace(/\.(excalidraw|json)$/, ''), port});
+  if (!values['no-open']) openBrowser(preview.url);
+  for (const signal of ['SIGINT', 'SIGTERM']) process.once(signal, async () => {await preview.close(); process.exit(0);});
+  return {url: preview.url, inputPath: resolve(inputPath), mode: beforeScene ? 'comparison' : 'preview'};
+}

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,72 @@
+import { createServer } from 'node:http';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { dirname, resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomBytes } from 'node:crypto';
+import { chromium } from 'playwright';
+const assets = resolve(dirname(fileURLToPath(import.meta.url)), '../dist/preview');
+const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="color-scheme" content="light"><title>Diagram review · Excalidraw Toolkit</title><link rel="stylesheet" href="./assets/preview.css"></head><body><div id="app"><p class="boot-message" role="status">Opening your diagram…</p></div><script type="module" src="./assets/preview.js"></script></body></html>`;
+export async function servePreview(scene, { port = 0, title, beforeScene, changes } = {}) {
+  if (!existsSync(resolve(assets, 'preview.js'))) throw new Error('PREVIEW_BUILD_MISSING: reinstall the packed toolkit or run npm run build');
+  const token = randomBytes(18).toString('hex');
+  const prefix = `/${token}/`;
+  const bytes = JSON.stringify(scene);
+  const context = JSON.stringify({ title: typeof title === 'string' ? title : null, beforeScene: beforeScene ?? null, changes: Array.isArray(changes) ? changes : null });
+  const server = createServer((req, res) => {
+    const pathname = new URL(req.url, 'http://127.0.0.1').pathname;
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    if (req.method !== 'GET' || !pathname.startsWith(prefix)) { res.writeHead(404); res.end(); return; }
+    const resource = pathname.slice(prefix.length);
+    if (!resource) { res.setHeader('Content-Type', 'text/html'); res.end(html); return; }
+    if (resource === 'scene') { res.setHeader('Content-Type', 'application/json'); res.end(bytes); return; }
+    if (resource === 'context') { res.setHeader('Content-Type', 'application/json'); res.end(context); return; }
+    const file = resolve(assets, resource.replace(/^assets\//, ''));
+    if (!resource.startsWith('assets/') || !file.startsWith(assets + '/') || !existsSync(file)) { res.writeHead(404); res.end(); return; }
+    const mime = { '.js': 'text/javascript', '.css': 'text/css', '.woff2': 'font/woff2', '.woff': 'font/woff', '.ttf': 'font/ttf' }[extname(file)] || 'application/octet-stream';
+    res.setHeader('Content-Type', mime);
+    try { res.end(readFileSync(file)); } catch { res.writeHead(404); res.end(); }
+  });
+  await new Promise((ok, fail) => { server.once('error', fail); server.listen(port, '127.0.0.1', ok); });
+  return { url: `http://127.0.0.1:${server.address().port}${prefix}`, close: () => new Promise(resolve => { server.closeAllConnections(); server.close(resolve); }) };
+}
+export async function renderScene(scene, outputPath) {
+  const preview = await servePreview(scene);
+  let browser;
+  try {
+    if (!rendererStatus().ready) throw new Error('PREVIEW_BROWSER_MISSING: run excalidraw-toolkit setup-preview to install the pinned Chromium renderer');
+    browser = await chromium.launch();
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
+    const origin = new URL(preview.url).origin;
+    const failedAssets = new Set();
+    page.on('requestfailed', request => { if (!request.url().endsWith('/favicon.ico')) failedAssets.add(request.url()); });
+    page.on('response', response => { if (response.status() >= 400 && !response.url().endsWith('/favicon.ico')) failedAssets.add(response.url()); });
+    await page.route('**/*', route => route.request().url().startsWith(origin + '/') || /^(data|blob):/.test(route.request().url()) ? route.continue() : route.abort());
+    await page.goto(preview.url);
+    await page.waitForFunction(() => window.previewReady || window.previewError, { timeout: 20000 });
+    const error = await page.evaluate(() => window.previewError);
+    if (error) throw new Error(error);
+    const data = await page.evaluate(() => window.renderPng());
+    if (failedAssets.size) throw new Error(`PREVIEW_ASSET_FAILED: ${[...failedAssets].join(', ')}`);
+    const png = Buffer.from(data.split(',')[1], 'base64');
+    if (png.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a') throw new Error('PREVIEW_INVALID: expected a PNG');
+    writeFileSync(outputPath, png, { flag: 'wx', mode: 0o600 });
+    return { renderer: '@excalidraw/excalidraw@0.18.1', browser: browser.version() };
+  } finally { if (browser) await browser.close(); await preview.close(); }
+}
+
+export function rendererStatus() {
+  const executablePath = chromium.executablePath();
+  return {ready: existsSync(executablePath), executablePath, renderer: '@excalidraw/excalidraw@0.18.1'};
+}
+export async function setupPreview() {
+  if (rendererStatus().ready) return rendererStatus();
+  const {createRequire} = await import('node:module');
+  const {execFile} = await import('node:child_process');
+  const {promisify} = await import('node:util');
+  const cli = resolve(dirname(createRequire(import.meta.url).resolve('playwright/package.json')), 'cli.js');
+  await promisify(execFile)(process.execPath, [cli, 'install', 'chromium'], {timeout: 180000, maxBuffer: 4 * 1024 * 1024});
+  const status = rendererStatus();
+  if (!status.ready) throw new Error('PREVIEW_BROWSER_MISSING: browser installation did not produce the expected executable');
+  return status;
+}

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,0 +1,385 @@
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { hostname } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+const STYLE_TYPES = ["rectangle", "ellipse", "diamond"];
+const STYLE_FIELDS = ["backgroundColor", "strokeColor"];
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function fail(code, message) {
+  throw Object.assign(new Error(message), { code });
+}
+
+export function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function object(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function keys(value, permitted, description) {
+  if (!object(value) || Object.keys(value).some((key) => !permitted.includes(key))) {
+    fail("INVALID_REQUEST", `Invalid fields in ${description}`);
+  }
+}
+
+export function validateScene(scene) {
+  if (!object(scene) || scene.type !== "excalidraw" || !Array.isArray(scene.elements)) {
+    fail("INVALID_SCENE", "Expected a native Excalidraw document with an elements array");
+  }
+  if (scene.files !== undefined && !object(scene.files)) fail("INVALID_SCENE", "Invalid scene files");
+  const index = new Map();
+  for (const element of scene.elements) {
+    if (!object(element) || typeof element.id !== "string" || !element.id || typeof element.type !== "string") {
+      fail("INVALID_SCENE", "Every element must have a nonempty ID and type");
+    }
+    if (index.has(element.id)) fail("DUPLICATE_ID", `Duplicate element ID: ${element.id}`);
+    index.set(element.id, element);
+  }
+  const live = (id, owner) => {
+    const target = index.get(id);
+    if (!target || target.isDeleted) fail("INVALID_BINDING", `${owner}: missing live reference ${id}`);
+    return target;
+  };
+  for (const element of scene.elements) {
+    // Deleted objects retain their native undo metadata, including old references.
+    if (element.isDeleted) continue;
+    if (element.boundElements != null) {
+      if (!Array.isArray(element.boundElements)) fail("INVALID_BINDING", `${element.id}: invalid boundElements`);
+      const seen = new Set();
+      for (const binding of element.boundElements) {
+        if (!object(binding) || typeof binding.id !== "string" || seen.has(binding.id)) {
+          fail("INVALID_BINDING", `${element.id}: invalid or duplicate bound element`);
+        }
+        seen.add(binding.id);
+        const child = live(binding.id, element.id);
+        if (binding.type !== child.type || !["text", "arrow"].includes(binding.type)) {
+          fail("INVALID_BINDING", `${element.id}: unsupported bound element reference`);
+        }
+        if (child.type === "text" && child.containerId !== element.id) {
+          fail("INVALID_BINDING", `${element.id}: nonreciprocal text binding`);
+        }
+        if (child.type === "arrow" && child.startBinding?.elementId !== element.id && child.endBinding?.elementId !== element.id) {
+          fail("INVALID_BINDING", `${element.id}: nonreciprocal arrow binding`);
+        }
+      }
+    }
+    if (element.containerId != null) {
+      const container = live(element.containerId, element.id);
+      if (element.type !== "text" || !container.boundElements?.some((entry) => entry.id === element.id && entry.type === "text")) {
+        fail("INVALID_BINDING", `${element.id}: nonreciprocal container binding`);
+      }
+    }
+    for (const field of ["startBinding", "endBinding"]) {
+      const binding = element[field];
+      if (binding == null) continue;
+      if (!object(binding) || typeof binding.elementId !== "string") fail("INVALID_BINDING", `${element.id}: invalid ${field}`);
+      const target = live(binding.elementId, element.id);
+      if (element.type !== "arrow" || !target.boundElements?.some((entry) => entry.id === element.id && entry.type === "arrow")) {
+        fail("INVALID_BINDING", `${element.id}: nonreciprocal ${field}`);
+      }
+    }
+    if (element.frameId != null && !["frame", "magicframe"].includes(live(element.frameId, element.id).type)) {
+      fail("INVALID_BINDING", `${element.id}: frameId does not reference a frame`);
+    }
+    if (element.type === "image" && element.fileId != null && !Object.hasOwn(scene.files ?? {}, element.fileId)) {
+      fail("MISSING_ASSET", `${element.id}: missing image asset ${element.fileId}`);
+    }
+  }
+  return index;
+}
+
+async function readScene(inputPath) {
+  const bytes = await fs.readFile(inputPath);
+  let scene;
+  try { scene = JSON.parse(bytes.toString("utf8")); }
+  catch { fail("INVALID_SCENE", "The input is not valid JSON"); }
+  validateScene(scene);
+  return { bytes, scene, hash: sha256(bytes) };
+}
+
+export async function inspectScene(inputPath) {
+  const { scene, hash } = await readScene(inputPath);
+  const index = new Map(scene.elements.map((element) => [element.id, element]));
+  return {
+    inputPath: resolve(inputPath),
+    baseHash: hash,
+    capabilities: {
+      operations: ["setStyle"],
+      setStyle: { elementTypes: STYLE_TYPES, fields: STYLE_FIELDS, colors: "hex RGB/RGBA or transparent" },
+      output: "edited copy; original is never overwritten",
+    },
+    elements: scene.elements.map((element) => ({
+      id: element.id, type: element.type, isDeleted: Boolean(element.isDeleted),
+      label: element.text ?? element.boundElements?.filter((binding) => binding.type === "text").map((binding) => index.get(binding.id)?.text).join("\n"),
+      x: element.x, y: element.y, width: element.width, height: element.height, angle: element.angle,
+      groupIds: element.groupIds, frameId: element.frameId, containerId: element.containerId,
+      boundElements: element.boundElements, startBinding: element.startBinding, endBinding: element.endBinding,
+    })),
+    assetIds: Object.keys(scene.files ?? {}),
+  };
+}
+
+export function applyStyleOperations(scene, operations) {
+  const index = validateScene(scene);
+  if (!Array.isArray(operations) || !operations.length) fail("INVALID_REQUEST", "operations must be a nonempty array");
+  const candidate = structuredClone(scene);
+  const next = new Map(candidate.elements.map((element) => [element.id, element]));
+  const allowed = new Map();
+  for (const operation of operations) {
+    keys(operation, ["op", "targetId", "style"], "operation");
+    if (operation.op !== "setStyle") fail("UNSUPPORTED_OPERATION", `Unsupported operation: ${operation.op}`);
+    const target = index.get(operation.targetId);
+    if (!target || target.isDeleted) fail("UNKNOWN_TARGET", `No live element with ID: ${operation.targetId}`);
+    if (!STYLE_TYPES.includes(target.type)) fail("UNSUPPORTED_TARGET", `Style edits do not support ${target.type}`);
+    keys(operation.style, STYLE_FIELDS, "style");
+    if (!Object.keys(operation.style).length) fail("INVALID_REQUEST", "style must contain at least one color");
+    const fields = allowed.get(target.id) ?? new Set();
+    for (const [field, color] of Object.entries(operation.style)) {
+      if (typeof color !== "string" || !(color === "transparent" || /^#(?:[\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i.test(color))) {
+        fail("INVALID_REQUEST", `Invalid ${field}: use a hex color or transparent`);
+      }
+      if (fields.has(field)) fail("INVALID_REQUEST", `Repeated assignment: ${target.id}.${field}`);
+      fields.add(field);
+      next.get(target.id)[field] = color;
+    }
+    allowed.set(target.id, fields);
+  }
+  validateScene(candidate);
+  const protectedCopy = structuredClone(candidate);
+  const changes = [];
+  for (let i = 0; i < scene.elements.length; i++) {
+    const before = scene.elements[i];
+    const after = candidate.elements[i];
+    const properties = {};
+    for (const field of allowed.get(before.id) ?? []) {
+      if (!isDeepStrictEqual(before[field], after[field])) {
+        properties[field] = { before: before[field] ?? null, after: after[field] };
+      }
+      if (Object.hasOwn(before, field)) protectedCopy.elements[i][field] = before[field];
+      else delete protectedCopy.elements[i][field];
+    }
+    if (Object.keys(properties).length) changes.push({ id: before.id, properties });
+  }
+  if (!isDeepStrictEqual(scene, protectedCopy)) fail("PROTECTED_CHANGE", "The candidate changed a protected value");
+  return { candidate, changes };
+}
+
+async function writeDurable(path, contents) {
+  const handle = await fs.open(path, "wx", 0o600);
+  try { await handle.writeFile(contents); await handle.sync(); }
+  finally { await handle.close(); }
+}
+
+async function syncDirectory(path) {
+  const handle = await fs.open(path, "r");
+  try { await handle.sync(); } finally { await handle.close(); }
+}
+
+async function publishJSON(path, value) {
+  const temp = `${path}.${randomUUID()}.tmp`;
+  await writeDurable(temp, `${JSON.stringify(value, null, 2)}\n`);
+  try { await fs.link(temp, path); await syncDirectory(dirname(path)); }
+  finally { await fs.unlink(temp); }
+}
+
+async function readJSON(path) {
+  try { return JSON.parse(await fs.readFile(path, "utf8")); }
+  catch (error) { if (error.code === "ENOENT") return null; throw error; }
+}
+
+function alive(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error.code !== "ESRCH"; }
+}
+
+async function claimAttempt(jobDir) {
+  const claimsDir = join(jobDir, "claims");
+  await fs.mkdir(claimsDir, { recursive: true });
+  const generations = (await fs.readdir(claimsDir)).filter((name) => /^\d+\.json$/.test(name)).map((name) => Number.parseInt(name)).sort((a, b) => a - b);
+  const previous = generations.at(-1) ?? 0;
+  if (previous) {
+    const owner = await readJSON(join(claimsDir, `${previous}.json`));
+    const finished = await readJSON(join(jobDir, "attempts", owner.attemptId, "finished.json"));
+    // Claims are never unlinked. A crashed attempt can only be succeeded by a new
+    // generation, avoiding the stale-lock removal race with another retry.
+    if (!finished && (owner.hostname !== hostname() || alive(owner.pid))) {
+      fail("REQUEST_BUSY", "This request has an active or unverifiable owner; retry after it exits");
+    }
+  }
+  const attemptId = randomUUID();
+  const attemptDir = join(jobDir, "attempts", attemptId);
+  await fs.mkdir(attemptDir, { recursive: true });
+  const owner = { attemptId, pid: process.pid, hostname: hostname(), startedAt: new Date().toISOString() };
+  const ownerPath = join(attemptDir, "owner.json");
+  await writeDurable(ownerPath, JSON.stringify(owner));
+  try { await fs.link(ownerPath, join(claimsDir, `${previous + 1}.json`)); await syncDirectory(claimsDir); }
+  catch (error) {
+    if (error.code === "EEXIST") fail("REQUEST_BUSY", "Another attempt claimed this request; retry later");
+    throw error;
+  }
+  return attemptDir;
+}
+
+function freeze(value) {
+  if (value && typeof value === "object") {
+    Object.freeze(value);
+    for (const child of Object.values(value)) freeze(child);
+  }
+  return value;
+}
+
+export function deriveSceneChanges(before, after) {
+  validateScene(before);
+  validateScene(after);
+  if (!isDeepStrictEqual({ ...before, elements: [] }, { ...after, elements: [] }) || after.elements.length < before.elements.length) {
+    fail("CORRUPT_RESULT", "The completed scene changed protected document fields or removed native history");
+  }
+  const changes = [];
+  for (let i = 0; i < after.elements.length; i++) {
+    const previous = before.elements[i], current = after.elements[i];
+    if (!previous) {
+      changes.push({ id: current.id, created: true, properties: Object.fromEntries(Object.entries(current).map(([field, value]) => [field, { before: null, after: value }])) });
+      continue;
+    }
+    if (previous.id !== current.id) fail("CORRUPT_RESULT", "The completed scene reordered or replaced existing element identities");
+    const properties = {};
+    for (const field of new Set([...Object.keys(previous), ...Object.keys(current)])) {
+      if (!isDeepStrictEqual(previous[field], current[field])) {
+        properties[field] = { before: previous[field] ?? null, ...(Object.hasOwn(current, field) ? { after: current[field] } : {}) };
+      }
+    }
+    if (Object.keys(properties).length) changes.push({ id: previous.id, properties });
+  }
+  return changes;
+}
+
+export async function verifyReceipt(receiptPath, { expectedDigest } = {}) {
+  const path = resolve(receiptPath), jobDir = dirname(path);
+  const hash = value => typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+  const exactFields = (value, fields) => object(value) && Object.keys(value).length === fields.length && fields.every(field => Object.hasOwn(value, field));
+  const readRegular = async file => {
+    try {
+      if (!(await fs.lstat(file)).isFile()) fail("CORRUPT_RESULT", "Completed files must be regular files");
+      return await fs.readFile(file);
+    } catch { fail("CORRUPT_RESULT", `Cannot read completed file: ${basename(file)}`); }
+  };
+  let receipt, recorded;
+  try {
+    receipt = JSON.parse(await readRegular(path));
+    recorded = JSON.parse(await readRegular(join(jobDir, "request.json")));
+  } catch { fail("CORRUPT_RESULT", "The completed receipt or recorded request is invalid"); }
+  if (!exactFields(recorded, ["digest", "inputPath", "requestId", "baseHash", "operations"]) ||
+    !hash(recorded.digest) || !hash(recorded.baseHash) || typeof recorded.inputPath !== "string" || resolve(recorded.inputPath) !== recorded.inputPath ||
+    typeof recorded.requestId !== "string" || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(recorded.requestId) ||
+    recorded.requestId !== basename(jobDir) || !Array.isArray(recorded.operations) || !recorded.operations.length || recorded.operations.some(operation => !object(operation))) {
+    fail("CORRUPT_RESULT", "The completed request record has an invalid shape or identity");
+  }
+  const { digest, ...request } = recorded;
+  if (digest !== sha256(canonical(request)) || (expectedDigest !== undefined && digest !== expectedDigest)) fail("CORRUPT_RESULT", "The completed request no longer matches its digest");
+  const names = ["before.excalidraw", "after.excalidraw", "before.png", "after.png"];
+  if (!exactFields(receipt, ["schemaVersion", "status", "requestId", "requestDigest", "inputPath", "inputHash", "outputHash", "changes", "validation", "artifacts", "receiptPath"]) ||
+    receipt.schemaVersion !== 1 || receipt.status !== "complete" || receipt.receiptPath !== path || basename(path) !== "receipt.json" ||
+    receipt.requestId !== recorded.requestId || receipt.requestDigest !== digest || receipt.inputPath !== recorded.inputPath || receipt.inputHash !== recorded.baseHash || !hash(receipt.outputHash) ||
+    !Array.isArray(receipt.changes) || !exactFields(receipt.artifacts, names) ||
+    !isDeepStrictEqual(receipt.validation, { uniqueIds: true, bindings: true, protectedValues: true, previews: true })) {
+    fail("CORRUPT_RESULT", "The completed receipt has inconsistent identity, hashes or validation metadata");
+  }
+  const documents = {};
+  let attemptDir;
+  for (const name of names) {
+    const artifact = receipt.artifacts[name];
+    if (!exactFields(artifact, ["path", "sha256"]) || typeof artifact.path !== "string" || !hash(artifact.sha256)) fail("CORRUPT_RESULT", `Invalid completed artifact: ${name}`);
+    const directory = dirname(artifact.path);
+    if (dirname(directory) !== join(jobDir, "attempts") || !/^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/.test(basename(directory)) ||
+      artifact.path !== join(directory, name) || (attemptDir && directory !== attemptDir)) fail("CORRUPT_RESULT", "Completed artifacts must belong to one attempt in this result directory");
+    if (!attemptDir) {
+      for (const directoryPath of [dirname(directory), directory]) {
+        try { if (!(await fs.lstat(directoryPath)).isDirectory()) fail("CORRUPT_RESULT", "Attempt directories cannot be symlinks"); }
+        catch { fail("CORRUPT_RESULT", "Cannot read the completed attempt directory"); }
+      }
+    }
+    attemptDir = directory;
+    const bytes = await readRegular(artifact.path);
+    if (sha256(bytes) !== artifact.sha256) fail("CORRUPT_RESULT", `Changed completed artifact: ${name}`);
+    if (name.endsWith(".excalidraw")) {
+      try { documents[name] = JSON.parse(bytes); validateScene(documents[name]); }
+      catch { fail("CORRUPT_RESULT", `Invalid completed native scene: ${name}`); }
+    } else if (bytes.length < 24 || !bytes.subarray(0, 8).equals(PNG_SIGNATURE)) fail("CORRUPT_RESULT", `Invalid completed PNG: ${name}`);
+  }
+  const beforeScene = documents["before.excalidraw"], afterScene = documents["after.excalidraw"];
+  const changes = deriveSceneChanges(beforeScene, afterScene);
+  if (receipt.inputHash !== receipt.artifacts["before.excalidraw"].sha256 || receipt.outputHash !== receipt.artifacts["after.excalidraw"].sha256 ||
+    !isDeepStrictEqual(receipt.changes, changes)) fail("CORRUPT_RESULT", "The receipt hashes or change summary disagree with the retained native scenes");
+  return { receipt, beforeScene, afterScene };
+}
+
+export async function editScene({ inputPath, outputDir, ...request }, options = {}) {
+  keys(request, ["requestId", "baseHash", "operations"], "request");
+  if (typeof request.requestId !== "string" || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(request.requestId)) {
+    fail("INVALID_REQUEST", "requestId must contain 1–80 letters, digits, dots, underscores, or hyphens and start with a letter or digit");
+  }
+  if (typeof request.baseHash !== "string" || !/^[\da-f]{64}$/.test(request.baseHash)) fail("INVALID_REQUEST", "baseHash must be the SHA-256 returned by inspect");
+  if (typeof inputPath !== "string" || typeof outputDir !== "string") fail("INVALID_REQUEST", "inputPath and outputDir are required");
+  const input = resolve(inputPath);
+  const jobDir = join(resolve(outputDir), request.requestId);
+  const digest = sha256(canonical({ inputPath: input, ...request }));
+  await fs.mkdir(jobDir, { recursive: true });
+  const requestPath = join(jobDir, "request.json");
+  try { await publishJSON(requestPath, { digest, inputPath: input, ...request }); }
+  catch (error) { if (error.code !== "EEXIST") throw error; }
+  const recorded = await readJSON(requestPath);
+  if (recorded.digest !== digest) fail("REQUEST_CONFLICT", "This requestId is already associated with a different request");
+  const receiptPath = join(jobDir, "receipt.json");
+  const completed = await readJSON(receiptPath);
+  if (completed) return (await verifyReceipt(receiptPath, { expectedDigest: digest })).receipt;
+  const attemptDir = await claimAttempt(jobDir);
+  try {
+    // A prior owner may have completed between our first receipt read and claim.
+    const latest = await readJSON(receiptPath);
+    if (latest) return (await verifyReceipt(receiptPath, { expectedDigest: digest })).receipt;
+    const { bytes, scene, hash } = await readScene(input);
+    if (hash !== request.baseHash) fail("STALE_INPUT", "Input changed after inspection; inspect it again before editing");
+    const { candidate, changes } = applyStyleOperations(scene, request.operations);
+    const after = Buffer.from(`${JSON.stringify(candidate, null, 2)}\n`);
+    const render = options.renderScene ?? (await import("./render.js")).renderScene;
+    await writeDurable(join(attemptDir, "before.excalidraw"), bytes);
+    await writeDurable(join(attemptDir, "after.excalidraw"), after);
+    for (const [name, document] of [["before.png", scene], ["after.png", candidate]]) {
+      await render(freeze(structuredClone(document)), join(attemptDir, name));
+      const png = await fs.readFile(join(attemptDir, name));
+      if (png.length < 24 || !png.subarray(0, 8).equals(PNG_SIGNATURE)) fail("INVALID_RENDER", `Renderer did not create a PNG: ${name}`);
+      const handle = await fs.open(join(attemptDir, name), "r");
+      try { await handle.sync(); } finally { await handle.close(); }
+    }
+    const artifacts = {};
+    for (const name of ["before.excalidraw", "after.excalidraw", "before.png", "after.png"]) {
+      const path = join(attemptDir, name);
+      artifacts[name] = { path, sha256: sha256(await fs.readFile(path)) };
+    }
+    if (artifacts["before.excalidraw"].sha256 !== hash || artifacts["after.excalidraw"].sha256 !== sha256(after)) {
+      fail("PROTECTED_CHANGE", "A native artifact changed during preview generation");
+    }
+    const receipt = {
+      schemaVersion: 1, status: "complete", requestId: request.requestId, requestDigest: digest,
+      inputPath: input, inputHash: hash, outputHash: sha256(after), changes,
+      validation: { uniqueIds: true, bindings: true, protectedValues: true, previews: true },
+      artifacts, receiptPath,
+    };
+    await publishJSON(receiptPath, receipt);
+    return receipt;
+  } finally {
+    await publishJSON(join(attemptDir, "finished.json"), { finishedAt: new Date().toISOString() });
+  }
+}

--- a/src/web/edit-summary.js
+++ b/src/web/edit-summary.js
@@ -1,0 +1,88 @@
+const live = element => element && !element.isDeleted;
+const connection = element => ['arrow', 'line'].includes(element?.type);
+const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+const geometry = ['x', 'y', 'width', 'height', 'angle', 'points'];
+const bookkeeping = new Set(['id', 'seed', 'version', 'versionNonce', 'updated', 'boundElements', 'isDeleted']);
+const styles = { backgroundColor: 'Fill', strokeColor: 'Stroke', fillStyle: 'Fill pattern', strokeWidth: 'Stroke width', strokeStyle: 'Stroke pattern', opacity: 'Opacity', roughness: 'Sketchiness', roundness: 'Corners', fontSize: 'Text size', fontFamily: 'Font family', textAlign: 'Text alignment', verticalAlign: 'Vertical alignment', lineHeight: 'Line height', startArrowhead: 'Start marker', endArrowhead: 'End marker' };
+
+export function elementLabel(element, elements) {
+  if (!element) return 'Unknown element';
+  const label = element.name || element.originalText || element.text || elements.filter(item => live(item) && item.type === 'text' && item.containerId === element.id).map(item => item.originalText || item.text).filter(Boolean).join(' ');
+  return typeof label === 'string' && label.trim() ? label.trim() : `${element.type[0].toUpperCase()}${element.type.slice(1)}`;
+}
+
+function endpoints(element) { return [element.startBinding?.elementId ?? null, element.endBinding?.elementId ?? null]; }
+function connectionLabel(element, elements) {
+  const [start, end] = endpoints(element);
+  if (!start && !end) return 'connection';
+  return [start, end].map(id => id ? elementLabel(elements.find(item => item.id === id), elements) : 'unbound end').join(' → ');
+}
+
+// The server verifies receipts. This presentation uses their before/after scenes;
+// it does not promote a field count or reciprocal bindings into extra edits.
+export function summarizeEdits(beforeScene, afterScene, changes) {
+  if (!beforeScene || !afterScene || !Array.isArray(changes)) return null;
+  const before = new Map(beforeScene.elements.map(element => [element.id, element]));
+  const after = new Map(afterScene.elements.map(element => [element.id, element]));
+  const summaries = [];
+  const push = (id, kind, text, details = []) => summaries.push({ id: `${id}:${kind}`, kind, text, details });
+  for (const change of changes) {
+    const old = before.get(change.id), next = after.get(change.id);
+    if (!live(old) && !live(next)) continue;
+    const element = live(next) ? next : old;
+    const elements = live(next) ? afterScene.elements : beforeScene.elements;
+    const label = elementLabel(element, elements);
+    const isConnection = connection(element);
+    if (!live(old) || !live(next)) {
+      const added = live(next);
+      // A new/deleted bound label is part of its new/deleted parent.
+      const parentId = element.type === 'text' && element.containerId;
+      if (parentId && Boolean(live(before.get(parentId))) !== Boolean(live(after.get(parentId)))) continue;
+      push(change.id, added ? 'added' : 'removed', `${added ? (isConnection ? 'Connected' : 'Added') : 'Removed'} ${isConnection ? connectionLabel(element, elements) : label}`);
+      continue;
+    }
+    const fields = new Set(Object.keys(change.properties || {}).filter(key => !same(old[key], next[key]) && !bookkeeping.has(key)));
+    const consume = keys => keys.forEach(key => fields.delete(key));
+    const oldLabel = elementLabel(old, beforeScene.elements);
+    if (['text', 'originalText', 'name'].some(key => fields.has(key))) {
+      if (oldLabel !== label) push(change.id, 'renamed', `Renamed ${oldLabel} → ${label}`);
+      consume(['text', 'originalText', 'name']);
+      if (element.type === 'text') consume(element.containerId ? ['x', 'y', 'width', 'height', 'autoResize'] : ['width', 'height', 'autoResize']);
+    }
+    if (isConnection && !same(endpoints(old), endpoints(next))) {
+      push(change.id, 'reconnected', `Reconnected ${connectionLabel(next, afterScene.elements)}`, [{ label: 'Previously', value: connectionLabel(old, beforeScene.elements) }]);
+      consume(geometry);
+    }
+    if (isConnection) {
+      consume(['startBinding', 'endBinding']);
+      // Native arrows follow moved/resized endpoints; their routing is supporting geometry.
+      if (endpoints(next).some(id => before.has(id) && after.has(id) && geometry.some(key => !same(before.get(id)[key], after.get(id)[key])))) consume(geometry);
+    }
+    if (element.type === 'text' && element.containerId) {
+      const oldParent = before.get(element.containerId), newParent = after.get(element.containerId);
+      if (oldParent && newParent && geometry.some(key => !same(oldParent[key], newParent[key]))) consume(geometry);
+      if (['fontSize', 'fontFamily', 'lineHeight', 'textAlign', 'verticalAlign'].some(key => fields.has(key))) consume(['x', 'y', 'width', 'height']);
+    }
+    if (geometry.some(key => fields.has(key))) {
+      const kind = isConnection ? 'adjusted' : fields.has('width') || fields.has('height') ? 'resized' : fields.has('angle') ? 'rotated' : 'moved';
+      push(change.id, kind, `${kind[0].toUpperCase()}${kind.slice(1)} ${isConnection ? connectionLabel(next, afterScene.elements) : label}`);
+      consume(geometry);
+    }
+    const details = Object.entries(styles).filter(([key]) => fields.has(key)).map(([key, label]) => ({ label, before: old[key], after: next[key] }));
+    if (details.length) push(change.id, 'styled', `Restyled ${label}`, details);
+    consume(Object.keys(styles));
+    if (fields.size) push(change.id, 'updated', `Updated ${label}`);
+  }
+  return summaries;
+}
+
+export function formatTechnicalChanges(changes) {
+  return JSON.stringify(changes, (_key, value) => typeof value === 'number' && Number.isFinite(value) ? Number(value.toFixed(2)) : value, 2);
+}
+
+export function displayValue(value) {
+  if (value == null) return 'None';
+  if (typeof value === 'number') return Number(value.toFixed(2)).toString();
+  if (typeof value === 'string') return value || 'Empty';
+  return JSON.stringify(value);
+}

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -1,0 +1,114 @@
+:root { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #26251f; background: #faf9f5; font-synthesis: none; color-scheme: light; --paper: #faf9f5; --ink: #26251f; --muted: #77756c; --line: #e5e3da; --clay: #c67a59; }
+* { box-sizing: border-box; }
+body { margin: 0; }
+button, input { font: inherit; }
+button { cursor: pointer; -webkit-tap-highlight-color: transparent; }
+button:disabled { cursor: default; opacity: .44; }
+button:focus-visible, a:focus-visible, .technical-changes summary:focus-visible, .technical-changes pre:focus-visible { outline: 2px solid #a25a3c; outline-offset: 4px; }
+svg { flex-shrink: 0; }
+.review-app { height: 100dvh; min-height: 560px; display: flex; flex-direction: column; }
+.boot-message { padding: 40px; color: var(--muted); }
+.skip-link { position: fixed; top: -80px; left: 20px; z-index: 100; background: var(--ink); color: white; padding: 12px 18px; border-radius: 8px; }
+.skip-link:focus { top: 12px; }
+.review-header { min-height: 80px; flex-shrink: 0; padding: 18px 32px; display: flex; align-items: center; gap: 24px; border-bottom: 1px solid var(--line); }
+.brand { display: flex; align-items: center; gap: 12px; font-size: 17px; letter-spacing: -.45px; white-space: nowrap; }
+.brand strong { font-weight: 600; }
+.brand-mark { width: 35px; height: 35px; display: grid; place-items: center; color: var(--clay); }
+.header-divider, .action-divider { height: 22px; width: 1px; background: var(--line); }
+.header-label { color: var(--muted); font-size: 13px; }
+.header-actions { display: flex; align-items: center; gap: 10px; margin-left: auto; }
+.button { min-height: 39px; border-radius: 7px; padding: 9px 13px; display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-size: 12px; font-weight: 550; border: 1px solid transparent; transition: background .15s ease, border-color .15s ease; white-space: nowrap; }
+.button-quiet { background: transparent; color: #5c5a51; }
+.button-quiet:hover:not(:disabled) { background: #efede6; }
+.button-outline { background: #fffefa; border-color: #d8d6cc; color: #45433b; }
+.button-outline:hover:not(:disabled) { border-color: #9e998b; background: white; }
+.button-primary { background: var(--ink); color: #fffdf7; border-color: var(--ink); box-shadow: 0 1px 2px #26251f14; }
+.button-primary:hover:not(:disabled) { background: #454136; border-color: #454136; }
+.action-divider { margin: 0 4px; }
+.review-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 264px minmax(0, 1fr); }
+.sidebar-toggle { display: none; }
+.review-sidebar { padding: 31px 22px 20px; border-right: 1px solid var(--line); display: flex; flex-direction: column; min-width: 0; min-height: 0; overflow-y: auto; }
+.sidebar-heading, .section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.eyebrow { color: #817a6d; text-transform: uppercase; font-size: 10px; font-weight: 650; letter-spacing: 1.4px; margin: 0; }
+.file-badge { color: #7d776b; font-size: 10px; padding: 3px 6px; border: 1px solid var(--line); border-radius: 4px; }
+.document-card { display: flex; align-items: flex-start; gap: 12px; margin: 22px 0 28px; }
+.document-icon { display: grid; place-items: center; width: 39px; height: 45px; background: #f0ece2; border: 1px solid #e4ddcd; border-radius: 6px; color: #9a8468; flex-shrink: 0; }
+.document-card h2 { font-size: 13px; font-weight: 550; line-height: 1.45; margin: 2px 0 5px; overflow-wrap: anywhere; }
+.document-card p { margin: 0; font-size: 11px; color: #827b6d; }
+.sidebar-section { border-top: 1px solid var(--line); padding-top: 22px; margin-bottom: 25px; }
+.section-heading { margin-bottom: 14px; }
+.section-heading h2 { font-size: 11px; font-weight: 600; margin: 0; color: #686459; }
+.section-heading > span { font-size: 11px; color: #7e7669; font-variant-numeric: tabular-nums; }
+.scene-stats { margin: 0; display: grid; gap: 12px; }
+.scene-stats > div { display: flex; align-items: center; justify-content: space-between; font-size: 12px; }
+.scene-stats dt { display: flex; align-items: center; gap: 10px; color: #706d62; }
+.scene-stats dt svg { color: #999386; }
+.scene-stats dd { margin: 0; color: #4a473e; font-variant-numeric: tabular-nums; }
+.object-list, .change-list { list-style: none; padding: 0; margin: 0; }
+.object-list { display: grid; gap: 12px; }
+.object-list li { display: flex; align-items: center; gap: 10px; font-size: 12px; color: #787367; min-width: 0; }
+.object-list li > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.object-dot { width: 5px; height: 5px; background: #c4bdae; border-radius: 50%; flex-shrink: 0; margin-left: 5px; margin-right: 6px; }
+.sidebar-note { font-size: 11px; line-height: 1.65; color: #81796b; margin: 0; }
+.more-objects { margin-top: 12px; padding-left: 26px; }
+.change-count { background: #eee3d8; border: 1px solid #e6d5c4; color: #9b6548 !important; border-radius: 5px; min-width: 20px; text-align: center; padding: 2px 5px; }
+.change-list { display: grid; gap: 14px; }
+.change-list > li { display: flex; align-items: flex-start; gap: 9px; }
+.change-mark { margin-top: 1px; flex-shrink: 0; width: 18px; height: 18px; border-radius: 50%; display: grid; place-items: center; font-size: 12px; line-height: 1; color: #8c7459; background: #eee9df; }
+.change-mark--added { color: #52684e; background: #e5eadf; }
+.change-mark--removed { color: #996148; background: #f0e2d9; }
+.change-description { min-width: 0; flex: 1; }
+.change-description > p { font-size: 12px; font-weight: 500; line-height: 1.55; margin: 0; color: #514b41; overflow-wrap: anywhere; }
+.property-change { font-size: 10px; line-height: 1.5; color: #7d7364; display: flex; flex-wrap: wrap; gap: 3px 7px; margin-top: 6px; overflow-wrap: anywhere; }
+.property-change > span:first-child { color: #645c50; }
+.change-values, .color-value { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 5px; }
+.change-values { gap: 6px; font-variant-numeric: tabular-nums; }
+.color-swatch { width: 9px; height: 9px; flex-shrink: 0; border-radius: 2px; border: 1px solid #0002; }
+.technical-changes { margin-top: 19px; border-top: 1px solid var(--line); padding-top: 13px; min-width: 0; }
+.technical-changes summary { cursor: pointer; font-size: 11px; line-height: 1.6; color: #746b5e; border-radius: 2px; }
+.technical-changes summary:hover { color: var(--ink); }
+.technical-changes summary > span { display: block; margin-left: 14px; color: #8b8171; font-size: 10px; font-variant-numeric: tabular-nums; }
+.technical-changes .sidebar-note { margin-top: 13px; font-size: 10px; }
+.technical-changes pre { margin: 12px 0 0; padding: 12px; max-height: 260px; overflow: auto; border: 1px solid var(--line); border-radius: 5px; background: #f3f0e8; font: 10px/1.65 ui-monospace, SFMono-Regular, Menlo, monospace; tab-size: 2; }
+.sidebar-footer { margin-top: auto; padding-top: 25px; font-size: 10px; line-height: 1.5; color: #857d6e; display: flex; align-items: center; gap: 7px; }
+.sidebar-footer svg { color: #918c74; }
+.diagram-workspace { padding: 38px 40px 22px; min-width: 0; min-height: 0; display: flex; flex-direction: column; outline: none; }
+.workspace-heading { display: flex; flex-shrink: 0; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 28px; }
+.workspace-heading .eyebrow { color: #a67f65; margin-bottom: 10px; }
+.workspace-heading h1 { font-family: Georgia, "Times New Roman", serif; font-size: clamp(26px, 2.45vw, 37px); letter-spacing: -.8px; font-weight: 400; line-height: 1.2; margin: 0; overflow-wrap: anywhere; }
+.workspace-description { margin: 12px 0 0; color: #81796d; font-size: 12px; line-height: 1.6; }
+.review-badge { flex-shrink: 0; display: flex; align-items: center; gap: 7px; border: 1px solid #e5e0d4; border-radius: 20px; padding: 7px 10px; font-size: 10px; color: #807565; }
+.review-badge > span { width: 5px; height: 5px; background: #b59a75; border-radius: 50%; }
+.canvas-card { min-height: 200px; flex: 1; display: flex; flex-direction: column; background: #fff; border: 1px solid #e1ded4; border-radius: 11px; overflow: hidden; box-shadow: 0 3px 7px #33270e03, 0 16px 40px #33270e03; }
+.canvas-toolbar { min-height: 52px; flex-shrink: 0; padding: 10px 17px; display: flex; align-items: center; gap: 20px; border-bottom: 1px solid #eeece5; background: #fffefa; }
+.canvas-caption { display: flex; align-items: center; gap: 8px; color: #82796c; font-size: 11px; }
+.canvas-caption svg { color: #ad9d88; }
+.view-tabs { display: inline-flex; padding: 3px; background: #f0ede5; border: 1px solid #e9e5dc; border-radius: 6px; gap: 2px; }
+.view-tabs button { padding: 5px 13px; border: 0; border-radius: 4px; background: transparent; color: #817461; font-size: 10px; }
+.view-tabs button[aria-selected="true"] { color: #5c4a35; background: #fffefa; box-shadow: 0 1px 3px #3a2c1512; }
+.fit-button { margin-left: auto; padding: 6px 0 6px 8px; border: 0; background: transparent; display: flex; align-items: center; gap: 7px; font-size: 10px; color: #7e7363; }
+.fit-button:hover:not(:disabled) { color: var(--ink); }
+.canvas-panel { position: relative; flex: 1; min-height: 0; }
+.canvas-panel > .excalidraw { position: absolute; inset: 0; --color-primary: #9b654b; --color-primary-darker: #805039; --color-primary-light: #efe1d5; --color-primary-light-darker: #e8d4c4; }
+.canvas-panel .excalidraw .App-bottom-bar,
+.canvas-panel .excalidraw .layer-ui__wrapper,
+.canvas-panel .excalidraw .App-menu_top { display: none; }
+.canvas-state { min-height: 390px; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 15px; padding: 30px; text-align: center; color: #b7a78f; background: radial-gradient(circle at 50% 40%, #fffefa, #fff); }
+.canvas-state h2 { font-family: Georgia, serif; color: #746858; font-weight: 400; font-size: 23px; margin: 2px 0 0; }
+.canvas-state p { margin: 0; font-size: 12px; color: #817665; }
+.loading-symbol { animation: breathe 1.8s ease-in-out infinite; }
+.canvas-footer { min-height: 39px; flex-shrink: 0; border-top: 1px solid #eeece5; display: flex; align-items: center; justify-content: space-between; gap: 15px; padding: 10px 17px; color: #867b6c; font-size: 10px; background: #fffefa; }
+#status { display: inline-flex; align-items: center; gap: 7px; }
+.status-dot { width: 5px; height: 5px; border-radius: 50%; background: #c4b7a2; }
+.status-dot.is-ready { background: #95a181; }
+.workspace-footer { display: flex; flex-shrink: 0; justify-content: space-between; gap: 20px; padding-top: 17px; font-size: 10px; line-height: 1.5; color: #8c8272; }
+.workspace-footer > span:first-child { font-family: Georgia, serif; font-style: italic; font-size: 12px; }
+.feedback { padding: 12px 14px; display: flex; align-items: center; gap: 10px; font-size: 12px; line-height: 1.5; border: 1px solid #dfbba6; background: #fbefe7; color: #8b503b; border-radius: 7px; margin-bottom: 16px; }
+.feedback > span { overflow-wrap: anywhere; }
+.feedback button { border: 0; background: transparent; color: inherit; margin-left: auto; font-size: 22px; }
+@keyframes breathe { 50% { opacity: .4; transform: translateY(-2px); } }
+@media (min-width: 1600px) { .diagram-workspace { padding-left: 64px; padding-right: 64px; } }
+@media (max-width: 1100px) { .review-header { padding: 16px 22px; gap: 18px; } .header-label, .header-divider { display: none; } .diagram-workspace { padding: 30px 26px 20px; } .review-body { grid-template-columns: 236px minmax(0, 1fr); } .review-sidebar { padding-left: 18px; padding-right: 18px; } .workspace-heading { align-items: flex-start; } .review-badge { display: none; } }
+@media (max-width: 820px) { .review-app { height: auto; min-height: 100dvh; } .review-body { display: flex; flex-direction: column; } .diagram-workspace { min-height: 540px; flex: 1; } .sidebar-toggle { display: flex; align-items: center; gap: 8px; min-height: 43px; border: 0; border-bottom: 1px solid var(--line); padding: 10px 24px; text-align: left; color: #7c7261; background: transparent; font-size: 11px; } .sidebar-toggle > span:last-child { margin-left: auto; font-size: 17px; } .review-sidebar { display: none; } .review-sidebar[data-open="true"] { display: flex; flex: none; max-height: 50dvh; padding: 20px 26px; border-right: 0; border-bottom: 1px solid var(--line); } .review-sidebar .sidebar-footer { padding-top: 0; } .review-header { flex-wrap: wrap; gap: 14px; } .brand { font-size: 16px; } .header-actions { gap: 7px; } .button { padding: 8px 10px; } .action-divider { display: none; } .workspace-heading h1 { font-size: 31px; } .canvas-panel { min-height: 260px; } }
+@media (max-width: 560px) { .review-header { padding: 15px 18px; } .header-actions { width: 100%; margin-left: 0; justify-content: space-between; } .button { min-height: 40px; padding: 8px; font-size: 11px; } .button-quiet { padding-left: 0; } .diagram-workspace { padding: 26px 16px 18px; } .workspace-heading { margin-bottom: 22px; } .workspace-heading h1 { font-size: 29px; } .workspace-description { max-width: 275px; } .canvas-toolbar { gap: 10px; padding: 10px 12px; flex-wrap: wrap; } .canvas-caption { margin-right: auto; } .fit-button span { display: none; } .fit-button { margin-left: 0; } .view-tabs button { padding: 6px 11px; } .canvas-hint { display: none; } .canvas-footer { padding: 10px 12px; } .workspace-footer { gap: 14px; } .workspace-footer > span:last-child { max-width: 175px; text-align: right; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; transition: none !important; } }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Excalidraw, exportToCanvas } from '@excalidraw/excalidraw';
+import '@excalidraw/excalidraw/index.css';
+import './preview.css';
+import { elementLabel, summarizeEdits, formatTechnicalChanges, displayValue } from './edit-summary.js';
+
+window.EXCALIDRAW_ASSET_PATH = new URL('./assets/', window.location.href).href;
+let activeScene;
+async function png() {
+  if (!activeScene) throw new Error('Open a diagram before exporting.');
+  await document.fonts.ready;
+  const canvas = await exportToCanvas({ elements: structuredClone(activeScene.elements.filter(e => !e.isDeleted)), files: structuredClone(activeScene.files || {}), appState: { ...activeScene.appState, exportBackground: true, exportWithDarkMode: false }, exportPadding: 30 });
+  await document.fonts.ready;
+  return canvas.toDataURL('image/png');
+}
+window.renderPng = png;
+window.sceneForPreview = () => structuredClone(activeScene);
+
+function Icon({ name, size = 18 }) {
+  const paths = {
+    open: <><path d="M3 7h6l2 2h10l-3 10H3z" /><path d="M3 7V5h6l2 2h7v2" /></>,
+    download: <path d="M12 3v12m-4-4 4 4 4-4M4 16v4h16v-4" />,
+    file: <path d="M6 3h8l4 4v14H6zM14 3v5h4M9 13h6m-6 4h6" />,
+    fit: <><path d="M8 3H3v5m13-5h5v5M3 16v5h5m13-5v5h-5" /><rect x="7" y="7" width="10" height="10" rx="1" /></>,
+    layers: <path d="m12 3 9 5-9 5-9-5zM3 12l9 5 9-5M3 16l9 5 9-5" />,
+    arrow: <path d="M4 12h16m-5-5 5 5-5 5" />,
+    check: <path d="m5 12 4 4L19 6" />,
+    text: <path d="M4 5h16M12 5v15M8 20h8M4 5v3m16-3v3" />,
+    shape: <rect x="4" y="4" width="16" height="16" rx="3" />,
+    image: <><rect x="3" y="3" width="18" height="18" rx="3" /><circle cx="8" cy="8" r="1.5" /><path d="m3 17 6-6 4 4 3-3 5 5" /></>,
+    frame: <path d="M6 2v20M18 2v20M2 6h20M2 18h20" />,
+    pen: <path d="m5 15-2 6 6-2L21 7l-4-4zM14 6l4 4" />,
+    info: <><circle cx="12" cy="12" r="9" /><path d="M12 11v6m0-10v.1" /></>,
+  };
+  return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">{paths[name] || paths.shape}</svg>;
+}
+
+function validate(value) {
+  if (!value || value.type !== 'excalidraw' || !Array.isArray(value.elements) || value.elements.some(e => !e || typeof e.id !== 'string' || typeof e.type !== 'string')) throw new Error('This is not a valid Excalidraw diagram. Choose a .excalidraw file and try again.');
+  return value;
+}
+function download(href, name) { const anchor = document.createElement('a'); anchor.href = href; anchor.download = name; anchor.click(); }
+class CanvasBoundary extends React.Component {
+  state = { failed: false };
+  static getDerivedStateFromError() { return { failed: true }; }
+  componentDidCatch(error) { this.props.onError(error.message); }
+  render() { return this.state.failed ? <div className="canvas-state"><Icon name="info" size={28} /><h2>Unable to display this diagram</h2><p>Open another file to continue.</p></div> : this.props.children; }
+}
+
+function Review() {
+  const [scene, setScene] = useState(null);
+  const [context, setContext] = useState({});
+  const [view, setView] = useState('after');
+  const [revision, setRevision] = useState(0);
+  const [api, setApi] = useState(null);
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const [notice, setNotice] = useState('');
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const fileInput = useRef(null);
+  const canvasPanel = useRef(null);
+  const tabs = useRef([]);
+  const displayed = view === 'before' ? context.beforeScene : scene;
+  activeScene = displayed;
+  const elements = useMemo(() => displayed?.elements.filter(e => !e.isDeleted) || [], [displayed]);
+  const title = context.title?.trim() || (typeof scene?.appState?.name === 'string' && scene.appState.name) || 'Diagram review';
+  const filename = title.replace(/[<>:"/\\|?*\x00-\x1f]/g, '-').trim() || 'diagram';
+  const changes = Array.isArray(context.changes) ? context.changes : null;
+  const summary = useMemo(() => summarizeEdits(context.beforeScene, scene, changes), [context.beforeScene, scene, changes]);
+  const objects = elements.filter(e => e.type !== 'text' && !['arrow', 'line'].includes(e.type));
+  const categories = [['shape', 'Shapes', ['rectangle', 'ellipse', 'diamond']], ['arrow', 'Connections', ['arrow', 'line']], ['text', 'Labels', ['text']], ['frame', 'Frames', ['frame', 'magicframe']], ['image', 'Images', ['image']], ['pen', 'Freehand', ['freedraw']]].map(([icon, label, types]) => ({ icon, label, count: elements.filter(e => types.includes(e.type)).length })).filter(item => item.count);
+  const otherCount = elements.length - categories.reduce((count, item) => count + item.count, 0);
+  if (otherCount) categories.push({ icon: 'layers', label: 'Other elements', count: otherCount });
+  function reportError(message) { setError(message); window.previewError = message; }
+  function resetReadiness() { setApi(null); setReady(false); window.previewReady = false; window.previewError = undefined; }
+  function fitDiagram() {
+    if (api) api.scrollToContent(api.getSceneElements(), { fitToViewport: true, viewportZoomFactor: 0.82, maxZoom: 1, animate: false });
+  }
+
+  useEffect(() => {
+    Promise.all(['scene', 'context'].map(async resource => {
+      const response = await fetch(`./${resource}`);
+      if (!response.ok) throw new Error('The diagram could not be loaded. Reopen the preview and try again.');
+      return response.json();
+    })).then(([value, metadata]) => { validate(value); if (metadata.beforeScene) validate(metadata.beforeScene); setScene(value); setContext(metadata); }).catch(error => reportError(error.message));
+  }, []);
+  useEffect(() => { document.title = `${title} · Excalidraw Toolkit`; }, [title]);
+  useEffect(() => {
+    if (!api || !displayed) return;
+    let cancelled = false;
+    let frame;
+    const resize = new ResizeObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => { frame = requestAnimationFrame(() => { if (!cancelled) fitDiagram(); }); });
+    });
+    resize.observe(canvasPanel.current);
+    (async () => {
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      await document.fonts.ready;
+      if (cancelled) return;
+      fitDiagram();
+      setReady(true); window.previewReady = true;
+    })().catch(error => reportError(error.message));
+    return () => { cancelled = true; resize.disconnect(); cancelAnimationFrame(frame); };
+  }, [api, displayed]);
+
+  async function openFile(event) {
+    const file = event.target.files?.[0]; if (!file) return;
+    try {
+      const value = validate(JSON.parse(await file.text()));
+      resetReadiness(); setError(''); setNotice(''); setView('after');
+      setScene(value); setContext({ title: file.name.replace(/\.(excalidraw|json)$/i, '') }); setRevision(value => value + 1);
+    } catch (error) { setError(error instanceof SyntaxError ? 'This file contains invalid JSON. Choose a valid .excalidraw file.' : error.message); }
+    event.target.value = '';
+  }
+  function selectView(next) { if (view !== next) { resetReadiness(); setError(''); setNotice(''); setView(next); } }
+  async function exportPng() {
+    setExporting(true); setError('');
+    try { download(await png(), `${filename}${context.beforeScene ? `-${view}` : ''}.png`); setNotice('PNG download started.'); }
+    catch (error) { setError(`PNG export failed: ${error.message}`); }
+    finally { setExporting(false); }
+  }
+  function saveNative() {
+    const url = URL.createObjectURL(new Blob([JSON.stringify(displayed, null, 2)], { type: 'application/json' }));
+    download(url, `${filename}${context.beforeScene ? `-${view}` : ''}.excalidraw`);
+    setTimeout(() => URL.revokeObjectURL(url), 1000); setNotice('Editable copy download started.');
+  }
+
+  return <div className="review-app">
+    <a className="skip-link" href="#diagram-workspace">Skip to diagram</a>
+    <header className="review-header">
+      <div className="brand"><span className="brand-mark"><Icon name="layers" size={25} /></span><span>Excalidraw <strong>Toolkit</strong></span></div>
+      <span className="header-divider" /><span className="header-label">Diagram review</span>
+      <div className="header-actions">
+        <input ref={fileInput} id="open" type="file" accept=".excalidraw,application/json" onChange={openFile} hidden />
+        <button className="button button-quiet" onClick={() => fileInput.current.click()}><Icon name="open" /><span>Open file</span></button>
+        <span className="action-divider" />
+        <button id="native" className="button button-outline" aria-label="Download editable .excalidraw copy" title="Download the current view as an editable .excalidraw copy" disabled={!ready} onClick={saveNative}><Icon name="file" /><span>Download copy</span></button>
+        <button id="png" className="button button-primary" disabled={!ready || exporting} onClick={exportPng}><Icon name="download" /><span>{exporting ? 'Exporting…' : 'Export PNG'}</span></button>
+      </div>
+    </header>
+    <div className="review-body">
+      <button className="sidebar-toggle" aria-expanded={detailsOpen} aria-controls="scene-details" onClick={() => setDetailsOpen(value => !value)}><Icon name="layers" size={16} /><span>Diagram details</span><span aria-hidden="true">{detailsOpen ? '−' : '+'}</span></button>
+      <aside id="scene-details" className="review-sidebar" data-open={detailsOpen} aria-label="Diagram details">
+        <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
+        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
+        <EditSummary changes={changes} summary={summary} key={revision} />
+        <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
+          {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
+        </section>
+        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
+        <div className="sidebar-footer"><Icon name="check" size={15} /><span>Review a copy. Keep your original.</span></div>
+      </aside>
+      <main id="diagram-workspace" className="diagram-workspace" tabIndex={-1}>
+        <div className="workspace-heading"><div><p className="eyebrow">{context.beforeScene ? 'Compare & review' : 'Your diagram'}</p><h1>{title}</h1><p className="workspace-description">{context.beforeScene ? 'A clear view of what changed, with the original close at hand.' : 'Explore the details. Take the editable file with you.'}</p></div><span className="review-badge"><span />Read-only preview</span></div>
+        {error && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{error}</span>{scene && <button aria-label="Dismiss error" onClick={() => setError('')}>×</button>}</div>}
+        <div className="canvas-card">
+          <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{context.beforeScene ? (view === 'after' ? 'Updated diagram' : 'Original diagram') : 'Canvas'}</span></div>
+            {context.beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{['before', 'after'].map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? 1 : 1 - index; selectView(['before', 'after'][next]); tabs.current[next]?.focus(); } }}>{item === 'before' ? 'Before' : 'After'}</button>)}</div>}
+            <button aria-label="Fit diagram" className="fit-button" disabled={!ready || !elements.length} onClick={fitDiagram}><Icon name="fit" size={15} /><span>Fit diagram</span></button>
+          </div>
+          <div ref={canvasPanel} id="canvas-panel" className="canvas-panel" role={context.beforeScene ? 'tabpanel' : 'region'} aria-labelledby={context.beforeScene ? `${view}-tab` : undefined} aria-label={context.beforeScene ? undefined : 'Diagram canvas'} aria-busy={!ready && !error}>
+            {displayed ? <CanvasBoundary key={`${revision}-${view}`} onError={reportError}><Excalidraw key={`${revision}-${view}`} initialData={{ elements: structuredClone(displayed.elements), files: structuredClone(displayed.files || {}), appState: { ...displayed.appState, viewModeEnabled: true } }} excalidrawAPI={setApi} viewModeEnabled={true} zenModeEnabled={true} theme="light" /></CanvasBoundary> : <div className="canvas-state"><span className={error ? '' : 'loading-symbol'}><Icon name={error ? 'info' : 'layers'} size={30} /></span><h2>{error ? 'Your diagram is waiting' : 'Opening your diagram'}</h2><p>{error ? 'Choose a file to start a new review.' : 'Preparing the native canvas…'}</p></div>}
+          </div>
+          <div className="canvas-footer"><span id="status" role="status"><span className={`status-dot ${ready ? 'is-ready' : ''}`} />{ready ? `${elements.length} ${elements.length === 1 ? 'element' : 'elements'} · Viewing a read-only copy` : error ? 'Preview unavailable' : 'Preparing canvas…'}</span><span className="canvas-hint">Scroll to pan · Pinch to zoom</span></div>
+        </div>
+        <div className="workspace-footer"><span>Made to stay editable.</span><span role="status" aria-live="polite">{notice || (context.beforeScene ? `Exports use the ${view} view.` : 'PNG for sharing. Excalidraw for what comes next.')}</span></div>
+      </main>
+    </div>
+  </div>;
+}
+function EditSummary({ changes, summary }) {
+  const fieldCount = changes?.reduce((count, change) => count + Object.keys(change.properties || {}).length, 0) || 0;
+  return <section className="sidebar-section changes-section" aria-labelledby="changes-title">
+    <div className="section-heading"><h2 id="changes-title">Edit summary</h2>{summary && <span className="change-count" aria-label={`${summary.length} summarized edits`}>{summary.length}</span>}</div>
+    {summary?.length ? <ul className="change-list">{summary.map(item => <li key={item.id}>
+      <span className={`change-mark change-mark--${item.kind}`} aria-hidden="true">{item.kind === 'added' ? '+' : item.kind === 'removed' ? '−' : '↗'}</span>
+      <div className="change-description"><p>{item.text}</p>{item.details.map((detail, index) => <div className="property-change" key={index}>
+        <span>{detail.label}</span>{'value' in detail ? <span>{detail.value}</span> : <span className="change-values"><StyleValue value={detail.before} label={detail.label} /><span aria-label="to">→</span><StyleValue value={detail.after} label={detail.label} /></span>}
+      </div>)}</div>
+    </li>)}</ul> : <p className="sidebar-note">{changes ? (changes.length ? 'Element metadata updated. See the technical changes below.' : 'No changes recorded in this review.') : 'No edit receipt is attached to this diagram.'}</p>}
+    {!!changes?.length && <details className="technical-changes">
+      <summary>Technical changes<span>{fieldCount} fields · {changes.length} elements</span></summary>
+      <p className="sidebar-note">Display values are rounded to two decimals. The editable copy keeps the original values.</p>
+      <pre tabIndex={0} aria-label="Full element field changes">{formatTechnicalChanges(changes)}</pre>
+    </details>}
+  </section>;
+}
+function StyleValue({ value, label }) {
+  const color = typeof value === 'string' && /^(#[\da-f]{3,8}|transparent)$/i.test(value);
+  const names = { '#1e1e1e': 'Charcoal', '#ffffff': 'White', '#000000': 'Black', '#a5d8ff': 'Light blue', '#e7f5ff': 'Pale blue', '#b2f2bb': 'Light green', '#d3f9d8': 'Pale green', '#ffc9c9': 'Light red', '#ffec99': 'Light yellow', transparent: 'None' };
+  const text = label === 'Corners' ? (value ? 'Rounded' : 'Square') : color ? names[value.toLowerCase()] || value : displayValue(value);
+  return <span className="color-value" title={color ? value : undefined}>{color && <span className="color-swatch" style={{ backgroundColor: value }} />}<span>{text}</span></span>;
+}
+createRoot(document.getElementById('app')).render(<Review />);

--- a/test/edit-summary.test.js
+++ b/test/edit-summary.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveSceneChanges } from '../src/scene.js';
+import { summarizeEdits, formatTechnicalChanges, displayValue } from '../src/web/edit-summary.js';
+
+const node = (id, label) => [
+  { id, type: 'rectangle', x: 0, y: 0, width: 200, height: 80, isDeleted: false, boundElements: [{ id: `${id}-label`, type: 'text' }] },
+  { id: `${id}-label`, type: 'text', text: label, originalText: label, x: 50, y: 20, width: 100, height: 20, containerId: id, isDeleted: false },
+];
+const arrow = (id, start, end) => ({ id, type: 'arrow', startBinding: start ? { elementId: start } : null, endBinding: end ? { elementId: end } : null, isDeleted: false });
+const scene = elements => ({ type: 'excalidraw', version: 2, source: 'test', elements, appState: {}, files: {} });
+function withBindings(value) {
+  const copy = structuredClone(value);
+  for (const element of copy.elements) if (element.boundElements) element.boundElements = element.boundElements.filter(binding => binding.type !== 'arrow');
+  for (const element of copy.elements.filter(element => element.type === 'arrow' && !element.isDeleted)) {
+    for (const binding of [element.startBinding, element.endBinding].filter(Boolean)) copy.elements.find(item => item.id === binding.elementId).boundElements.push({ id: element.id, type: 'arrow' });
+  }
+  return copy;
+}
+function summarize(before, after) {
+  before = withBindings(before); after = withBindings(after);
+  return summarizeEdits(before, after, deriveSceneChanges(before, after));
+}
+
+test('queue insertion summarizes the topology and rename without reciprocal bindings or label metrics', () => {
+  const before = scene([...node('api', 'API service'), ...node('worker', 'Worker'), arrow('direct', 'api', 'worker')]);
+  const after = structuredClone(before);
+  Object.assign(after.elements[1], { text: 'Public API', originalText: 'Public API', width: 121.3784319, x: 39.31078405 });
+  after.elements[0].boundElements.push({ id: 'enqueue', type: 'arrow' });
+  after.elements[2].boundElements.push({ id: 'delivery', type: 'arrow' });
+  after.elements[4].isDeleted = true;
+  after.elements.push(...node('queue', 'Queue'), arrow('enqueue', 'api', 'queue'), arrow('delivery', 'queue', 'worker'));
+  const snapshot = structuredClone({ before, after });
+  assert.deepEqual(summarize(before, after).map(item => item.text), [
+    'Renamed API service → Public API', 'Removed API service → Worker', 'Added Queue', 'Connected Public API → Queue', 'Connected Queue → Worker',
+  ]);
+  assert.deepEqual({ before, after }, snapshot);
+});
+
+test('moving a node includes its bound label and attached routing as one edit', () => {
+  const before = scene([...node('api', 'API'), ...node('worker', 'Worker'), { ...arrow('direct', 'api', 'worker'), x: 0, points: [[0, 0], [100, 0]] }]);
+  const after = structuredClone(before);
+  after.elements[2].x += 80;
+  after.elements[3].x += 80;
+  after.elements[4].points[1][0] += 80;
+  assert.deepEqual(summarize(before, after).map(item => item.text), ['Moved Worker']);
+});
+
+test('style edits use human labels and retain their actual before/after values', () => {
+  const before = scene(node('worker', 'Worker'));
+  before.elements[0].backgroundColor = '#ffffff';
+  const after = structuredClone(before);
+  after.elements[0].backgroundColor = '#a5d8ff';
+  after.elements[0].strokeWidth = 2.1234567;
+  const [change] = summarize(before, after);
+  assert.equal(change.text, 'Restyled Worker');
+  assert.deepEqual(change.details, [{ label: 'Fill', before: '#ffffff', after: '#a5d8ff' }, { label: 'Stroke width', before: undefined, after: 2.1234567 }]);
+});
+
+test('reconnections use endpoint identities while retaining the prior route', () => {
+  const before = scene([...node('api', 'API'), ...node('worker', 'Worker'), ...node('queue', 'Queue'), arrow('direct', 'api', 'worker')]);
+  const after = structuredClone(before);
+  after.elements[6].endBinding.elementId = 'queue';
+  assert.deepEqual(summarize(before, after).map(({ text, details }) => ({ text, details })), [{ text: 'Reconnected API → Queue', details: [{ label: 'Previously', value: 'API → Worker' }] }]);
+});
+
+test('unsupported changes remain visible and unknown endpoints are not invented', () => {
+  const before = scene(node('api', 'API'));
+  const after = structuredClone(before);
+  after.elements[0].link = 'https://example.com';
+  after.elements.push(arrow('unbound', 'api', null));
+  assert.deepEqual(summarize(before, after).map(item => item.text), ['Updated API', 'Connected API → unbound end']);
+  assert.equal(summarizeEdits(null, after, []), null);
+});
+
+test('technical changes format nested objects as JSON and round display only', () => {
+  const changes = [{ id: 'label', properties: { x: { before: 11.1234567, after: 18.998765 }, boundElements: { before: [], after: [{ id: 'label', type: 'text' }] } } }];
+  const original = structuredClone(changes);
+  const formatted = formatTechnicalChanges(changes);
+  assert.equal(JSON.parse(formatted)[0].properties.x.after, 19);
+  assert.match(formatted, /"id": "label"/);
+  assert.doesNotMatch(formatted, /\[object Object\]/);
+  assert.equal(displayValue([{ id: 'label' }]), '[{"id":"label"}]');
+  assert.equal(displayValue(1.234567), '1.23');
+  assert.deepEqual(changes, original);
+});

--- a/test/fixtures/annotated.excalidraw
+++ b/test/fixtures/annotated.excalidraw
@@ -1,0 +1,347 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "toolkit-acceptance",
+  "elements": [
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "manual-group"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "service-label",
+          "type": "text"
+        },
+        {
+          "id": "request",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "service",
+      "type": "rectangle",
+      "x": 100,
+      "y": 100,
+      "width": 220,
+      "height": 100,
+      "customData": {
+        "owner": "human",
+        "priority": 7
+      }
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "manual-group"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "service-label",
+      "type": "text",
+      "x": 150,
+      "y": 136,
+      "width": 120,
+      "height": 25,
+      "text": "API service",
+      "originalText": "API service",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "service",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "request",
+      "type": "arrow",
+      "x": 325,
+      "y": 150,
+      "width": 250,
+      "height": 0,
+      "customData": {
+        "owner": "human",
+        "priority": 7
+      },
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          250,
+          0
+        ]
+      ],
+      "startBinding": {
+        "elementId": "service",
+        "focus": 0,
+        "gap": 5
+      },
+      "endBinding": {
+        "elementId": "worker",
+        "focus": 0,
+        "gap": 5
+      },
+      "startArrowhead": null,
+      "endArrowhead": "arrow",
+      "elbowed": false
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "worker-label",
+          "type": "text"
+        },
+        {
+          "id": "request",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "worker",
+      "type": "rectangle",
+      "x": 580,
+      "y": 100,
+      "width": 220,
+      "height": 100,
+      "customData": {
+        "owner": "human",
+        "priority": 7
+      }
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "worker-label",
+      "type": "text",
+      "x": 640,
+      "y": 136,
+      "width": 120,
+      "height": 25,
+      "text": "Worker",
+      "originalText": "Worker",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "worker",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "note",
+      "type": "text",
+      "x": 100,
+      "y": 260,
+      "width": 280,
+      "height": 25,
+      "text": "Keep this manual annotation",
+      "originalText": "Keep this manual annotation",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "image",
+      "type": "image",
+      "x": 100,
+      "y": 335,
+      "width": 64,
+      "height": 64,
+      "customData": {
+        "owner": "human",
+        "priority": 7
+      },
+      "fileId": "asset",
+      "scale": [
+        1,
+        1
+      ],
+      "status": "saved",
+      "crop": null
+    },
+    {
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "manual-group"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "seed": 11,
+      "version": 1,
+      "versionNonce": 11,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "id": "old-label",
+          "type": "text"
+        }
+      ],
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "id": "deleted",
+      "type": "rectangle",
+      "x": 100,
+      "y": 100,
+      "width": 220,
+      "height": 100,
+      "customData": {
+        "owner": "human",
+        "priority": 7
+      }
+    }
+  ],
+  "appState": {
+    "viewBackgroundColor": "#ffffff",
+    "customSetting": {
+      "keep": true
+    }
+  },
+  "files": {
+    "asset": {
+      "id": "asset",
+      "mimeType": "image/png",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIElEQVR4nGP4TyFgoJoB+7pSScKjBowaMFwNIBdQbAAAMog/LsGC1o4AAAAASUVORK5CYII=",
+      "created": 123
+    }
+  },
+  "customMetadata": {
+    "topic": "acceptance",
+    "humanNote": "Do not normalize this document"
+  }
+}

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {mkdtempSync, readFileSync, writeFileSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+import {renderScene, servePreview} from '../src/render.js';
+import {chromium} from 'playwright';
+const exec = promisify(execFile);
+const fixture = new URL('./fixtures/annotated.excalidraw', import.meta.url);
+const cli = new URL('../bin/cli.js', import.meta.url).pathname;
+function temporary(t) {const dir=mkdtempSync(join(tmpdir(),'toolkit-native-'));t.after(()=>rmSync(dir,{recursive:true,force:true}));return dir;}
+async function run(args) {const {stdout}=await exec(process.execPath,[cli,...args],{timeout:60000});return JSON.parse(stdout);}
+
+test('CLI edits a complete native file, renders both versions, and reuses the completed result', async t => {
+  const dir=temporary(t);const input=join(dir,'input.excalidraw');const request=join(dir,'request.json');
+  const original=readFileSync(fixture);writeFileSync(input,original);
+  const inspected=await run(['inspect',input]);
+  writeFileSync(request,JSON.stringify({requestId:'native-style',baseHash:inspected.baseHash,operations:[{op:'setStyle',targetId:'service',style:{backgroundColor:'#a5d8ff'}}]}));
+  const args=['edit',input,'--request',request,'--output',join(dir,'results')];
+  const receipt=await run(args);
+  assert.deepEqual(await run(args),receipt);
+  assert.deepEqual(readFileSync(input),original);
+  assert.deepEqual(readFileSync(receipt.artifacts['before.excalidraw'].path),original);
+  const expected=JSON.parse(original);expected.elements.find(e=>e.id==='service').backgroundColor='#a5d8ff';
+  assert.deepEqual(JSON.parse(readFileSync(receipt.artifacts['after.excalidraw'].path)),expected);
+  for(const name of ['before.png','after.png']) {const bytes=readFileSync(receipt.artifacts[name].path);assert.equal(bytes.subarray(0,8).toString('hex'),'89504e470d0a1a0a');assert.ok(bytes.readUInt32BE(16)>600);assert.ok(bytes.readUInt32BE(20)>250);}
+  writeFileSync(receipt.artifacts['after.excalidraw'].path,'{}');
+  await assert.rejects(run(['preview',receipt.receiptPath,'--no-open']),error=>error.stderr.includes('CORRUPT_RESULT'));
+});
+
+test('native rendering refuses an image asset that cannot be loaded locally', async t => {
+  const dir=temporary(t);const scene=JSON.parse(readFileSync(fixture));scene.files.asset.dataURL='https://invalid.example/toolkit-missing.png';
+  await assert.rejects(renderScene(scene,join(dir,'bad.png')),/PREVIEW_ASSET_FAILED|PREVIEW|image/i);
+});
+
+
+test('failed initial loading remains visible and Open file recovers without a false preparing state', async t => {
+  const scene = JSON.parse(readFileSync(fixture));
+  const preview = await servePreview(scene);
+  t.after(() => preview.close());
+  const browser = await chromium.launch();
+  t.after(() => browser.close());
+  const page = await browser.newPage();
+  await page.route('**/scene', route => route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"controlled load failure"}' }));
+  await page.goto(preview.url);
+  await page.getByRole('alert').waitFor();
+  assert.match(await page.getByRole('alert').innerText(), /could not be loaded/);
+  assert.equal(await page.getByRole('button', { name: 'Dismiss error' }).count(), 0);
+  assert.equal(await page.getByRole('heading', { name: 'Opening your diagram', exact: true }).count(), 0);
+  assert.equal(await page.locator('#status').innerText(), 'Preview unavailable');
+  assert.equal(await page.getByRole('button', { name: 'Export PNG', exact: true }).isEnabled(), false);
+  const chooser = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Open file', exact: true }).click();
+  await (await chooser).setFiles(fixture.pathname);
+  await page.waitForFunction(() => window.previewReady);
+  assert.equal(await page.evaluate(() => window.previewError), undefined);
+  assert.deepEqual(await page.evaluate(() => window.sceneForPreview()), scene);
+  assert.equal(await page.getByRole('alert').count(), 0);
+  assert.equal(await page.getByRole('button', { name: 'Export PNG', exact: true }).isEnabled(), true);
+  assert.match(await page.locator('#status').innerText(), /Viewing a read-only copy/);
+});

--- a/test/preview-package.test.js
+++ b/test/preview-package.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test('preview build replaces an output symlink and npm includes every generated asset', t => {
+  const directory = mkdtempSync(join(tmpdir(), 'toolkit-preview-package-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  mkdirSync(join(directory, 'scripts'));
+  mkdirSync(join(directory, 'dist'));
+  const shared = join(directory, 'shared-preview');
+  mkdirSync(shared);
+  writeFileSync(join(shared, 'preview.js'), 'preserve shared output');
+  symlinkSync(shared, join(directory, 'dist/preview'), process.platform === 'win32' ? 'junction' : 'dir');
+  symlinkSync(realpathSync(join(root, 'node_modules')), join(directory, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir');
+  cpSync(join(root, 'src/web'), join(directory, 'src/web'), { recursive: true });
+  for (const script of ['build-preview.mjs', 'check-preview-package.mjs']) cpSync(join(root, 'scripts', script), join(directory, 'scripts', script));
+  const packagePath = join(directory, 'package.json');
+  const pkg = { name: 'toolkit-preview-fixture', version: '1.0.0', type: 'module', files: ['dist/preview'] };
+  writeFileSync(packagePath, JSON.stringify(pkg));
+  const run = script => execFileSync(process.execPath, [join(directory, 'scripts', script)], { cwd: directory, encoding: 'utf8', stdio: 'pipe', timeout: 60000 });
+  run('build-preview.mjs');
+  assert.equal(lstatSync(join(directory, 'dist/preview')).isSymbolicLink(), false);
+  assert.equal(readFileSync(join(shared, 'preview.js'), 'utf8'), 'preserve shared output');
+  assert.equal(existsSync(join(shared, 'fonts')), false);
+  assert.match(run('check-preview-package.mjs'), /built files included/);
+  writeFileSync(packagePath, JSON.stringify({ ...pkg, files: ['src'] }));
+  assert.throws(() => run('check-preview-package.mjs'), /PACKED_PREVIEW: npm omitted/);
+});

--- a/test/scene.test.js
+++ b/test/scene.test.js
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { test } from "node:test";
+import { applyStyleOperations, deriveSceneChanges, editScene, inspectScene, sha256, validateScene, verifyReceipt } from "../src/scene.js";
+
+const PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zz1kAAAAASUVORK5CYII=", "base64");
+const renderScene = async (_scene, path) => fs.writeFile(path, PNG);
+
+function sceneFixture() {
+  const element = (id, type, extra = {}) => ({
+    id, type, x: 20, y: 20, width: 100, height: 60, angle: 0,
+    strokeColor: "#000000", backgroundColor: "transparent", fillStyle: "solid",
+    strokeWidth: 1, strokeStyle: "solid", roughness: 1, opacity: 100,
+    groupIds: [], frameId: null, roundness: null, seed: 12,
+    version: 7, versionNonce: 100, isDeleted: false, boundElements: null,
+    updated: 1234, link: null, locked: false, ...extra,
+  });
+  return {
+    type: "excalidraw", version: 2, source: "test",
+    elements: [
+      element("api", "rectangle", { boundElements: [{ id: "label", type: "text" }, { id: "edge", type: "arrow" }], customData: { manual: "keep" } }),
+      element("label", "text", { containerId: "api", text: "API", originalText: "API", fontSize: 20, fontFamily: 1, textAlign: "center", verticalAlign: "middle", autoResize: true, lineHeight: 1.25 }),
+      element("worker", "ellipse", { x: 250, boundElements: [{ id: "edge", type: "arrow" }] }),
+      element("edge", "arrow", { x: 120, y: 50, width: 130, height: 0, points: [[0, 0], [130, 0]], startBinding: { elementId: "api", focus: 0, gap: 1 }, endBinding: { elementId: "worker", focus: 0, gap: 1 } }),
+      element("note", "text", { x: 45, y: 175, text: "Hand-positioned note", originalText: "Hand-positioned note", fontSize: 16, fontFamily: 1, textAlign: "left", verticalAlign: "top", containerId: null, autoResize: true, lineHeight: 1.25 }),
+      element("image", "image", { y: 250, fileId: "asset", scale: [1, 1], status: "saved" }),
+      element("deleted", "rectangle", { isDeleted: true, boundElements: [{ id: "old-missing-label", type: "text" }] }),
+      element("future-element", "future-element", { mystery: { untouched: [1, 2, 3] } }),
+    ],
+    appState: { viewBackgroundColor: "#f5f5f5", gridSize: 20, customView: { mode: "manual" } },
+    files: { asset: { id: "asset", mimeType: "image/png", dataURL: `data:image/png;base64,${PNG.toString("base64")}`, created: 100 } },
+    arbitraryMetadata: { extension: "keep", nested: [1, { preserve: true }] },
+  };
+}
+
+async function setup(t) {
+  const directory = await fs.mkdtemp(join(tmpdir(), "excalidraw-edit-test-"));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const scene = sceneFixture();
+  const inputPath = join(directory, "input.excalidraw");
+  const original = `${JSON.stringify(scene)}\n\n`;
+  await fs.writeFile(inputPath, original);
+  return {
+    scene, inputPath, original, directory,
+    request: { inputPath, outputDir: join(directory, "output"), requestId: "edit-001", baseHash: sha256(original), operations: [{ op: "setStyle", targetId: "api", style: { backgroundColor: "#a5d8ff" } }] },
+  };
+}
+
+test("inspect exposes stable IDs, bindings, assets, and the supported operation set", async (t) => {
+  const { inputPath, original } = await setup(t);
+  const result = await inspectScene(inputPath);
+  assert.equal(result.baseHash, sha256(original));
+  assert.equal(result.elements.find((element) => element.id === "api").label, "API");
+  assert.equal(result.elements.find((element) => element.id === "edge").startBinding.elementId, "api");
+  assert.deepEqual(result.assetIds, ["asset"]);
+  assert.deepEqual(result.capabilities.operations, ["setStyle"]);
+  assert.deepEqual(result.capabilities.setStyle.elementTypes, ["rectangle", "ellipse", "diamond"]);
+});
+
+test("style edit preserves original bytes and every protected native value", async (t) => {
+  const { scene, inputPath, original, request } = await setup(t);
+  const receipt = await editScene(request, { renderScene });
+  assert.equal(receipt.status, "complete");
+  const candidate = JSON.parse(await fs.readFile(receipt.artifacts["after.excalidraw"].path));
+  const expected = structuredClone(scene);
+  expected.elements[0].backgroundColor = "#a5d8ff";
+  assert.deepEqual(candidate, expected);
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+  assert.equal(await fs.readFile(receipt.artifacts["before.excalidraw"].path, "utf8"), original);
+  assert.deepEqual(receipt.changes, [{ id: "api", properties: { backgroundColor: { before: "transparent", after: "#a5d8ff" } } }]);
+  assert.equal(receipt.outputHash, sha256(await fs.readFile(receipt.artifacts["after.excalidraw"].path)));
+});
+
+test("same recorded request returns the completed bundle without rendering again", async (t) => {
+  const { request } = await setup(t);
+  let calls = 0;
+  const render = async (...args) => { calls++; await renderScene(...args); };
+  const first = await editScene(request, { renderScene: render });
+  const retry = await editScene(request, { renderScene: render });
+  assert.deepEqual(first, retry);
+  assert.equal(calls, 2);
+  const reordered = { ...request, operations: [{ style: { backgroundColor: "#a5d8ff" }, targetId: "api", op: "setStyle" }] };
+  assert.deepEqual(await editScene(reordered, { renderScene: render }), first);
+  const different = structuredClone(request);
+  different.operations[0].style.backgroundColor = "#ff0000";
+  await assert.rejects(editScene(different, { renderScene }), { code: "REQUEST_CONFLICT" });
+});
+
+test("retry does not claim a corrupted or incomplete artifact as complete", async (t) => {
+  const { request } = await setup(t);
+  const first = await editScene(request, { renderScene });
+  await fs.writeFile(first.artifacts["after.excalidraw"].path, "changed");
+  await assert.rejects(editScene(request, { renderScene }), { code: "CORRUPT_RESULT" });
+});
+
+test("receipt verification derives changes and rejects metadata tampering on retry and preview", async (t) => {
+  const { request, directory } = await setup(t);
+  let renders = 0;
+  const render = async (...args) => { renders++; return renderScene(...args); };
+  const receipt = await editScene(request, { renderScene: render });
+  const { sceneCommand } = await import("../src/commands.js");
+  const outside = join(directory, "copied-after.excalidraw");
+  await fs.copyFile(receipt.artifacts["after.excalidraw"].path, outside);
+  for (const mutate of [
+    value => { value.outputHash = "0".repeat(64); },
+    value => { value.inputHash = "0".repeat(64); },
+    value => { value.changes = []; },
+    value => { value.changes[0].properties.backgroundColor.after = "#ff0000"; },
+    value => { value.validation.protectedValues = false; },
+    value => { value.requestId = "another-request"; },
+    value => { value.requestDigest = "0".repeat(64); },
+    value => { value.schemaVersion = 2; },
+    value => { value.artifacts["after.excalidraw"].path = outside; },
+  ]) {
+    const changed = structuredClone(receipt); mutate(changed);
+    await fs.writeFile(receipt.receiptPath, JSON.stringify(changed));
+    await assert.rejects(editScene(request, { renderScene: render }), { code: "CORRUPT_RESULT" });
+    await assert.rejects(sceneCommand("preview", receipt.receiptPath, { "no-open": true }), { code: "CORRUPT_RESULT" });
+  }
+  await fs.writeFile(receipt.receiptPath, JSON.stringify(receipt));
+  const verified = await verifyReceipt(receipt.receiptPath);
+  assert.deepEqual(verified.receipt, receipt);
+  assert.deepEqual(deriveSceneChanges(verified.beforeScene, verified.afterScene), receipt.changes);
+  assert.deepEqual(await editScene(request, { renderScene: render }), receipt);
+  assert.equal(renders, 2);
+  const requestPath = join(request.outputDir, request.requestId, "request.json");
+  const recorded = JSON.parse(await fs.readFile(requestPath));
+  recorded.operations[0].style.backgroundColor = "#ff0000";
+  await fs.writeFile(requestPath, JSON.stringify(recorded));
+  await assert.rejects(verifyReceipt(receipt.receiptPath), { code: "CORRUPT_RESULT" });
+});
+
+test("derived receipts retain tombstones and the appended created-element schema", () => {
+  const before = sceneFixture(), after = structuredClone(before);
+  after.elements.find(element => element.id === "note").isDeleted = true;
+  const added = { id: "new-node", type: "rectangle", x: 450, y: 20, width: 100, height: 60, isDeleted: false };
+  after.elements.push(added);
+  assert.deepEqual(deriveSceneChanges(before, after), [
+    { id: "note", properties: { isDeleted: { before: false, after: true } } },
+    { id: "new-node", created: true, properties: Object.fromEntries(Object.entries(added).map(([field, value]) => [field, { before: null, after: value }])) },
+  ]);
+  const reordered = structuredClone(before); [reordered.elements[0], reordered.elements[1]] = [reordered.elements[1], reordered.elements[0]];
+  assert.throws(() => deriveSceneChanges(before, reordered), { code: "CORRUPT_RESULT" });
+});
+
+test("completed retry returns its recorded result even when the source later changes", async (t) => {
+  const { inputPath, request } = await setup(t);
+  const first = await editScene(request, { renderScene });
+  await fs.writeFile(inputPath, "subsequent user edit");
+  assert.deepEqual(await editScene(request, { renderScene }), first);
+  assert.equal(await fs.readFile(inputPath, "utf8"), "subsequent user edit");
+});
+
+test("an external edit during rendering is retained while the bundle uses its inspected revision", async (t) => {
+  const { inputPath, original, request } = await setup(t);
+  const receipt = await editScene(request, { renderScene: async (...args) => {
+    await fs.writeFile(inputPath, "user changed the original while rendering");
+    await renderScene(...args);
+  } });
+  assert.equal(await fs.readFile(inputPath, "utf8"), "user changed the original while rendering");
+  assert.equal(await fs.readFile(receipt.artifacts["before.excalidraw"].path, "utf8"), original);
+  assert.equal(receipt.inputHash, sha256(original));
+});
+
+test("stale input and validation failures leave the source intact without a completion receipt", async (t) => {
+  const { inputPath, original, request } = await setup(t);
+  const stale = { ...request, baseHash: "0".repeat(64) };
+  await assert.rejects(editScene(stale, { renderScene }), { code: "STALE_INPUT" });
+  await assert.rejects(fs.readFile(join(request.outputDir, request.requestId, "receipt.json")), { code: "ENOENT" });
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+});
+
+test("failed rendering remains incomplete and the same request recovers in a new attempt", async (t) => {
+  const { inputPath, original, request } = await setup(t);
+  await assert.rejects(editScene(request, { renderScene: async () => { throw new Error("renderer unavailable"); } }), /renderer unavailable/);
+  const jobDir = join(request.outputDir, request.requestId);
+  await assert.rejects(fs.readFile(join(jobDir, "receipt.json")), { code: "ENOENT" });
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+  const result = await editScene(request, { renderScene });
+  assert.equal(result.status, "complete");
+  assert.deepEqual((await fs.readdir(join(jobDir, "claims"))).sort(), ["1.json", "2.json"]);
+});
+
+test("a renderer cannot mutate canonical scene values", async (t) => {
+  const { scene, inputPath, original, request } = await setup(t);
+  const mutate = async (document, path) => {
+    assert.throws(() => { document.elements[0].x = 999; }, TypeError);
+    assert.throws(() => { document.arbitraryMetadata.extension = "lost"; }, TypeError);
+    await renderScene(document, path);
+  };
+  const receipt = await editScene(request, { renderScene: mutate });
+  const candidate = JSON.parse(await fs.readFile(receipt.artifacts["after.excalidraw"].path));
+  assert.equal(candidate.elements[0].x, scene.elements[0].x);
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+});
+
+test("invalid PNG output is never a completed result", async (t) => {
+  const { request } = await setup(t);
+  await assert.rejects(editScene(request, { renderScene: async (_, path) => fs.writeFile(path, "not an image") }), { code: "INVALID_RENDER" });
+});
+
+test("unexpected native-file writes during rendering cannot be reported as a valid edit", async (t) => {
+  const { request, inputPath, original } = await setup(t);
+  await assert.rejects(editScene(request, { renderScene: async (document, path) => {
+    await fs.writeFile(join(dirname(path), "after.excalidraw"), "normalized by renderer");
+    await renderScene(document, path);
+  } }), { code: "PROTECTED_CHANGE" });
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+  await assert.rejects(fs.readFile(join(request.outputDir, request.requestId, "receipt.json")), { code: "ENOENT" });
+});
+
+test("simultaneous requests cannot own the same job", async (t) => {
+  const { request } = await setup(t);
+  let release;
+  let started;
+  const hold = new Promise((resolve) => { release = resolve; });
+  const entered = new Promise((resolve) => { started = resolve; });
+  const first = editScene(request, { renderScene: async (...args) => { started(); await hold; await renderScene(...args); } });
+  await entered;
+  await assert.rejects(editScene(request, { renderScene }), { code: "REQUEST_BUSY" });
+  release();
+  const receipt = await first;
+  assert.deepEqual(await editScene(request, { renderScene }), receipt);
+});
+
+test("racing retries after failure select one generation without stealing a live claim", async (t) => {
+  const { request } = await setup(t);
+  await assert.rejects(editScene(request, { renderScene: async () => { throw new Error("first failure"); } }));
+  let renders = 0;
+  const results = await Promise.allSettled(Array.from({ length: 8 }, () => editScene(request, { renderScene: async (...args) => {
+    renders++;
+    await delay(20);
+    await renderScene(...args);
+  } })));
+  assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+  for (const result of results.filter((result) => result.status === "rejected")) assert.equal(result.reason.code, "REQUEST_BUSY");
+  assert.equal(renders, 2);
+  assert.deepEqual((await fs.readdir(join(request.outputDir, request.requestId, "claims"))).sort(), ["1.json", "2.json"]);
+});
+
+test("a killed owner is recovered without deleting or reusing its claim", async (t) => {
+  const { directory, request, inputPath, original } = await setup(t);
+  const marker = join(directory, "render-started");
+  const source = `import { editScene } from ${JSON.stringify(new URL("../src/scene.js", import.meta.url).href)};
+    import { promises as fs } from 'node:fs';
+    await editScene(${JSON.stringify(request)}, { renderScene: async () => {
+      await fs.writeFile(${JSON.stringify(marker)}, 'started');
+      await new Promise(() => { setInterval(() => {}, 1000); });
+    }});`;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", source], { stdio: "pipe" });
+  t.after(() => { if (child.exitCode === null) child.kill("SIGKILL"); });
+  let started = false;
+  for (let count = 0; count < 150; count++) {
+    try { await fs.access(marker); started = true; break; } catch {}
+    await delay(20);
+  }
+  assert.equal(started, true, "child reached rendering");
+  const exited = once(child, "exit");
+  child.kill("SIGKILL");
+  await exited;
+  const result = await editScene(request, { renderScene });
+  assert.equal(result.status, "complete");
+  assert.deepEqual((await fs.readdir(join(request.outputDir, request.requestId, "claims"))).sort(), ["1.json", "2.json"]);
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+});
+
+test("invalid IDs, references, image assets, and unsupported mutations fail explicitly", () => {
+  const duplicate = sceneFixture();
+  duplicate.elements.push(structuredClone(duplicate.elements[0]));
+  assert.throws(() => validateScene(duplicate), { code: "DUPLICATE_ID" });
+  const dangling = sceneFixture();
+  dangling.elements[1].containerId = "missing";
+  assert.throws(() => validateScene(dangling), { code: "INVALID_BINDING" });
+  const missing = sceneFixture();
+  delete missing.files.asset;
+  assert.throws(() => validateScene(missing), { code: "MISSING_ASSET" });
+  const scene = sceneFixture();
+  assert.throws(() => applyStyleOperations(scene, [{ op: "setStyle", targetId: "future-element", style: { strokeColor: "#fff" } }]), { code: "UNSUPPORTED_TARGET" });
+  assert.throws(() => applyStyleOperations(scene, [{ op: "setStyle", targetId: "api", style: { x: 300 } }]), { code: "INVALID_REQUEST" });
+  assert.throws(() => applyStyleOperations(scene, [{ op: "setStyle", targetId: "api", style: { strokeColor: "javascript:alert(1)" } }]), { code: "INVALID_REQUEST" });
+  assert.throws(() => applyStyleOperations(scene, [{ op: "setLabel", targetId: "api", text: "New" }]), { code: "INVALID_REQUEST" });
+});


### PR DESCRIPTION
Editing a saved scene now changes selected fill or stroke colors while retaining the complete native document and an exact original snapshot. The command returns before/after native files, PNG previews, and a durable receipt; rendering never round-trips the authoritative scene.

- Validates IDs, reciprocal bindings, protected fields, and request identity. Matching retries reuse the verified result; stale inputs, conflicting requests, interrupted work, and failed rendering cannot report a completed edit.
- Adds a local review workspace with Before/After, readable changes, an optional field diff, native-copy download, PNG export, and file reopen. The layout adapts to desktop and narrow screens.
- Routes saved-file requests through inspect → supported edit → preview verification. This PR supports fill/stroke edits on rectangles, ellipses, and diamonds.

Validation: all 185 tests in the integrated core stack pass, including scoped preservation, recovery, receipt verification, native rendering, and npm package selection. Computer use checked Before/After, native and PNG downloads, reopen, and label visibility. Separate desktop/mobile browser checks covered copy downloads and the readable change disclosure.

Depends on #19. The runtime font-loading fix is included; final installed client qualification follows in #22. No npm release is published by this PR.
