### PR TITLE
[Editing]: remove scoped elements without orphaned bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,32 @@ content. Connections reuse the supported center-binding geometry with a default
 10px gap. Existing moves and label/style edits run before additions; newly added
 nodes can be connected in that request and edited further in a subsequent request.
 
+`remove` marks an element and its owned bound labels deleted. A connected node
+requires an explicit choice for its arrows:
+
+```json
+{ "op": "remove", "targetId": "obsolete-service", "connections": "remove" }
+```
+
+Use `connections: "detach"` to retain the arrows as free-ended paths, including
+their labels. To remove just an obsolete edge, use
+`{"op":"remove","targetId":"old-edge"}`. Native tombstones retain their other
+fields, and image assets remain in the document. Removing a frame with retained
+children fails; identify those children explicitly if they should also be removed.
+
+`disconnect` detaches selected arrow endpoints while keeping its path and label:
+
+```json
+{ "op": "disconnect", "targetId": "old-edge", "end": "both" }
+```
+
+`end` accepts `start`, `end`, or `both`. Reciprocal bindings on retained objects
+are updated without changing the remaining connected endpoint. Removal and
+disconnection run before moves, relabeling, and additions, so a single request can
+replace a direct connection with a queue flow without leaving an intermediate
+diagram. The receipt lists every changed ID/property; the original snapshot remains
+the recovery artifact.
+
 A retry with the same request ID and payload returns its existing verified
 bundle. Different payloads under that ID conflict. Failed attempts can be retried;
 interrupted attempts recover in a new attempt after their owner exits. Concurrent

--- a/src/removals.js
+++ b/src/removals.js
@@ -1,0 +1,90 @@
+import { isDeepStrictEqual } from "node:util";
+
+export const REMOVE_CAPABILITIES = {
+  remove: { required: ["targetId"], connections: ["detach", "remove"], behavior: "mark selected native elements and owned labels deleted; connections policy required for connected nodes" },
+  disconnect: { required: ["targetId", "end"], end: ["start", "end", "both"], behavior: "detach bindings while preserving the arrow path and its label" },
+  preservation: "keep element order, native tombstones, unknown metadata, and image assets; reject deleting frames with retained children",
+};
+
+function fail(code, message) { throw Object.assign(new Error(message), { code }); }
+function keys(value, permitted) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).some((key) => !permitted.includes(key))) fail("INVALID_REQUEST", "Invalid removal fields");
+}
+
+export function planRemovals(scene, operations) {
+  const index = new Map(scene.elements.filter((element) => !element.isDeleted).map((element) => [element.id, element]));
+  const candidate = new Map(scene.elements.map((element) => [element.id, structuredClone(element)]));
+  const deleted = new Set();
+  const modes = new Map();
+  const targets = new Set();
+  const disconnects = [];
+  const supported = ["rectangle", "ellipse", "diamond", "text", "arrow", "line", "freedraw", "image", "frame", "magicframe", "embeddable", "iframe"];
+
+  function owned(id) {
+    const element = index.get(id);
+    return [id, ...(element.boundElements ?? []).filter((binding) => binding.type === "text").map((binding) => binding.id)];
+  }
+  function mark(id, mode) {
+    for (const childId of owned(id)) {
+      deleted.add(childId);
+      if (mode) modes.set(childId, mode);
+    }
+  }
+
+  for (const operation of operations) {
+    keys(operation, operation.op === "remove" ? ["op", "targetId", "connections"] : ["op", "targetId", "end"]);
+    if (targets.has(operation.targetId)) fail("INVALID_REQUEST", `Repeated removal/disconnection target: ${operation.targetId}`);
+    targets.add(operation.targetId);
+    const target = index.get(operation.targetId);
+    if (!target) fail("UNKNOWN_TARGET", `No live element with ID: ${operation.targetId}`);
+    if (operation.op === "disconnect") {
+      if (target.type !== "arrow") fail("UNSUPPORTED_TARGET", "disconnect targets an existing arrow");
+      if (!["start", "end", "both"].includes(operation.end)) fail("INVALID_REQUEST", "disconnect requires end:'start', 'end', or 'both'");
+      disconnects.push(operation);
+      continue;
+    }
+    if (operation.op !== "remove" || !supported.includes(target.type)) fail("UNSUPPORTED_TARGET", "Unsupported removal target");
+    if (operation.connections !== undefined && !["detach", "remove"].includes(operation.connections)) fail("INVALID_REQUEST", "connections must be 'detach' or 'remove'");
+    const dependentArrows = new Set(owned(target.id).flatMap((id) => (index.get(id).boundElements ?? []).filter((binding) => binding.type === "arrow").map((binding) => binding.id)));
+    if (dependentArrows.size && operation.connections === undefined) fail("AMBIGUOUS_REMOVAL", `Removing ${target.id} requires a connections policy for ${[...dependentArrows].join(", ")}`);
+    mark(target.id, operation.connections);
+    if (operation.connections === "remove") for (const arrowId of dependentArrows) mark(arrowId);
+  }
+
+  for (const operation of disconnects) {
+    if (deleted.has(operation.targetId)) fail("INVALID_REQUEST", "An arrow cannot be removed and disconnected in the same request");
+    const arrow = candidate.get(operation.targetId);
+    if (["start", "both"].includes(operation.end)) arrow.startBinding = null;
+    if (["end", "both"].includes(operation.end)) arrow.endBinding = null;
+  }
+  for (const id of deleted) candidate.get(id).isDeleted = true;
+  for (const element of candidate.values()) {
+    if (element.isDeleted) continue;
+    if (element.frameId != null && deleted.has(element.frameId)) fail("AMBIGUOUS_REMOVAL", `Frame ${element.frameId} still contains ${element.id}; remove its children explicitly first`);
+    if (element.containerId != null && deleted.has(element.containerId)) fail("AMBIGUOUS_REMOVAL", `Retained text ${element.id} still references a removed container`);
+    for (const field of ["startBinding", "endBinding"]) {
+      const targetId = element[field]?.elementId;
+      if (!deleted.has(targetId)) continue;
+      if (modes.get(targetId) !== "detach") fail("AMBIGUOUS_REMOVAL", `Retained arrow ${element.id} still references removed element ${targetId}`);
+      element[field] = null;
+    }
+  }
+  for (const element of candidate.values()) {
+    if (element.isDeleted || !Array.isArray(element.boundElements)) continue;
+    element.boundElements = element.boundElements.filter((binding) => {
+      const child = candidate.get(binding.id);
+      if (child.isDeleted) return false;
+      return binding.type !== "arrow" || child.startBinding?.elementId === element.id || child.endBinding?.elementId === element.id;
+    });
+  }
+  const updates = [];
+  for (const before of scene.elements) {
+    const after = candidate.get(before.id);
+    const properties = {};
+    for (const field of ["isDeleted", "boundElements", "startBinding", "endBinding"]) {
+      if (!isDeepStrictEqual(before[field], after[field])) properties[field] = after[field];
+    }
+    if (Object.keys(properties).length) updates.push({ targetId: before.id, properties });
+  }
+  return updates;
+}

