### PR TITLE
[Editing]: add measured nodes and stable native connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,35 @@ crossings fail with `GEOMETRY_COLLISION`; unrelated existing overlaps remain int
 This check is conservative for nonrectangular shapes and is not an automatic
 layout engine. Inspect the delivered preview before adopting the result.
 
+`addNode` and `connect` add content with explicit stable IDs:
+
+```json
+[
+  {
+    "op": "addNode", "id": "queue", "type": "rectangle",
+    "x": 200, "y": 160, "width": 140, "height": 80,
+    "region": { "x": 180, "y": 150, "width": 180, "height": 100 },
+    "label": { "id": "queue-label", "text": "Queue" }
+  },
+  { "op": "connect", "id": "enqueue", "fromId": "api", "toId": "queue" },
+  { "op": "connect", "id": "dequeue", "fromId": "queue", "toId": "worker" }
+]
+```
+
+Put these operations in the same request envelope used above. New IDs, including
+label IDs, must not collide with any existing or deleted element. Native seeds and
+version nonces derive from those IDs, so recovery recreates the same candidate.
+An explicitly repeated relationship under a different ID is a separate addition.
+
+Nodes require a placement region and explicit dimensions. Labels use the native
+font measurement and fit rules; rectangle, ellipse, and diamond interiors are
+supported. A region may include `containerId` to authorize placement inside an
+existing rectangle or frame. Frames also establish native `frameId` membership.
+New overlaps or straight-arrow crossings fail rather than rearranging other
+content. Connections reuse the supported center-binding geometry with a default
+10px gap. Existing moves and label/style edits run before additions; newly added
+nodes can be connected in that request and edited further in a subsequent request.
+
 A retry with the same request ID and payload returns its existing verified
 bundle. Different payloads under that ID conflict. Failed attempts can be retried;
 interrupted attempts recover in a new attempt after their owner exits. Concurrent

