### PR TITLE
[Geometry]: move supported shapes and bound arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,29 @@ Unrelated element types pass through unchanged; unsupported targets or operation
 fail explicitly. A label repair requires a new scoped request, never an implicit
 font shrink or container resize.
 
+`move` places a supported shape at absolute coordinates:
+
+```json
+{ "op": "move", "targetId": "worker", "x": 600, "y": 200 }
+```
+
+| Geometry | Movement support |
+| --- | --- |
+| Unrotated rectangle, ellipse, diamond | Translate the shape and its existing bound label. |
+| Straight two-point arrow, center bindings (`focus: 0`) | Reanchor both bound ends using the original binding gaps; free endpoints remain fixed. |
+| Bound arrow label | Preserve its offset from the segment midpoint and its existing text metrics. |
+| Rotated shapes/labels, elbow or multipoint arrows, fixed-point or nonzero-focus bindings | Reject when connected to the requested move; unrelated objects remain unchanged. |
+| Rounded shapes with bound arrows | Reject because this version does not reproduce rounded-outline routing. |
+| Nested containers | Reject moving the container alone; existing frame membership and zone containment are preserved when moving a child. |
+
+Paths must already match their center bindings; a manually adjusted route is not
+replaced automatically. Multiple moves in one request update shared arrows once.
+A combined move/relabel request moves first, then measures the new label at its
+translated anchor. New or worsened bounding-box overlaps and new straight-arrow
+crossings fail with `GEOMETRY_COLLISION`; unrelated existing overlaps remain intact.
+This check is conservative for nonrectangular shapes and is not an automatic
+layout engine. Inspect the delivered preview before adopting the result.
+
 A retry with the same request ID and payload returns its existing verified
 bundle. Different payloads under that ID conflict. Failed attempts can be retried;
 interrupted attempts recover in a new attempt after their owner exits. Concurrent

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -1,0 +1,242 @@
+const TYPES = ["rectangle", "ellipse", "diamond"];
+const EPSILON = 0.001;
+
+export const MOVE_CAPABILITIES = {
+  elementTypes: TYPES,
+  geometry: "unrotated shapes and labels; bound frames retain containment",
+  arrows: "straight two-point arrows; center focus 0; finite nonnegative gaps; no fixed points, elbows, or rounded bound shapes",
+  routing: "reanchor both bound ends; preserve free endpoints, bindings, and label offsets",
+  collisions: "reject new bounding-box overlaps and straight-arrow crossings; preserve existing containment",
+};
+
+function fail(code, message) {
+  throw Object.assign(new Error(message), { code });
+}
+
+export function bounds(element) {
+  if (!element || ![element.x, element.y, element.width, element.height].every(Number.isFinite)) return null;
+  const angle = element.angle ?? 0;
+  const width = Math.abs(element.width * Math.cos(angle)) + Math.abs(element.height * Math.sin(angle));
+  const height = Math.abs(element.width * Math.sin(angle)) + Math.abs(element.height * Math.cos(angle));
+  const center = centerOf(element);
+  return { left: center[0] - width / 2, top: center[1] - height / 2, right: center[0] + width / 2, bottom: center[1] + height / 2 };
+}
+
+export function contains(outer, inner) {
+  return outer && inner && outer.left <= inner.left + EPSILON && outer.top <= inner.top + EPSILON && outer.right >= inner.right - EPSILON && outer.bottom >= inner.bottom - EPSILON;
+}
+
+function overlapArea(a, b) {
+  if (!a || !b) return 0;
+  return Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left)) * Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
+}
+
+export function centerOf(element) {
+  return [element.x + element.width / 2, element.y + element.height / 2];
+}
+
+function supportedShape(element, connected = false) {
+  if (!element || !TYPES.includes(element.type) || element.angle !== 0 || !bounds(element) || element.width <= 0 || element.height <= 0) {
+    fail("UNSUPPORTED_GEOMETRY", "Movement requires unrotated rectangle, ellipse, or diamond geometry");
+  }
+  if (connected && element.roundness != null && element.type !== "ellipse") {
+    fail("UNSUPPORTED_GEOMETRY", "Bound arrows on rounded shapes are not supported by this move operation");
+  }
+}
+
+export function centerEndpoint(element, toward, gap = 1) {
+  supportedShape(element, true);
+  if (!Number.isFinite(gap) || gap < 0 || !toward?.every(Number.isFinite)) fail("UNSUPPORTED_GEOMETRY", "Invalid arrow endpoint geometry");
+  const center = centerOf(element);
+  if (gap === 0) return center;
+  const dx = toward[0] - center[0];
+  const dy = toward[1] - center[1];
+  if (Math.hypot(dx, dy) < EPSILON) fail("GEOMETRY_COLLISION", "A connection cannot route between coincident centers");
+  // Native 0.18.1 offsets unrounded outlines by binding.gap. Diamonds also
+  // retain getDiamondPoints' pixel rounding, which is asymmetric by one pixel.
+  if (element.type === "diamond") {
+    const midX = element.x + Math.floor(element.width / 2) + 1;
+    const midY = element.y + Math.floor(element.height / 2) + 1;
+    const vertices = [[midX, element.y - gap], [element.x + element.width + gap, midY], [midX, element.y + element.height + gap], [element.x - gap, midY]];
+    for (let i = 0; i < vertices.length; i++) {
+      const a = vertices[i];
+      const b = vertices[(i + 1) % vertices.length];
+      const edgeX = b[0] - a[0]; const edgeY = b[1] - a[1];
+      const denominator = dx * edgeY - dy * edgeX;
+      if (Math.abs(denominator) < EPSILON) continue;
+      const t = ((a[0] - center[0]) * edgeY - (a[1] - center[1]) * edgeX) / denominator;
+      const u = ((a[0] - center[0]) * dy - (a[1] - center[1]) * dx) / denominator;
+      if (t > 0 && t < 1 && u >= -EPSILON && u <= 1 + EPSILON) return [center[0] + dx * t, center[1] + dy * t];
+    }
+    fail("GEOMETRY_COLLISION", "A connection endpoint lies inside its bound diamond");
+  }
+  const rx = element.width / 2 + gap;
+  const ry = element.height / 2 + gap;
+  const divisor = element.type === "ellipse" ? Math.hypot(dx / rx, dy / ry)
+    : Math.max(Math.abs(dx) / rx, Math.abs(dy) / ry);
+  if (divisor <= 1) fail("GEOMETRY_COLLISION", "A connection endpoint lies inside its bound shape");
+  return [center[0] + dx / divisor, center[1] + dy / divisor];
+}
+
+export function arrowEndpoints(arrow) {
+  if (arrow.type !== "arrow" || arrow.angle !== 0 || arrow.elbowed || arrow.fixedSegments?.length
+    || !Array.isArray(arrow.points) || arrow.points.length !== 2 || arrow.points.some((point) => !Array.isArray(point) || point.length !== 2 || !point.every(Number.isFinite))
+    || ![arrow.x, arrow.y].every(Number.isFinite)) {
+    fail("UNSUPPORTED_GEOMETRY", "Connected arrows must be unrotated, straight two-point paths");
+  }
+  for (const binding of [arrow.startBinding, arrow.endBinding]) {
+    if (binding && (binding.focus !== 0 || binding.fixedPoint != null || !Number.isFinite(binding.gap) || binding.gap < 0)) {
+      fail("UNSUPPORTED_GEOMETRY", "Connected arrows require center bindings with finite gaps");
+    }
+  }
+  return arrow.points.map(([x, y]) => [arrow.x + x, arrow.y + y]);
+}
+
+export function routeStraightArrow(arrow, index) {
+  const [oldStart, oldEnd] = arrowEndpoints(arrow);
+  const startShape = arrow.startBinding && index.get(arrow.startBinding.elementId);
+  const endShape = arrow.endBinding && index.get(arrow.endBinding.elementId);
+  if (arrow.startBinding && !startShape || arrow.endBinding && !endShape) fail("INVALID_BINDING", "An arrow references a missing shape");
+  const startCenter = startShape ? centerOf(startShape) : oldStart;
+  const endCenter = endShape ? centerOf(endShape) : oldEnd;
+  const start = startShape ? centerEndpoint(startShape, endCenter, arrow.startBinding.gap) : oldStart;
+  const end = endShape ? centerEndpoint(endShape, startCenter, arrow.endBinding.gap) : oldEnd;
+  const direction = [endCenter[0] - startCenter[0], endCenter[1] - startCenter[1]];
+  if ((end[0] - start[0]) * direction[0] + (end[1] - start[1]) * direction[1] <= EPSILON) fail("GEOMETRY_COLLISION", "Bound shapes leave no space for the connection");
+  return { x: start[0], y: start[1], width: Math.abs(end[0] - start[0]), height: Math.abs(end[1] - start[1]), points: [[0, 0], [end[0] - start[0], end[1] - start[1]]] };
+}
+
+function segmentInsideBox(start, end, box) {
+  if (!box) return false;
+  const limits = [[box.left + EPSILON, box.right - EPSILON], [box.top + EPSILON, box.bottom - EPSILON]];
+  let low = 0;
+  let high = 1;
+  for (let axis = 0; axis < 2; axis++) {
+    const difference = end[axis] - start[axis];
+    if (Math.abs(difference) < EPSILON) {
+      if (start[axis] <= limits[axis][0] || start[axis] >= limits[axis][1]) return false;
+    } else {
+      const intersections = limits[axis].map((value) => (value - start[axis]) / difference).sort((a, b) => a - b);
+      low = Math.max(low, intersections[0]); high = Math.min(high, intersections[1]);
+      if (low >= high) return false;
+    }
+  }
+  return low < high;
+}
+
+function areaElement(element) {
+  return !element.isDeleted && !["arrow", "line", "freedraw"].includes(element.type);
+}
+
+function stationaryStraightPoints(element) {
+  if (element.type !== "arrow" || element.elbowed || element.points?.length !== 2 || !element.points.every((point) => Array.isArray(point) && point.length === 2 && point.every(Number.isFinite))) return null;
+  const points = element.points.map(([x, y]) => [element.x + x, element.y + y]);
+  if (![element.x, element.y, element.angle ?? 0].every(Number.isFinite)) return null;
+  const center = [(points[0][0] + points[1][0]) / 2, (points[0][1] + points[1][1]) / 2];
+  const angle = element.angle ?? 0;
+  return points.map(([x, y]) => [center[0] + (x - center[0]) * Math.cos(angle) - (y - center[1]) * Math.sin(angle), center[1] + (x - center[0]) * Math.sin(angle) + (y - center[1]) * Math.cos(angle)]);
+}
+
+function validateCollisions(before, after, changed) {
+  const previous = new Map(before.elements.map((element) => [element.id, element]));
+  for (const element of after.elements.filter((element) => changed.has(element.id))) {
+    const old = previous.get(element.id);
+    if (element.type === "arrow") {
+      const [start, end] = arrowEndpoints(element);
+      const [oldStart, oldEnd] = arrowEndpoints(old);
+      for (const other of after.elements.filter(areaElement)) {
+        if ([element.startBinding?.elementId, element.endBinding?.elementId, element.id].includes(other.id) || other.containerId === element.id) continue;
+        if (segmentInsideBox(start, end, bounds(other)) && !segmentInsideBox(oldStart, oldEnd, bounds(previous.get(other.id)))) {
+          fail("GEOMETRY_COLLISION", `Moving ${element.id} introduces a crossing through ${other.id}`);
+        }
+      }
+      continue;
+    }
+    if (!areaElement(element)) continue;
+    for (const other of after.elements.filter((other) => !other.isDeleted && other.type === "arrow" && !changed.has(other.id))) {
+      if ([other.startBinding?.elementId, other.endBinding?.elementId].includes(element.id) || element.containerId === other.id) continue;
+      const points = stationaryStraightPoints(other);
+      if (points && segmentInsideBox(...points, bounds(element)) && !segmentInsideBox(...points, bounds(old))) {
+        fail("GEOMETRY_COLLISION", `Moving ${element.id} introduces a crossing with ${other.id}`);
+      }
+    }
+    for (const other of after.elements.filter(areaElement)) {
+      if (other.id === element.id || other.containerId === element.id || element.containerId === other.id) continue;
+      const oldOther = previous.get(other.id);
+      const oldBounds = bounds(old);
+      const oldOtherBounds = bounds(oldOther);
+      const newBounds = bounds(element);
+      const otherBounds = bounds(other);
+      if (contains(oldOtherBounds, oldBounds)) {
+        if (!contains(otherBounds, newBounds)) fail("GEOMETRY_COLLISION", `Moving ${element.id} would leave its existing container ${other.id}`);
+        continue;
+      }
+      if (contains(oldBounds, oldOtherBounds) && contains(newBounds, otherBounds)) continue;
+      if (overlapArea(newBounds, otherBounds) > overlapArea(oldBounds, oldOtherBounds) + EPSILON) {
+        fail("GEOMETRY_COLLISION", `Moving ${element.id} introduces or worsens an overlap with ${other.id}`);
+      }
+    }
+  }
+}
+
+export function moveUpdates(scene, operations) {
+  const index = new Map(scene.elements.filter((element) => !element.isDeleted).map((element) => [element.id, element]));
+  const candidate = structuredClone(scene);
+  const next = new Map(candidate.elements.map((element) => [element.id, element]));
+  const updates = new Map();
+  const moved = new Set();
+  const arrows = new Set();
+  const update = (id, properties) => {
+    updates.set(id, { targetId: id, properties: { ...updates.get(id)?.properties, ...properties } });
+    Object.assign(next.get(id), properties);
+  };
+  for (const { targetId, x, y } of operations) {
+    if (moved.has(targetId)) fail("INVALID_REQUEST", `Repeated move target: ${targetId}`);
+    moved.add(targetId);
+    const target = index.get(targetId);
+    if (!target) fail("UNKNOWN_TARGET", `No live element with ID: ${targetId}`);
+    supportedShape(target);
+    if (![x, y].every(Number.isFinite)) fail("INVALID_REQUEST", "Move coordinates must be finite numbers");
+    const dx = x - target.x;
+    const dy = y - target.y;
+    if (dx === 0 && dy === 0) continue;
+    const labels = target.boundElements?.filter((binding) => binding.type === "text") ?? [];
+    if (labels.length > 1) fail("UNSUPPORTED_GEOMETRY", "A moved shape can have at most one bound label");
+    for (const other of scene.elements.filter(areaElement)) {
+      if (other.id !== targetId && other.containerId !== targetId && contains(bounds(target), bounds(other))) {
+        fail("UNSUPPORTED_GEOMETRY", "Moving a container with nested content requires an explicit group operation");
+      }
+    }
+    update(targetId, { x, y });
+    for (const binding of target.boundElements ?? []) {
+      if (binding.type === "arrow") { arrows.add(binding.id); continue; }
+      const label = index.get(binding.id);
+      if (!label || label.containerId !== targetId || label.angle !== 0 || !bounds(label)) fail("UNSUPPORTED_GEOMETRY", "A moved label needs unrotated native geometry");
+      update(label.id, { x: label.x + dx, y: label.y + dy });
+    }
+    if (target.frameId != null && !contains(bounds(index.get(target.frameId)), bounds(next.get(targetId)))) {
+      fail("GEOMETRY_COLLISION", `Moving ${targetId} would leave its existing frame`);
+    }
+  }
+  for (const id of arrows) {
+    const arrow = index.get(id);
+    const oldPoints = arrowEndpoints(arrow);
+    const expected = arrowEndpoints({ ...arrow, ...routeStraightArrow(arrow, index) });
+    if (oldPoints.some((point, i) => Math.hypot(point[0] - expected[i][0], point[1] - expected[i][1]) > EPSILON)) {
+      fail("UNSUPPORTED_GEOMETRY", "The existing arrow path does not match its center bindings; preserve it as a manual route");
+    }
+    const properties = routeStraightArrow(arrow, next);
+    update(id, properties);
+    const newPoints = arrowEndpoints(next.get(id));
+    for (const binding of arrow.boundElements ?? []) {
+      const label = index.get(binding.id);
+      if (binding.type !== "text" || !label || label.containerId !== id || label.angle !== 0 || !bounds(label)) fail("UNSUPPORTED_GEOMETRY", "Unsupported arrow label geometry");
+      update(label.id, {
+        x: label.x + (newPoints[0][0] + newPoints[1][0] - oldPoints[0][0] - oldPoints[1][0]) / 2,
+        y: label.y + (newPoints[0][1] + newPoints[1][1] - oldPoints[0][1] - oldPoints[1][1]) / 2,
+      });
+    }
+  }
+  validateCollisions(scene, candidate, new Set(updates.keys()));
+  return [...updates.values()];
+}