--- a/src/scene.js
+++ b/src/scene.js
@@ -6,6 +6,7 @@ import { isDeepStrictEqual } from "node:util";
 import { LABEL_CAPABILITIES, labelUpdate } from "./text.js";
 import { MOVE_CAPABILITIES, moveUpdates } from "./geometry.js";
 import { ADD_CAPABILITIES, planAdditions } from "./additions.js";
+import { REMOVE_CAPABILITIES, planRemovals } from "./removals.js";
 
 const STYLE_TYPES = ["rectangle", "ellipse", "diamond"];
 const STYLE_FIELDS = ["backgroundColor", "strokeColor"];
@@ -119,7 +120,8 @@ export async function inspectScene(inputPath) {
     inputPath: resolve(inputPath),
     baseHash: hash,
     capabilities: {
-      operations: ["setStyle", "setLabel", "move", "addNode", "connect"],
+      operations: ["setStyle", "setLabel", "move", "addNode", "connect", "remove", "disconnect"],
+      ...REMOVE_CAPABILITIES,
       ...ADD_CAPABILITIES,
       move: MOVE_CAPABILITIES,
       setLabel: LABEL_CAPABILITIES,
@@ -225,7 +227,7 @@ async function applyExistingOperations(scene, operations, options = {}) {
   return applyUpdates(scene, [...combined.values()]);
 }
 
-export async function applyOperations(scene, operations, options = {}) {
+async function applyNonRemovalOperations(scene, operations, options = {}) {
   checkOperations(scene, operations);
   const additionOperations = operations.filter((operation) => ["addNode", "connect"].includes(operation?.op));
   const existingOperations = operations.filter((operation) => !["addNode", "connect"].includes(operation?.op));
@@ -235,6 +237,22 @@ export async function applyOperations(scene, operations, options = {}) {
   const combined = new Map(existing.changes.map((change) => [change.id, { targetId: change.id, properties: Object.fromEntries(Object.entries(change.properties).map(([field, value]) => [field, value.after])) }]));
   for (const update of updates) combined.set(update.targetId, { ...update, properties: { ...combined.get(update.targetId)?.properties, ...update.properties } });
   return applyUpdates(scene, [...combined.values()], additions);
+}
+
+export async function applyOperations(scene, operations, options = {}) {
+  checkOperations(scene, operations);
+  const removalOperations = operations.filter((operation) => ["remove", "disconnect"].includes(operation?.op));
+  const remaining = operations.filter((operation) => !["remove", "disconnect"].includes(operation?.op));
+  if (!removalOperations.length) return applyNonRemovalOperations(scene, operations, options);
+  const removals = planRemovals(scene, removalOperations);
+  const base = applyUpdates(scene, removals).candidate;
+  if (!remaining.length) return applyUpdates(scene, removals);
+  const result = await applyNonRemovalOperations(base, remaining, options);
+  const combined = new Map(removals.map((update) => [update.targetId, update]));
+  for (const change of result.changes.filter((change) => !change.created)) {
+    combined.set(change.id, { targetId: change.id, properties: { ...combined.get(change.id)?.properties, ...Object.fromEntries(Object.entries(change.properties).map(([field, value]) => [field, value.after])) } });
+  }
+  return applyUpdates(scene, [...combined.values()], result.candidate.elements.slice(scene.elements.length));
 }
 
 async function writeDurable(path, contents) {

--- a/test/removals.test.js
+++ b/test/removals.test.js
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { applyOperations, editScene, sha256, validateScene } from "../src/scene.js";
+
+const PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zz1kAAAAASUVORK5CYII=", "base64");
+const renderScene = async (_, path) => fs.writeFile(path, PNG);
+
+function fixture() {
+  return {
+    type: "excalidraw", version: 2, appState: { gridSize: 20 }, files: { photo: { dataURL: "keep image data", mimeType: "image/png" } }, customData: { annotation: "keep" },
+    elements: [
+      { id: "api", type: "rectangle", x: 0, y: 0, width: 120, height: 80, angle: 0, boundElements: [{ id: "api-label", type: "text" }, { id: "direct", type: "arrow" }] },
+      { id: "api-label", type: "text", x: 30, y: 25, width: 60, height: 25, angle: 0, text: "API", originalText: "API", containerId: "api", fontFamily: 5, fontSize: 20, lineHeight: 1.25, textAlign: "center", verticalAlign: "middle", autoResize: true },
+      { id: "worker", type: "rectangle", x: 400, y: 0, width: 120, height: 80, angle: 0, boundElements: [{ id: "direct", type: "arrow" }] },
+      { id: "direct", type: "arrow", x: 130, y: 40, width: 260, height: 0, angle: 0, points: [[0, 0], [260, 0]], startBinding: { elementId: "api", focus: 0, gap: 10 }, endBinding: { elementId: "worker", focus: 0, gap: 10 }, boundElements: [{ id: "arrow-label", type: "text" }], customData: { manual: true } },
+      { id: "arrow-label", type: "text", x: 230, y: 30, width: 60, height: 20, angle: 0, containerId: "direct", text: "HTTP" },
+      { id: "note", type: "text", x: 20, y: 250, width: 150, height: 30, angle: 0, text: "Hand-positioned note" },
+      { id: "image", type: "image", fileId: "photo", x: 600, y: 100, width: 80, height: 80, angle: 0, customData: { preserve: true } },
+      { id: "old-deleted", type: "rectangle", isDeleted: true, customData: { historic: true }, boundElements: [{ id: "old-missing", type: "text" }] },
+    ],
+  };
+}
+
+test("removing an arrow tombstones it and its owned label, unlinking only its live endpoints", async () => {
+  const scene = fixture();
+  const { candidate, changes } = await applyOperations(scene, [{ op: "remove", targetId: "direct" }]);
+  validateScene(candidate);
+  const expected = structuredClone(scene);
+  expected.elements[0].boundElements = [{ id: "api-label", type: "text" }];
+  expected.elements[2].boundElements = [];
+  expected.elements[3].isDeleted = true;
+  expected.elements[4].isDeleted = true;
+  assert.deepEqual(candidate, expected);
+  assert.deepEqual(changes.map((change) => change.id), ["api", "worker", "direct", "arrow-label"]);
+});
+
+test("connected node removal requires an explicit connection policy", async () => {
+  await assert.rejects(applyOperations(fixture(), [{ op: "remove", targetId: "api" }]), { code: "AMBIGUOUS_REMOVAL" });
+  await assert.rejects(applyOperations(fixture(), [{ op: "remove", targetId: "api", connections: "guess" }]), { code: "INVALID_REQUEST" });
+});
+
+test("detach policy removes the node and label while preserving the visible arrow geometry", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [{ op: "remove", targetId: "api", connections: "detach" }]);
+  validateScene(candidate);
+  assert.equal(candidate.elements[0].isDeleted, true);
+  assert.equal(candidate.elements[1].isDeleted, true);
+  assert.deepEqual(candidate.elements[3], { ...scene.elements[3], startBinding: null });
+  assert.deepEqual(candidate.elements[4], scene.elements[4]);
+  assert.deepEqual(candidate.elements[2], scene.elements[2]);
+  assert.deepEqual(candidate.elements.slice(5), scene.elements.slice(5));
+});
+
+test("remove policy deletes dependent arrows and labels without deleting the opposite component", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [{ op: "remove", targetId: "api", connections: "remove" }]);
+  validateScene(candidate);
+  assert.deepEqual(candidate.elements.filter((element) => element.isDeleted && element.id !== "old-deleted").map((element) => element.id), ["api", "api-label", "direct", "arrow-label"]);
+  assert.deepEqual(candidate.elements[2], { ...scene.elements[2], boundElements: [] });
+  assert.deepEqual(candidate.files, scene.files);
+});
+
+test("disconnecting selected ends preserves the path, text, and any remaining reciprocal binding", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [{ op: "disconnect", targetId: "direct", end: "start" }]);
+  validateScene(candidate);
+  assert.deepEqual(candidate.elements[3], { ...scene.elements[3], startBinding: null });
+  assert.deepEqual(candidate.elements[0].boundElements, [{ id: "api-label", type: "text" }]);
+  assert.deepEqual(candidate.elements[2], scene.elements[2]);
+  const both = await applyOperations(scene, [{ op: "disconnect", targetId: "direct", end: "both" }]);
+  validateScene(both.candidate);
+  assert.equal(both.candidate.elements[3].endBinding, null);
+  assert.deepEqual(both.candidate.elements[2].boundElements, []);
+  const loop = fixture();
+  loop.elements[3].endBinding.elementId = "api";
+  loop.elements[2].boundElements = [];
+  const partial = await applyOperations(loop, [{ op: "disconnect", targetId: "direct", end: "start" }]);
+  assert.deepEqual(partial.candidate.elements[0].boundElements, loop.elements[0].boundElements);
+  validateScene(partial.candidate);
+});
+
+test("deleting a bound label or image preserves unrelated native data and asset bytes", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [{ op: "remove", targetId: "api-label" }, { op: "remove", targetId: "image" }]);
+  validateScene(candidate);
+  assert.deepEqual(candidate.elements[0].boundElements, [{ id: "direct", type: "arrow" }]);
+  assert.deepEqual(candidate.elements[6], { ...scene.elements[6], isDeleted: true });
+  assert.deepEqual(candidate.files, scene.files);
+  assert.deepEqual(candidate.elements[7], scene.elements[7]);
+});
+
+test("frames cannot be deleted while they retain live children", async () => {
+  const scene = fixture();
+  scene.elements.push({ id: "frame", type: "frame", x: -20, y: -20, width: 160, height: 120, angle: 0 });
+  scene.elements[0].frameId = "frame";
+  scene.elements[1].frameId = "frame";
+  await assert.rejects(applyOperations(scene, [{ op: "remove", targetId: "frame" }]), { code: "AMBIGUOUS_REMOVAL" });
+  const { candidate } = await applyOperations(scene, [{ op: "remove", targetId: "frame" }, { op: "remove", targetId: "api", connections: "remove" }]);
+  validateScene(candidate);
+  assert.equal(candidate.elements[8].isDeleted, true);
+});
+
+test("revise a direct flow into a queue flow while preserving manual annotations", async () => {
+  const scene = fixture();
+  const { candidate } = await applyOperations(scene, [
+    { op: "setLabel", targetId: "api", text: "Entry" },
+    { op: "addNode", id: "queue", type: "rectangle", x: 200, y: 0, width: 120, height: 80, region: { x: 180, y: -10, width: 160, height: 100 }, label: { id: "queue-label", text: "Queue" } },
+    { op: "connect", id: "enqueue", fromId: "api", toId: "queue" },
+    { op: "connect", id: "dequeue", fromId: "queue", toId: "worker" },
+    { op: "remove", targetId: "direct" },
+  ], { measureLabel: async ({ text }) => ({ text, width: 60, height: 25 }) });
+  const index = validateScene(candidate);
+  assert.equal(index.get("direct").isDeleted, true);
+  assert.equal(index.get("arrow-label").isDeleted, true);
+  assert.equal(index.get("api-label").text, "Entry");
+  assert.equal(index.get("enqueue").endBinding.elementId, "queue");
+  assert.equal(index.get("dequeue").endBinding.elementId, "worker");
+  assert.deepEqual(index.get("note"), scene.elements[5]);
+  assert.deepEqual(candidate.files, scene.files);
+});
+
+test("deletion uses the shared retry and recovery contract", async (t) => {
+  const directory = await fs.mkdtemp(join(tmpdir(), "excalidraw-remove-test-"));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  const inputPath = join(directory, "input.excalidraw");
+  const original = JSON.stringify(fixture());
+  await fs.writeFile(inputPath, original);
+  const request = { inputPath, outputDir: directory, requestId: "remove-001", baseHash: sha256(original), operations: [{ op: "remove", targetId: "api", connections: "remove" }] };
+  await assert.rejects(editScene(request, { renderScene: async () => { throw new Error("interrupted render"); } }));
+  await assert.rejects(fs.access(join(directory, request.requestId, "receipt.json")), { code: "ENOENT" });
+  const receipt = await editScene(request, { renderScene });
+  assert.deepEqual(await editScene(request, { renderScene: async () => assert.fail("must reuse completed result") }), receipt);
+  assert.equal(await fs.readFile(inputPath, "utf8"), original);
+  validateScene(JSON.parse(await fs.readFile(receipt.artifacts["after.excalidraw"].path)));
+});
+
+test("unsupported or contradictory deletion requests fail without inference", async () => {
+  await assert.rejects(applyOperations(fixture(), [{ op: "disconnect", targetId: "direct" }]), { code: "INVALID_REQUEST" });
+  await assert.rejects(applyOperations(fixture(), [{ op: "disconnect", targetId: "api", end: "both" }]), { code: "UNSUPPORTED_TARGET" });
+  await assert.rejects(applyOperations(fixture(), [{ op: "remove", targetId: "old-deleted" }]), { code: "UNKNOWN_TARGET" });
+  await assert.rejects(applyOperations(fixture(), [{ op: "remove", targetId: "api", connections: "remove" }, { op: "disconnect", targetId: "direct", end: "both" }]), { code: "INVALID_REQUEST" });
+});