--- a/src/additions.js
+++ b/src/additions.js
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { bounds, contains, overlapArea, routeStraightArrow, arrowEndpoints, segmentInsideBox, stationaryStraightPoints } from "./geometry.js";
+import { LABEL_CAPABILITIES, measureLabel } from "./text.js";
+
+export const ADD_CAPABILITIES = {
+  addNode: "rectangle/ellipse/diamond; explicit stable ID, dimensions, and placement region; optional measured label with its own ID",
+  connect: "explicit stable ID and fromId/toId; center-bound straight arrows with reciprocal references",
+  collisions: "no new shape overlaps or straight-arrow crossings; region.containerId explicitly permits containment",
+};
+
+function fail(code, message) { throw Object.assign(new Error(message), { code }); }
+function keys(value, permitted, description) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).some((key) => !permitted.includes(key))) fail("INVALID_REQUEST", `Invalid ${description} fields`);
+}
+
+function style(value = {}, fields = ["backgroundColor", "strokeColor"]) {
+  keys(value, fields, "style");
+  for (const color of Object.values(value)) {
+    if (typeof color !== "string" || !(color === "transparent" || /^#(?:[\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i.test(color))) fail("INVALID_REQUEST", "Styles require hex colors or transparent");
+  }
+  return value;
+}
+
+function nativeElement(id, type, properties) {
+  const hash = createHash("sha256").update(id).digest();
+  return {
+    id, type, x: 0, y: 0, width: 0, height: 0, angle: 0,
+    strokeColor: "#1e1e1e", backgroundColor: "transparent", fillStyle: "solid",
+    strokeWidth: 2, strokeStyle: "solid", roughness: 1, opacity: 100,
+    groupIds: [], frameId: null, roundness: null,
+    seed: hash.readUInt32BE(0) & 0x7fffffff,
+    version: 1, versionNonce: hash.readUInt32BE(4) & 0x7fffffff,
+    isDeleted: false, boundElements: null, updated: 0, link: null, locked: false,
+    ...properties,
+  };
+}
+
+function claimId(id, ids) {
+  if (typeof id !== "string" || !id.trim() || id.length > 200) fail("INVALID_REQUEST", "Every new element needs an explicit stable ID of at most 200 characters");
+  if (ids.has(id)) fail("ID_CONFLICT", `Element ID already exists: ${id}`);
+  ids.add(id);
+}
+
+function regionFor(value, scene, node) {
+  keys(value, ["x", "y", "width", "height", "containerId"], "region");
+  if (![value.x, value.y, value.width, value.height].every(Number.isFinite) || value.width <= 0 || value.height <= 0) fail("INVALID_REQUEST", "A placement region needs finite positive dimensions");
+  const region = bounds(value);
+  if (!contains(region, bounds(node))) fail("PLACEMENT_CONFLICT", `Node ${node.id} does not fit its declared region`);
+  if (value.containerId !== undefined) {
+    const container = scene.elements.find((element) => element.id === value.containerId && !element.isDeleted);
+    if (!container || !["rectangle", "frame", "magicframe"].includes(container.type) || container.angle !== 0 || !contains(bounds(container), region)) {
+      fail("PLACEMENT_CONFLICT", "region.containerId must identify a containing unrotated rectangle or frame");
+    }
+    if (["frame", "magicframe"].includes(container.type)) node.frameId = container.id;
+  }
+}
+
+async function newNode(operation, scene, ids, measure) {
+  keys(operation, ["op", "id", "type", "x", "y", "width", "height", "region", "label", "style"], "addNode");
+  if (!["rectangle", "ellipse", "diamond"].includes(operation.type)) fail("UNSUPPORTED_TARGET", "addNode supports rectangles, ellipses, and diamonds");
+  claimId(operation.id, ids);
+  const { x, y, width, height } = operation;
+  if (![x, y, width, height].every(Number.isFinite) || width <= 10 || height <= 10) fail("INVALID_REQUEST", "Node dimensions must be finite and larger than 10px");
+  const node = nativeElement(operation.id, operation.type, { x, y, width, height, ...style(operation.style) });
+  regionFor(operation.region, scene, node);
+  if (operation.label === undefined) return [node];
+  keys(operation.label, ["id", "text", "fontSize", "fontFamily", "lineHeight"], "label");
+  claimId(operation.label.id, ids);
+  const { text, fontSize = 20, fontFamily = 5, lineHeight = 1.25 } = operation.label;
+  if (typeof text !== "string" || !text.length || /[\u0000-\u0009\u000b-\u001f]/u.test(text) || ![fontSize, lineHeight].every(Number.isFinite) || fontSize <= 0 || lineHeight <= 0) fail("INVALID_REQUEST", "A label needs nonempty text and positive font metrics");
+  if (!LABEL_CAPABILITIES.fontFamilies.includes(fontFamily)) fail("UNSUPPORTED_FONT", "A bundled label font is required");
+  if (/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(text) && fontFamily !== 5) fail("UNSUPPORTED_FONT_TEXT", "CJK labels require Excalifont");
+  const ratio = node.type === "ellipse" ? Math.SQRT1_2 : node.type === "diamond" ? 0.5 : 1;
+  const maxWidth = Math.round(width * ratio) - 10;
+  const maxHeight = Math.round(height * ratio) - 10;
+  const metrics = await measure({ text, fontSize, fontFamily, lineHeight, maxWidth });
+  if (!metrics || typeof metrics.text !== "string" || ![metrics.width, metrics.height].every(Number.isFinite) || metrics.width <= 0 || metrics.height <= 0) fail("INVALID_TEXT_METRICS", "Invalid native text metrics");
+  if (metrics.text.replaceAll("\n", "").replaceAll(" ", "") !== text.replaceAll("\n", "").replaceAll(" ", "")) fail("INVALID_TEXT_METRICS", "Native wrapping lost requested label content");
+  if (metrics.width > maxWidth + 0.001 || metrics.height > maxHeight + 0.001) fail("TEXT_OVERFLOW", `Label ${operation.label.id} cannot fit the requested node`);
+  const label = nativeElement(operation.label.id, "text", {
+    x: x + (width - metrics.width) / 2, y: y + (height - metrics.height) / 2,
+    width: metrics.width, height: metrics.height, text: metrics.text, originalText: text,
+    fontSize, fontFamily, lineHeight, textAlign: "center", verticalAlign: "middle",
+    containerId: node.id, frameId: node.frameId, autoResize: true, strokeColor: node.strokeColor,
+  });
+  node.boundElements = [{ id: label.id, type: "text" }];
+  return [node, label];
+}
+
+function checkPlacement(scene, additions, operations) {
+  const all = [...scene.elements, ...additions].filter((element) => !element.isDeleted);
+  const nodeOperations = new Map(operations.filter((operation) => operation.op === "addNode").map((operation) => [operation.id, operation]));
+  for (const node of additions.filter((element) => nodeOperations.has(element.id))) {
+    const within = nodeOperations.get(node.id).region.containerId;
+    for (const other of all) {
+      if (other.id === node.id || other.containerId === node.id || other.id === within || ["line", "freedraw"].includes(other.type)) continue;
+      if (other.type === "arrow") {
+        if ([other.startBinding?.elementId, other.endBinding?.elementId].includes(node.id)) continue;
+        const points = stationaryStraightPoints(other);
+        if (points && segmentInsideBox(...points, bounds(node))) fail("PLACEMENT_CONFLICT", `Node ${node.id} crosses arrow ${other.id}`);
+      } else if (overlapArea(bounds(node), bounds(other)) > 0.001) {
+        fail("PLACEMENT_CONFLICT", `Node ${node.id} overlaps ${other.id}`);
+      }
+    }
+  }
+  const index = new Map(all.map((element) => [element.id, element]));
+  for (const arrow of additions.filter((element) => element.type === "arrow")) {
+    const points = arrowEndpoints(arrow);
+    for (const other of all) {
+      if (["arrow", "line", "freedraw"].includes(other.type) || [arrow.startBinding.elementId, arrow.endBinding.elementId].includes(other.id)) continue;
+      if (contains(bounds(other), bounds(index.get(arrow.startBinding.elementId))) || contains(bounds(other), bounds(index.get(arrow.endBinding.elementId)))) continue;
+      if (segmentInsideBox(...points, bounds(other))) fail("PLACEMENT_CONFLICT", `Connection ${arrow.id} crosses ${other.id}`);
+    }
+  }
+}
+
+export async function planAdditions(scene, operations, options = {}) {
+  const ids = new Set(scene.elements.map((element) => element.id));
+  const additions = [];
+  const updates = new Map();
+  for (const operation of operations.filter((operation) => operation.op === "addNode")) additions.push(...await newNode(operation, scene, ids, options.measureLabel ?? measureLabel));
+  const index = new Map([...scene.elements, ...additions].filter((element) => !element.isDeleted).map((element) => [element.id, element]));
+  for (const operation of operations.filter((operation) => operation.op === "connect")) {
+    keys(operation, ["op", "id", "fromId", "toId", "gap", "style"], "connect");
+    claimId(operation.id, ids);
+    if (operation.fromId === operation.toId) fail("UNSUPPORTED_GEOMETRY", "Self-connections are outside the straight-arrow operation");
+    const from = index.get(operation.fromId); const to = index.get(operation.toId);
+    if (!from || !to) fail("UNKNOWN_TARGET", "A connection must reference live existing or newly added nodes");
+    const gap = operation.gap ?? 10;
+    if (!Number.isFinite(gap) || gap < 1) fail("INVALID_REQUEST", "Connection gap must be a finite number of at least 1px");
+    const arrow = nativeElement(operation.id, "arrow", {
+      points: [[0, 0], [1, 1]], startBinding: { elementId: from.id, focus: 0, gap }, endBinding: { elementId: to.id, focus: 0, gap },
+      startArrowhead: null, endArrowhead: "arrow", elbowed: false, ...style(operation.style, ["strokeColor"]),
+    });
+    Object.assign(arrow, routeStraightArrow(arrow, index));
+    additions.push(arrow); index.set(arrow.id, arrow);
+    for (const node of [from, to]) {
+      const properties = updates.get(node.id)?.properties ?? {};
+      const boundElements = [...(properties.boundElements ?? node.boundElements ?? []), { id: arrow.id, type: "arrow" }];
+      if (additions.includes(node)) node.boundElements = boundElements;
+      else updates.set(node.id, { targetId: node.id, properties: { boundElements } });
+    }
+  }
+  checkPlacement(scene, additions, operations);
+  return { additions, updates: [...updates.values()] };
+}

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -26,7 +26,7 @@ export function contains(outer, inner) {
   return outer && inner && outer.left <= inner.left + EPSILON && outer.top <= inner.top + EPSILON && outer.right >= inner.right - EPSILON && outer.bottom >= inner.bottom - EPSILON;
 }
 
-function overlapArea(a, b) {
+export function overlapArea(a, b) {
   if (!a || !b) return 0;
   return Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left)) * Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
 }
@@ -106,7 +106,7 @@ export function routeStraightArrow(arrow, index) {
   return { x: start[0], y: start[1], width: Math.abs(end[0] - start[0]), height: Math.abs(end[1] - start[1]), points: [[0, 0], [end[0] - start[0], end[1] - start[1]]] };
 }
 
-function segmentInsideBox(start, end, box) {
+export function segmentInsideBox(start, end, box) {
   if (!box) return false;
   const limits = [[box.left + EPSILON, box.right - EPSILON], [box.top + EPSILON, box.bottom - EPSILON]];
   let low = 0;
@@ -128,7 +128,7 @@ function areaElement(element) {
   return !element.isDeleted && !["arrow", "line", "freedraw"].includes(element.type);
 }
 
-function stationaryStraightPoints(element) {
+export function stationaryStraightPoints(element) {
   if (element.type !== "arrow" || element.elbowed || element.points?.length !== 2 || !element.points.every((point) => Array.isArray(point) && point.length === 2 && point.every(Number.isFinite))) return null;
   const points = element.points.map(([x, y]) => [element.x + x, element.y + y]);
   if (![element.x, element.y, element.angle ?? 0].every(Number.isFinite)) return null;

--- a/src/scene.js
+++ b/src/scene.js
@@ -5,6 +5,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { LABEL_CAPABILITIES, labelUpdate } from "./text.js";
 import { MOVE_CAPABILITIES, moveUpdates } from "./geometry.js";
+import { ADD_CAPABILITIES, planAdditions } from "./additions.js";
 
 const STYLE_TYPES = ["rectangle", "ellipse", "diamond"];
 const STYLE_FIELDS = ["backgroundColor", "strokeColor"];
@@ -118,7 +119,8 @@ export async function inspectScene(inputPath) {
     inputPath: resolve(inputPath),
     baseHash: hash,
     capabilities: {
-      operations: ["setStyle", "setLabel", "move"],
+      operations: ["setStyle", "setLabel", "move", "addNode", "connect"],
+      ...ADD_CAPABILITIES,
       move: MOVE_CAPABILITIES,
       setLabel: LABEL_CAPABILITIES,
       setStyle: { elementTypes: STYLE_TYPES, fields: STYLE_FIELDS, colors: "hex RGB/RGBA or transparent" },
@@ -151,8 +153,9 @@ function styleUpdate(scene, operation) {
   return { targetId: target.id, properties: operation.style };
 }
 
-function applyUpdates(scene, updates) {
+function applyUpdates(scene, updates, additions = []) {
   const candidate = structuredClone(scene);
+  candidate.elements.push(...structuredClone(additions));
   const next = new Map(candidate.elements.map((element) => [element.id, element]));
   const allowed = new Map();
   for (const { targetId, properties } of updates) {
@@ -180,7 +183,11 @@ function applyUpdates(scene, updates) {
     }
     if (Object.keys(properties).length) changes.push({ id: before.id, properties });
   }
+  protectedCopy.elements.length = scene.elements.length;
   if (!isDeepStrictEqual(scene, protectedCopy)) fail("PROTECTED_CHANGE", "The candidate changed a protected value");
+  for (const element of candidate.elements.slice(scene.elements.length)) {
+    changes.push({ id: element.id, created: true, properties: Object.fromEntries(Object.entries(element).map(([field, after]) => [field, { before: null, after }])) });
+  }
   return { candidate, changes };
 }
 
@@ -194,7 +201,7 @@ export function applyStyleOperations(scene, operations) {
   return applyUpdates(scene, operations.map((operation) => styleUpdate(scene, operation)));
 }
 
-export async function applyOperations(scene, operations, options = {}) {
+async function applyExistingOperations(scene, operations, options = {}) {
   checkOperations(scene, operations);
   const moves = operations.filter((operation) => operation?.op === "move");
   for (const operation of moves) keys(operation, ["op", "targetId", "x", "y"], "move operation");
@@ -216,6 +223,18 @@ export async function applyOperations(scene, operations, options = {}) {
   const combined = new Map(geometry.map((update) => [update.targetId, update]));
   for (const update of updates) combined.set(update.targetId, { ...update, properties: { ...combined.get(update.targetId)?.properties, ...update.properties } });
   return applyUpdates(scene, [...combined.values()]);
+}
+
+export async function applyOperations(scene, operations, options = {}) {
+  checkOperations(scene, operations);
+  const additionOperations = operations.filter((operation) => ["addNode", "connect"].includes(operation?.op));
+  const existingOperations = operations.filter((operation) => !["addNode", "connect"].includes(operation?.op));
+  const existing = existingOperations.length ? await applyExistingOperations(scene, existingOperations, options) : { candidate: scene, changes: [] };
+  if (!additionOperations.length) return existing;
+  const { additions, updates } = await planAdditions(existing.candidate, additionOperations, options);
+  const combined = new Map(existing.changes.map((change) => [change.id, { targetId: change.id, properties: Object.fromEntries(Object.entries(change.properties).map(([field, value]) => [field, value.after])) }]));
+  for (const update of updates) combined.set(update.targetId, { ...update, properties: { ...combined.get(update.targetId)?.properties, ...update.properties } });
+  return applyUpdates(scene, [...combined.values()], additions);
 }
 
 async function writeDurable(path, contents) {

--- a/test/additions.test.js
+++ b/test/additions.test.js
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { applyOperations, editScene, sha256, validateScene } from "../src/scene.js";
+
+const PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zz1kAAAAASUVORK5CYII=", "base64");
+const measureLabel = async ({ text }) => ({ text, width: 65, height: 25 });
+const renderScene = async (_, path) => fs.writeFile(path, PNG);
+
+function fixture() {
+  return {
+    type: "excalidraw", version: 2, files: { unused: { id: "unused", dataURL: "keep this asset" } }, appState: { gridSize: 20 }, customData: { keep: true },
+    elements: [
+      { id: "api", type: "rectangle", x: 0, y: 0, width: 120, height: 80, angle: 0, roundness: null, boundElements: [{ id: "direct", type: "arrow" }], customData: { manual: true } },
+      { id: "worker", type: "rectangle", x: 400, y: 0, width: 120, height: 80, angle: 0, roundness: null, boundElements: [{ id: "direct", type: "arrow" }] },
+      { id: "direct", type: "arrow", x: 130, y: 40, width: 260, height: 0, angle: 0, points: [[0, 0], [260, 0]], startBinding: { elementId: "api", focus: 0, gap: 10 }, endBinding: { elementId: "worker", focus: 0, gap: 10 } },
+      { id: "note", type: "text", x: 20, y: 260, width: 150, height: 30, angle: 0, text: "Manual note" },
+      { id: "deleted", type: "rectangle", x: 20, y: 300, width: 100, height: 80, angle: 0, isDeleted: true },
+    ],
+  };
+}
+
+function operations() {
+  return [
+    { op: "addNode", id: "queue", type: "rectangle", x: 200, y: 160, width: 140, height: 80, region: { x: 180, y: 150, width: 180, height: 100 }, label: { id: "queue-label", text: "Queue" }, style: { backgroundColor: "#fff3bf" } },
+    { op: "connect", id: "enqueue", fromId: "api", toId: "queue" },
+    { op: "connect", id: "dequeue", fromId: "queue", toId: "worker" },
+  ];
+}
+
+test("add a measured node and its requested connections exactly once with reciprocal bindings", async () => {
+  const scene = fixture();
+  const { candidate, changes } = await applyOperations(scene, operations(), { measureLabel });
+  const index = validateScene(candidate);
+  assert.deepEqual(candidate.elements.map((element) => element.id), [...scene.elements.map((element) => element.id), "queue", "queue-label", "enqueue", "dequeue"]);
+  assert.deepEqual(index.get("api").boundElements, [{ id: "direct", type: "arrow" }, { id: "enqueue", type: "arrow" }]);
+  assert.deepEqual(index.get("queue").boundElements, [{ id: "queue-label", type: "text" }, { id: "enqueue", type: "arrow" }, { id: "dequeue", type: "arrow" }]);
+  assert.equal(index.get("queue-label").containerId, "queue");
+  assert.equal(index.get("queue-label").originalText, "Queue");
+  assert.equal(index.get("queue-label").x, 237.5);
+  assert.deepEqual(candidate.elements.slice(2, 5), scene.elements.slice(2));
+  assert.deepEqual(candidate.files, scene.files);
+  assert.deepEqual(candidate.customData, scene.customData);
+  assert.deepEqual(changes.filter((change) => change.created).map((change) => change.id), ["queue", "queue-label", "enqueue", "dequeue"]);
+  assert.deepEqual(changes.filter((change) => !change.created).map((change) => Object.keys(change.properties)), [["boundElements"], ["boundElements"]]);
+});
+
+test("explicit IDs make the complete new native elements deterministic", async () => {
+  const first = await applyOperations(fixture(), operations(), { measureLabel });
+  const second = await applyOperations(fixture(), operations(), { measureLabel });
+  assert.deepEqual(first, second);
+  for (const id of ["api", "deleted", "queue-label"]) {
+    const request = operations(); request[0].id = id;
+    await assert.rejects(applyOperations(fixture(), request, { measureLabel }), { code: "ID_CONFLICT" });
+  }
+});
+
+test("failed rendering recovers with identical IDs and bytes; completed retry returns the same result", async (t) => {
+  const directory = await fs.mkdtemp(join(tmpdir(), "excalidraw-add-test-"));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const inputPath = join(directory, "input.excalidraw");
+  const original = JSON.stringify(fixture());
+  await fs.writeFile(inputPath, original);
+  const request = { inputPath, outputDir: directory, requestId: "queue-001", baseHash: sha256(original), operations: operations() };
+  await assert.rejects(editScene(request, { measureLabel, renderScene: async () => { throw new Error("render failed"); } }));
+  const attempts = join(directory, request.requestId, "attempts");
+  const [failedAttempt] = await fs.readdir(attempts);
+  const failedBytes = await fs.readFile(join(attempts, failedAttempt, "after.excalidraw"), "utf8");
+  const receipt = await editScene(request, { measureLabel, renderScene });
+  assert.equal(await fs.readFile(receipt.artifacts["after.excalidraw"].path, "utf8"), failedBytes);
+  assert.deepEqual(await editScene(request, { measureLabel, renderScene: async () => assert.fail("retry must not render") }), receipt);
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+});
+
+test("new nodes must fit their declared region and avoid existing content", async () => {
+  const outside = operations(); outside[0].region.width = 50;
+  await assert.rejects(applyOperations(fixture(), outside, { measureLabel }), { code: "PLACEMENT_CONFLICT" });
+  const overlap = [operations()[0]]; Object.assign(overlap[0], { x: 20, y: 20, region: { x: 0, y: 0, width: 300, height: 200 } });
+  await assert.rejects(applyOperations(fixture(), overlap, { measureLabel }), { code: "PLACEMENT_CONFLICT" });
+  const crossing = operations(); Object.assign(crossing[0], { y: 0, region: { x: 180, y: 0, width: 180, height: 100 } });
+  await assert.rejects(applyOperations(fixture(), crossing, { measureLabel }), { code: "PLACEMENT_CONFLICT" });
+});
+
+test("a named region permits intentional containment and sets native frame membership", async () => {
+  const scene = fixture();
+  scene.elements.push({ id: "zone", type: "frame", x: 180, y: 140, width: 200, height: 120, angle: 0 });
+  const request = [operations()[0]];
+  request[0].region.containerId = "zone";
+  const { candidate } = await applyOperations(scene, request, { measureLabel });
+  assert.equal(candidate.elements.find((element) => element.id === "queue").frameId, "zone");
+  assert.equal(candidate.elements.find((element) => element.id === "queue-label").frameId, "zone");
+  validateScene(candidate);
+  delete request[0].region.containerId;
+  await assert.rejects(applyOperations(scene, request, { measureLabel }), { code: "PLACEMENT_CONFLICT" });
+});
+
+test("all node shapes measure against their native label interior and reject overflow", async () => {
+  for (const [type, expectedWidth] of [["rectangle", 130], ["ellipse", Math.round(140 * Math.SQRT1_2) - 10], ["diamond", 60]]) {
+    const request = [operations()[0]]; request[0].type = type;
+    await applyOperations(fixture(), request, { measureLabel: async ({ text, maxWidth }) => {
+      assert.equal(maxWidth, expectedWidth); return { text, width: 50, height: 25 };
+    } });
+    await assert.rejects(applyOperations(fixture(), request, { measureLabel: async ({ text }) => ({ text, width: 500, height: 25 }) }), { code: "TEXT_OVERFLOW" });
+  }
+});
+
+test("missing relationships, duplicated IDs, or unsupported connection geometry fail explicitly", async () => {
+  const missing = operations(); missing[1].toId = "absent";
+  await assert.rejects(applyOperations(fixture(), missing, { measureLabel }), { code: "UNKNOWN_TARGET" });
+  const duplicate = operations(); duplicate[2].id = duplicate[1].id;
+  await assert.rejects(applyOperations(fixture(), duplicate, { measureLabel }), { code: "ID_CONFLICT" });
+  const self = [{ op: "connect", id: "self", fromId: "api", toId: "api" }];
+  await assert.rejects(applyOperations(fixture(), self), { code: "UNSUPPORTED_GEOMETRY" });
+  const invalid = operations(); invalid[1].gap = NaN;
+  await assert.rejects(applyOperations(fixture(), invalid, { measureLabel }), { code: "INVALID_REQUEST" });
+});

--- a/test/scene.test.js
+++ b/test/scene.test.js
@@ -58,7 +58,7 @@ test("inspect exposes stable IDs, bindings, assets, and the supported operation 
   assert.equal(result.elements.find((element) => element.id === "api").label, "API");
   assert.equal(result.elements.find((element) => element.id === "edge").startBinding.elementId, "api");
   assert.deepEqual(result.assetIds, ["asset"]);
-  assert.deepEqual(result.capabilities.operations, ["setStyle", "setLabel", "move"]);
+  assert.deepEqual(result.capabilities.operations, ["setStyle", "setLabel", "move", "addNode", "connect"]);
   assert.deepEqual(result.capabilities.setStyle.elementTypes, ["rectangle", "ellipse", "diamond"]);
 });
 


### PR DESCRIPTION
Scoped requests can append nodes and straight connections using explicit stable IDs, measured labels, declared placement regions, and reciprocal bindings. Existing IDs, including tombstones, conflict instead of being replaced; collisions fail instead of rearranging the canvas.

Validation: fixtures cover duplicate IDs, placement/label failures, bound endpoints, exact additions, retries, and protected content. An actual native queue insertion rendered correctly and reused the same completed result on retry. Removing the original direct edge is provided by the following PR.

Depends on the supported-movement PR. The isolated installed core package passed native edit, exact retry, and protected-content checks; computer use verified the saved scene and preview.