--- a/src/scene.js
+++ b/src/scene.js
@@ -4,6 +4,7 @@ import { hostname } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { LABEL_CAPABILITIES, labelUpdate } from "./text.js";
+import { MOVE_CAPABILITIES, moveUpdates } from "./geometry.js";
 
 const STYLE_TYPES = ["rectangle", "ellipse", "diamond"];
 const STYLE_FIELDS = ["backgroundColor", "strokeColor"];
@@ -117,7 +118,8 @@ export async function inspectScene(inputPath) {
     inputPath: resolve(inputPath),
     baseHash: hash,
     capabilities: {
-      operations: ["setStyle", "setLabel"],
+      operations: ["setStyle", "setLabel", "move"],
+      move: MOVE_CAPABILITIES,
       setLabel: LABEL_CAPABILITIES,
       setStyle: { elementTypes: STYLE_TYPES, fields: STYLE_FIELDS, colors: "hex RGB/RGBA or transparent" },
       output: "edited copy; original is never overwritten",
@@ -194,16 +196,26 @@ export function applyStyleOperations(scene, operations) {
 
 export async function applyOperations(scene, operations, options = {}) {
   checkOperations(scene, operations);
+  const moves = operations.filter((operation) => operation?.op === "move");
+  for (const operation of moves) keys(operation, ["op", "targetId", "x", "y"], "move operation");
+  const geometry = moves.length ? moveUpdates(scene, moves) : [];
+  const positioned = geometry.length ? applyUpdates(scene, geometry).candidate : scene;
   const updates = [];
-  for (const operation of operations) {
+  for (const operation of operations.filter((operation) => operation?.op !== "move")) {
     if (operation?.op === "setLabel") {
       keys(operation, ["op", "targetId", "text"], "label operation");
-      updates.push(await labelUpdate(scene, operation.targetId, operation.text, options.measureLabel));
+      updates.push(await labelUpdate(positioned, operation.targetId, operation.text, options.measureLabel));
     } else {
-      updates.push(styleUpdate(scene, operation));
+      updates.push(styleUpdate(positioned, operation));
     }
   }
-  return applyUpdates(scene, updates);
+  if (!geometry.length) return applyUpdates(scene, updates);
+  // Validate repeated semantic assignments separately. A move and a relabel may
+  // both compute text coordinates, so merge those authorized derived fields.
+  applyUpdates(positioned, updates);
+  const combined = new Map(geometry.map((update) => [update.targetId, update]));
+  for (const update of updates) combined.set(update.targetId, { ...update, properties: { ...combined.get(update.targetId)?.properties, ...update.properties } });
+  return applyUpdates(scene, [...combined.values()]);
 }
 
 async function writeDurable(path, contents) {

--- a/test/geometry.test.js
+++ b/test/geometry.test.js
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { applyOperations, editScene, sha256, validateScene } from "../src/scene.js";
+import { arrowEndpoints, centerEndpoint, centerOf, routeStraightArrow } from "../src/geometry.js";
+
+function fixture() {
+  const shape = (id, type, x, y) => ({ id, type, x, y, width: 100, height: 80, angle: 0, roundness: null, groupIds: ["flow"], boundElements: [{ id: "edge", type: "arrow" }], customData: { preserve: true } });
+  const a = shape("a", "rectangle", 0, 0);
+  const b = shape("b", "ellipse", 300, 0);
+  const label = { id: "label", type: "text", x: 20, y: 25, width: 60, height: 25, angle: 0, containerId: "a", text: "API", originalText: "API", textAlign: "center", verticalAlign: "middle", fontSize: 20, fontFamily: 5, lineHeight: 1.25, autoResize: true };
+  a.boundElements.push({ id: "label", type: "text" });
+  const arrow = { id: "edge", type: "arrow", x: 110, y: 40, width: 178, height: 0, angle: 0, points: [[0, 0], [178, 0]], startBinding: { elementId: "a", focus: 0, gap: 10 }, endBinding: { elementId: "b", focus: 0, gap: 12 }, boundElements: null, customData: { preserve: "route" } };
+  const scene = { type: "excalidraw", version: 2, appState: { gridSize: 20 }, files: {}, elements: [a, label, b, arrow, { id: "note", type: "text", x: 700, y: 300, width: 100, height: 30, angle: 0, text: "Manual note" }] };
+  validateScene(scene);
+  return scene;
+}
+
+test("moving a shape translates its label and preserves every protected field", async () => {
+  const scene = fixture();
+  const { candidate, changes } = await applyOperations(scene, [{ op: "move", targetId: "a", x: -80, y: 0 }]);
+  assert.equal(candidate.elements[0].x, -80);
+  assert.equal(candidate.elements[1].x, -60);
+  assert.equal(candidate.elements[1].y, 25);
+  assert.deepEqual(candidate.elements[2], scene.elements[2]);
+  assert.deepEqual(candidate.elements[4], scene.elements[4]);
+  assert.deepEqual(candidate.elements[3].startBinding, scene.elements[3].startBinding);
+  assert.deepEqual(candidate.elements[3].endBinding, scene.elements[3].endBinding);
+  assert.deepEqual(arrowEndpoints(candidate.elements[3]), [[30, 40], [288, 40]]);
+  assert.deepEqual(changes.map((change) => change.id), ["a", "label", "edge"]);
+  assert.deepEqual(Object.keys(changes[0].properties), ["x"]);
+  assert.deepEqual(Object.keys(changes[2].properties).sort(), ["points", "width", "x"]);
+  validateScene(candidate);
+});
+
+test("a changed slope reanchors both native bound endpoints while the stationary shape stays unchanged", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [{ op: "move", targetId: "b", x: 400, y: 120 }]);
+  const [start, end] = arrowEndpoints(candidate.elements[3]);
+  assert.deepEqual(candidate.elements[0], scene.elements[0]);
+  assert.deepEqual(candidate.elements[1], scene.elements[1]);
+  assert.notEqual(start[1], 40);
+  const a = candidate.elements[0];
+  const b = candidate.elements[2];
+  assert.deepEqual(start, centerEndpoint(a, centerOf(b), 10));
+  assert.deepEqual(end, centerEndpoint(b, centerOf(a), 12));
+  assert.deepEqual(candidate.elements[3].endBinding, scene.elements[3].endBinding);
+});
+
+test("all supported shapes use their native expanded outline for center bindings", () => {
+  for (const [type, expected] of [["rectangle", [60, 60]], ["diamond", [30.5, 30.5]], ["ellipse", [60 / Math.sqrt(2), 60 / Math.sqrt(2)]]]) {
+    const actual = centerEndpoint({ id: "shape", type, x: -50, y: -50, width: 100, height: 100, angle: 0, roundness: null }, [200, 200], 10);
+    assert.ok(Math.abs(actual[0] - expected[0]) < 0.001);
+    assert.ok(Math.abs(actual[1] - expected[1]) < 0.001);
+  }
+});
+
+test("a single bound endpoint moves while the free endpoint remains exactly fixed", async () => {
+  const scene = fixture();
+  scene.elements[3].endBinding = null;
+  scene.elements[2].boundElements = null;
+  const oldFree = arrowEndpoints(scene.elements[3])[1];
+  const { candidate } = await applyOperations(scene, [{ op: "move", targetId: "a", x: 0, y: 100 }]);
+  assert.deepEqual(arrowEndpoints(candidate.elements[3])[1], oldFree);
+});
+
+test("moving both ends in one request updates a shared arrow only once", async () => {
+  const scene = fixture();
+  const { candidate, changes } = await applyOperations(scene, [
+    { op: "move", targetId: "a", x: 0, y: 150 },
+    { op: "move", targetId: "b", x: 300, y: 150 },
+  ]);
+  assert.deepEqual(arrowEndpoints(candidate.elements[3]), [[110, 190], [288, 190]]);
+  assert.equal(changes.filter((change) => change.id === "edge").length, 1);
+});
+
+test("bound arrow text preserves its manual offset from the segment midpoint", async () => {
+  const scene = fixture();
+  scene.elements[3].boundElements = [{ id: "arrow-label", type: "text" }];
+  scene.elements.push({ id: "arrow-label", type: "text", x: 160, y: 45, width: 60, height: 20, angle: 0, containerId: "edge", text: "HTTP" });
+  const { candidate } = await applyOperations(scene, [{ op: "move", targetId: "a", x: -80, y: 0 }]);
+  assert.equal(candidate.elements[5].x, 120);
+  assert.equal(candidate.elements[5].y, 45);
+  assert.equal(candidate.elements[5].text, "HTTP");
+});
+
+test("existing zone containment and native frame membership survive movement", async () => {
+  const scene = fixture();
+  scene.elements.push({ id: "zone", type: "rectangle", x: -100, y: -100, width: 600, height: 400, angle: 0 });
+  const { candidate } = await applyOperations(scene, [{ op: "move", targetId: "a", x: -50, y: 100 }]);
+  assert.deepEqual(candidate.elements[5], scene.elements[5]);
+  await assert.rejects(applyOperations(scene, [{ op: "move", targetId: "a", x: -150, y: 0 }]), { code: "GEOMETRY_COLLISION" });
+  scene.elements[5].type = "frame";
+  scene.elements[0].frameId = "zone";
+  await assert.rejects(applyOperations(scene, [{ op: "move", targetId: "a", x: -150, y: 0 }]), { code: "GEOMETRY_COLLISION" });
+});
+
+test("unrelated existing overlaps and unsupported arrow paths remain unchanged", async () => {
+  const scene = fixture();
+  scene.elements.push({ id: "old-overlap", type: "text", x: 700, y: 300, width: 100, height: 30, angle: 0, text: "Already overlapping" });
+  scene.elements.push({ id: "manual-unrelated", type: "arrow", x: 800, y: 0, width: 60, height: 40, angle: 0.3, elbowed: true, points: [[0, 0], [20, 30], [60, 40]] });
+  const { candidate } = await applyOperations(scene, [{ op: "move", targetId: "a", x: -50, y: 0 }]);
+  assert.deepEqual(candidate.elements.slice(4), scene.elements.slice(4));
+});
+
+test("new box overlaps and straight-arrow crossings reject before mutation", async () => {
+  const scene = fixture();
+  await assert.rejects(applyOperations(scene, [{ op: "move", targetId: "a", x: 270, y: 10 }]), { code: "GEOMETRY_COLLISION" });
+  scene.elements.push({ id: "blocker", type: "rectangle", x: 180, y: 90, width: 70, height: 30, angle: 0 });
+  await assert.rejects(applyOperations(scene, [{ op: "move", targetId: "b", x: 300, y: 160 }]), { code: "GEOMETRY_COLLISION" });
+  const stationary = fixture();
+  stationary.elements.push({ id: "stationary-arrow", type: "arrow", x: -60, y: -60, angle: 0, points: [[0, 0], [0, 200]] });
+  await assert.rejects(applyOperations(stationary, [{ op: "move", targetId: "a", x: -80, y: 0 }]), { code: "GEOMETRY_COLLISION" });
+});
+
+test("connected unsupported geometry or a manual path fails explicitly", async () => {
+  for (const mutate of [
+    (scene) => { scene.elements[3].elbowed = true; },
+    (scene) => { scene.elements[3].angle = 0.2; },
+    (scene) => { scene.elements[3].points.splice(1, 0, [100, 40]); },
+    (scene) => { scene.elements[3].startBinding.focus = 0.2; },
+    (scene) => { scene.elements[3].startBinding.fixedPoint = [1, 0.5]; },
+    (scene) => { scene.elements[3].points[0][1] = 10; },
+    (scene) => { scene.elements[0].roundness = { type: 3 }; },
+  ]) {
+    const scene = fixture(); mutate(scene);
+    await assert.rejects(applyOperations(scene, [{ op: "move", targetId: "a", x: -50, y: 0 }]), { code: "UNSUPPORTED_GEOMETRY" });
+  }
+});
+
+test("move and relabel compose using the translated text anchor", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [
+    { op: "setLabel", targetId: "a", text: "New API" },
+    { op: "move", targetId: "a", x: -80, y: 0 },
+  ], { measureLabel: async () => ({ text: "New API", width: 80, height: 25 }) });
+  assert.equal(candidate.elements[1].x, -70);
+  assert.equal(candidate.elements[1].text, "New API");
+});
+
+test("failed geometry leaves original bytes and produces no completed receipt", async (t) => {
+  const directory = await fs.mkdtemp(join(tmpdir(), "excalidraw-move-test-"));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const inputPath = join(directory, "input.excalidraw");
+  const bytes = JSON.stringify(fixture());
+  await fs.writeFile(inputPath, bytes);
+  await assert.rejects(editScene({ inputPath, outputDir: directory, requestId: "bad-move", baseHash: sha256(bytes), operations: [{ op: "move", targetId: "a", x: 270, y: 10 }] }, { renderScene: async () => assert.fail("render must not run") }), { code: "GEOMETRY_COLLISION" });
+  assert.equal(await fs.readFile(inputPath, "utf8"), bytes);
+  await assert.rejects(fs.access(join(directory, "bad-move", "receipt.json")), { code: "ENOENT" });
+});

--- a/test/scene.test.js
+++ b/test/scene.test.js
@@ -58,7 +58,7 @@ test("inspect exposes stable IDs, bindings, assets, and the supported operation 
   assert.equal(result.elements.find((element) => element.id === "api").label, "API");
   assert.equal(result.elements.find((element) => element.id === "edge").startBinding.elementId, "api");
   assert.deepEqual(result.assetIds, ["asset"]);
-  assert.deepEqual(result.capabilities.operations, ["setStyle", "setLabel"]);
+  assert.deepEqual(result.capabilities.operations, ["setStyle", "setLabel", "move"]);
   assert.deepEqual(result.capabilities.setStyle.elementTypes, ["rectangle", "ellipse", "diamond"]);
 });
 


### PR DESCRIPTION
Absolute movement now updates a supported shape, its bound label, and the dependent endpoints of straight native arrows. Stationary endpoints retain their gaps; unrelated elements and manual routing pass through unchanged. New local overlaps/crossings and unsupported connected geometry reject the request before publication.

Supports unrotated rectangles, ellipses, and diamonds with the documented center-bound, two-point arrow subset. Elbowed, fixed-point, off-center, and multipoint connected routes remain explicit limitations.

Validation: geometry fixtures cover both/free endpoints, labels, containment, existing unrelated collisions, and rejected paths. A native worker movement and subsequent queue-flow edit passed preservation/retry assertions and browser inspection. All 193 integrated core tests pass after building the required runtime and preview assets.

Depends on the agent-client workflow PR in this delivery stack.