--- a/test/scene.test.js
+++ b/test/scene.test.js
@@ -58,7 +58,7 @@ test("inspect exposes stable IDs, bindings, assets, and the supported operation 
   assert.equal(result.elements.find((element) => element.id === "api").label, "API");
   assert.equal(result.elements.find((element) => element.id === "edge").startBinding.elementId, "api");
   assert.deepEqual(result.assetIds, ["asset"]);
-  assert.deepEqual(result.capabilities.operations, ["setStyle", "setLabel", "move", "addNode", "connect"]);
+  assert.deepEqual(result.capabilities.operations, ["setStyle", "setLabel", "move", "addNode", "connect", "remove", "disconnect"]);
   assert.deepEqual(result.capabilities.setStyle.elementTypes, ["rectangle", "ellipse", "diamond"]);
 });
 


### PR DESCRIPTION
Remove/disconnect requests resolve affected labels and arrows before editing. Connected node removal requires an explicit detach/remove policy; deleted elements retain native tombstones and the original remains recoverable. Ambiguous cascades and frames with retained children fail before mutation.

Validation: deletion fixtures cover reciprocal references, protected assets/tombstones, unsupported requests, and retry recovery. A real native transaction renamed API, removed the direct edge, added Queue and two bound arrows, and preserved the manual note/image. Computer use verified the final flow and its five readable change summaries. All 193 integrated core tests pass after building the required runtime and preview assets.

Depends on the stable-additions PR. The isolated installed core package passed the complete queue transaction, exact retry, and protected-content checks; computer use verified native reopening and exports.
