### PR TITLE
[Evidence]: retain scoped source claims and native baselines

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,6 +33,9 @@ Usage:
   npx ${pkg.name} inspect <scene>  Read native IDs, input hash, and supported operations
   npx ${pkg.name} edit <scene> --request <json> --output <directory>
   npx ${pkg.name} preview <scene-or-receipt>  Review and export a native file
+  npx ${pkg.name} validate-evidence --request <json>  Check scoped source references
+  npx ${pkg.name} associate-evidence --request <json>  Retain an existing scene's evidence
+  npx ${pkg.name} accept-baseline --request <json>  Accept generated/delivered snapshots
   npx ${pkg.name} version    Print version
 
 Options: --home <directory>, --target <claude|codex|all>, --project <directory>,
@@ -61,6 +64,15 @@ async function main() {
     return;
   }
   if ((values.project || values.scope) && !values.target) throw new Error("AGENT_TARGET: use --target with --project or --scope");
+  const { WORKFLOW_COMMANDS, workflowCommand } = await import("../src/workflow-commands.js");
+  if (WORKFLOW_COMMANDS.includes(command)) {
+    if (positionals.length !== 1) throw new Error("WORKFLOW_REQUEST: use --request <json> for workflow commands");
+    const result = await workflowCommand(command, values.request, values);
+    console.log(JSON.stringify(result, null, 2));
+    const status = result.receipt?.status ?? result.status;
+    if (["failed", "blocked", "uncertain", "busy", "reconciliation-required"].includes(status)) process.exitCode = 1;
+    return;
+  }
   const { install, uninstall, doctor, start, stop } = await import("../src/installer.js");
 
   switch (command) {

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -1,0 +1,175 @@
+# Source evidence and native scene baselines
+
+The evidence module associates a scoped code investigation with an existing native
+Excalidraw file. The host coding agent searches the repository, writes claims and
+references, and chooses explicit semantic and element IDs. The module checks the
+locations and native mappings, then saves an immutable bundle. It does not analyze
+programs, infer runtime calls, modify diagrams, or establish complete coverage.
+
+## API
+
+```js
+import {
+  validateEvidence,
+  associateEvidence,
+  acceptEvidenceBaseline,
+  readEvidenceBundle,
+} from "./src/evidence.js";
+
+const options = {
+  repositoryPath: "/absolute/repository/root",
+  inputPath: "/absolute/delivered.excalidraw",
+  evidence: proposal,
+};
+
+// Read-only: returns checked references, resolved source revision and scene hash.
+const checked = await validateEvidence(options);
+
+// Explicitly associate a preexisting diagram; its earlier generated state is unknown.
+const saved = await associateEvidence({ ...options, outputDir: "/new/association" });
+
+// For an actual generated result that has been reviewed and accepted, retain both
+// that generated state and the delivered scene, including any manual adjustments.
+const accepted = await acceptEvidenceBaseline({
+  ...options,
+  generatedPath: "/absolute/generated.excalidraw",
+  outputDir: "/new/accepted-baseline",
+});
+
+// Retain the returned hash independently to detect manifest changes as well.
+const { bundle, deliveredScene, generatedScene } = await readEvidenceBundle(
+  accepted.bundlePath,
+  { expectedHash: accepted.sha256 },
+);
+```
+
+`validateEvidence` returns a normalized result, not another proposal: its added
+provenance fields are output-only. Pass the original proposal to a save method;
+the save method validates it again against its input scene and source files.
+`saved` and `accepted` contain `bundlePath`, the manifest's `sha256`, and `bundle`.
+No CLI, installer or model invocation is provided by this module.
+
+## Proposal schema, version 1
+
+All listed fields are required unless marked optional. Unknown fields are rejected.
+Paths use normalized repository-relative `/` separators. `repositoryPath` must be
+the Git root, including when reading a working tree.
+
+```json
+{
+  "schemaVersion": 1,
+  "source": { "kind": "git", "revision": "HEAD" },
+  "scope": {
+    "question": "How does the request handler reach the worker?",
+    "paths": ["src/api.js", "src/worker.js"],
+    "coverage": "partial",
+    "unknowns": ["Caller routing and runtime inputs were not traced."]
+  },
+  "references": [
+    { "id": "handler-call", "path": "src/api.js", "startLine": 3, "endLine": 3, "symbol": "run" },
+    { "id": "worker-definition", "path": "src/worker.js", "startLine": 1, "endLine": 1, "symbol": "run" }
+  ],
+  "nodes": [
+    { "semanticId": "request:handler", "elementId": "api-box", "referenceIds": ["handler-call"] },
+    { "semanticId": "request:worker", "elementId": "worker-box", "referenceIds": ["worker-definition"] }
+  ],
+  "relations": [
+    {
+      "semanticId": "request:handler-to-worker",
+      "elementId": "call-arrow",
+      "from": "request:handler",
+      "to": "request:worker",
+      "kind": "call",
+      "claim": "The handler contains a call expression for run(input).",
+      "referenceIds": ["handler-call"]
+    }
+  ]
+}
+```
+
+- A Git `revision` resolves to an exact commit. References read regular blobs at
+  that commit, regardless of working-tree changes. Output records commit, blob ID,
+  full-file SHA-256, line range and selected excerpt. Git replacement objects and
+  inherited Git repository redirection variables are disabled for these reads.
+- For uncommitted code, use `source: { "kind": "working-tree" }` and include an
+  inspected full-file `sha256` on every reference. A mismatch fails before creating
+  a bundle. Output retains each digest and the current HEAD as `baseRevision`, or
+  `null` for an unborn repository. HEAD does not certify uncommitted content.
+- `startLine` and `endLine` are inclusive, one-based integers. `symbol` is optional;
+  if present, its exact token must occur within those lines. This is a location
+  check, not a parser's definition or name-resolution result. Use narrow ranges and
+  distinct explicit reference IDs when names repeat.
+- Optional `sha256` on a Git reference also checks against the inspected content.
+  Sources must be UTF-8 regular files of at most 8 MiB. Symlinks, submodules, nested
+  working-tree repositories, `.git` paths and traversal are rejected. Each reference
+  must lie under one declared scope path; `"."` explicitly permits the whole root.
+- `coverage` must be `"partial"`. `unknowns` is required and may be empty; neither
+  an empty array nor a large scope establishes completeness. Unseen content is not
+  a deletion instruction. No external file is read as part of reference validation.
+- Semantic IDs use up to 160 letters, digits, `:`, `.`, `_`, `/` or `-`, starting
+  with a letter or digit. They identify concepts chosen for this investigation,
+  not labels inferred from the canvas. Reuse them across accepted revisions when
+  identity is known. Ambiguous or duplicate semantic IDs and mapped element IDs
+  fail; this module never resolves ambiguity by matching display text.
+- Node mappings are sparse and require at least one reference. Each points to a
+  live native element other than an arrow or line. Unmapped notes, images and other
+  diagram content remain intact.
+- Relations require explicit `from` and `to` node semantic IDs and a live native
+  arrow whose start/end bindings match those nodes. `import` means an authored
+  import relationship; `call` means an authored call-expression relationship;
+  `assumption` is explicitly conjectural. Imports and calls require references;
+  assumptions may have none. A call expression does not establish runtime execution.
+
+Every checked result includes:
+
+```json
+{
+  "validation": {
+    "sourceLocations": true,
+    "sceneMappings": true,
+    "semanticClaims": false,
+    "runtimeBehavior": false
+  }
+}
+```
+
+A valid reference cannot prove that a relation was classified correctly or that a
+claim follows from its excerpt. The host agent must explain the inference and the
+reviewer must assess it. Present these flags with the evidence; do not relabel the
+whole diagram as verified.
+
+## Baseline bundles
+
+Each save requires a new output directory. A bundle contains `evidence.json` and
+`delivered.excalidraw`; an accepted generated baseline also contains
+`generated.excalidraw`. Native inputs are copied byte-for-byte, preserving IDs,
+manual geometry, text, styles, embedded assets and unknown properties. No live
+canvas import/export round-trip occurs.
+
+`evidence.json` has `schemaVersion: 1`, `status: "complete"`, the checked `evidence`,
+and a `baseline` containing artifact filenames and SHA-256 hashes:
+
+| Baseline kind | Generated state | Prior baseline |
+| --- | --- | --- |
+| `association` | `null`; no historical generated state is claimed | `null` |
+| `accepted-generated` | Captured actual generated native document | `null`; this module creates an initial baseline |
+
+Calling `acceptEvidenceBaseline` is the caller's assertion that the supplied
+generated/delivered pair has been accepted. The module cannot establish who created
+the files or whether a human approved them. Both files must satisfy the explicit
+semantic mappings, but may differ in manual layout and styling. A previously
+handwritten diagram must first use association; only an actual subsequent generated
+result can establish a generated baseline for later three-way refresh work.
+
+The complete manifest is published atomically after the artifact files are synced.
+A failed attempt may leave a partial directory; it is not an accepted baseline.
+Choose a new directory for a retry. Completed bundles are never overwritten by the
+module. Keep the returned manifest hash with the accepted receipt or version control:
+without that independent hash, artifact checks detect changed files but cannot
+authenticate a rewritten manifest and matching artifacts.
+
+`readEvidenceBundle` verifies the retained pair and returns both parsed scenes.
+It does not need the original scene paths or a still-present source checkout. This
+retained pair is the input for later comparison of generated changes against manual
+overrides. It does not itself implement refresh, merge, source completeness or
+publishing. Working-tree sources retain excerpts and digests, not a full code backup.

--- a/docs/workflow-commands.md
+++ b/docs/workflow-commands.md
@@ -1,0 +1,47 @@
+# Source workflow request files
+
+The CLI's workflow handler is `workflowCommand(command, requestPath, values)` in
+`src/workflow-commands.js`. Each command reads one JSON request and returns the
+public module's JSON result. The CLI owns JSON printing and exit status.
+
+Filesystem paths inside the request are relative to the request file. Repository
+source paths inside `evidence.scope` and `evidence.references` remain repository
+relative. `--output` can supply an omitted `outputDir`; conflicting output paths
+fail before writing. Commands read only their own modules, so source validation
+does not load the browser renderer or require a model runtime.
+
+| Command | Request fields | Result |
+| --- | --- | --- |
+| `validate-evidence` | `repositoryPath`, `inputPath`, `evidence` | Checked source locations, scene mappings and their limits; no files written |
+| `associate-evidence` | Validation fields plus `outputDir` | Immutable association of an existing scene; no generated history invented |
+| `accept-baseline` | Association fields plus `generatedPath` | Explicitly accepted generated and delivered native snapshots |
+
+The existing coding agent investigates the selected entry point and path, reads
+source files at the declared revision, constructs supported scene edits, and
+writes the PR9 evidence object. Use exact Git commits for reproducibility. A valid
+source location does not prove a semantic relationship: cite import/call claims
+and label assumptions explicitly. Keep unknowns in the scope and preserve native
+manual content through the supported editing operations.
+
+Request example:
+
+```json
+{
+  "repositoryPath": "../source",
+  "inputPath": "flow.excalidraw",
+  "outputDir": "evidence-bundle",
+  "evidence": {
+    "schemaVersion": 1,
+    "source": {"kind": "git", "revision": "<inspected commit>"},
+    "scope": {"question": "How does this request reach the worker?", "paths": ["src"], "coverage": "partial", "unknowns": ["Runtime dispatch was not traced."]},
+    "references": [{"id": "handler", "path": "src/api.js", "startLine": 1, "endLine": 3, "symbol": "handle"}],
+    "nodes": [{"semanticId": "request:handler", "elementId": "<inspected native ID>", "referenceIds": ["handler"]}],
+    "relations": []
+  }
+}
+```
+
+Call `<installed CLI> associate-evidence --request /absolute/request.json`.
+Read the returned bundle/hash and inspect the saved native scene and preview.
+Baseline acceptance is an explicit action after the result is adopted; a source
+association alone is not a last-generated baseline.

--- a/plugins/excalidraw/skills/scoped-edit/SKILL.md
+++ b/plugins/excalidraw/skills/scoped-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scoped-edit
-description: Edit an existing saved .excalidraw diagram with scoped changes, preserved manual content, and before/after artifacts. Use for recoloring or relabeling a saved scene, or another edit explicitly supported by the installed toolkit.
+description: Edit a saved .excalidraw diagram while preserving manual content, or explain a scoped source request flow with cited native elements. Use the installed toolkit's supported file operations and evidence commands.
 ---
 
 # Edit a saved Excalidraw scene
@@ -38,3 +38,28 @@ For a CLI-capable client, follow these equivalent steps:
 5. Return links to the editable result, before/after previews, and receipt. Summarize the change and any unresolved limitation. Claim preservation, completion, or visual quality only when supported by the receipt, saved files, and images you actually inspected.
 
 The native input remains the presentation authority, including its image assets, ordering, settings, and unknown fields. Use the supported edit path throughout; do not clear a live canvas or regenerate the scene to perform a saved-file edit.
+
+## Explain a scoped source path
+
+For a source-backed request flow, first establish the user's entry point, question,
+repository and source paths. Investigate that scope with the existing coding
+agent. Read the actual files at a recorded Git revision and distinguish import,
+call and assumption claims. Keep unknown dispatch or runtime behavior explicit.
+For a subsystem expansion, retain the surrounding native scene and associate only
+newly inspected nodes and relationships; unexamined content stays outside the
+declared evidence scope and cannot be inferred obsolete.
+
+Use the saved-scene workflow above to express the inspected flow. Map stable
+semantic IDs to inspected native element IDs. Each source reference needs its
+repository-relative path and exact line range; each relation must match the native
+arrow's endpoints. Label assumptions visibly in the diagram.
+
+When command help advertises `validate-evidence`, write a JSON request with
+`repositoryPath`, `inputPath` and the scoped `evidence` object, then run that
+command with `--request <file>`. Validation checks locations and mappings; inspect
+the cited source yourself before claiming a relationship. Use
+`associate-evidence` with `outputDir` to retain an existing diagram's evidence.
+Use `accept-baseline` with an explicit `generatedPath` only after the generated
+result is adopted. Retain the returned bundle path and manifest hash for refresh.
+Request-file filesystem paths resolve relative to the request file. These commands
+return JSON; report their concrete errors and any unverified source or visual claim.

--- a/src/evidence.js
+++ b/src/evidence.js
@@ -1,0 +1,281 @@
+import { execFile } from "node:child_process";
+import { constants, promises as fs } from "node:fs";
+import { dirname, join, posix, resolve } from "node:path";
+import { promisify } from "node:util";
+import { sha256, validateScene } from "./scene.js";
+
+const exec = promisify(execFile);
+const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+const ID = /^[A-Za-z0-9][A-Za-z0-9:._/-]{0,159}$/;
+const HASH = /^[a-f0-9]{64}$/;
+const object = value => value !== null && typeof value === "object" && !Array.isArray(value);
+
+function fail(code, message) { throw Object.assign(new Error(message), { code }); }
+function fields(value, names, context) {
+  if (!object(value) || Object.keys(value).some(name => !names.includes(name))) fail("INVALID_EVIDENCE", `Invalid fields in ${context}`);
+}
+function text(value, context) {
+  if (typeof value !== "string" || !value.trim() || /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u.test(value)) fail("INVALID_EVIDENCE", `${context} must be nonempty text`);
+}
+function identifier(value, context) {
+  if (typeof value !== "string" || !ID.test(value)) fail("INVALID_EVIDENCE", `Invalid ${context}`);
+}
+function sourcePath(path, allowRoot = false) {
+  if (allowRoot && path === ".") return path;
+  if (typeof path !== "string" || !path || path === "." || path.startsWith("/") || /^[A-Za-z]:/.test(path) ||
+    /[\\\u0000\r\n]/u.test(path) || posix.normalize(path) !== path || path.split("/").some(part => !part || part === ".." || part === ".git")) {
+    fail("SOURCE_BOUNDARY", "Source paths must be normalized repository-relative paths outside .git");
+  }
+  return path;
+}
+
+async function git(repository, args) {
+  try {
+    const { stdout } = await exec("git", ["--no-pager", "--literal-pathspecs", "-C", repository, ...args], {
+      encoding: "buffer", maxBuffer: MAX_SOURCE_BYTES, timeout: 10000,
+      env: {
+        ...Object.fromEntries(Object.entries(process.env).filter(([name]) => !name.startsWith("GIT_"))),
+        GIT_TERMINAL_PROMPT: "0", GIT_NO_REPLACE_OBJECTS: "1", GIT_OPTIONAL_LOCKS: "0",
+      },
+    });
+    return stdout;
+  } catch { fail("SOURCE_GIT", `Cannot read the requested Git source (${args[0]})`); }
+}
+
+async function sourceContext(repositoryPath, source) {
+  fields(source, ["kind", "revision"], "source");
+  const repository = await fs.realpath(resolve(repositoryPath));
+  const top = (await git(repository, ["rev-parse", "--show-toplevel"])).toString("utf8").trim();
+  if (await fs.realpath(top) !== repository) fail("SOURCE_BOUNDARY", "repositoryPath must name the Git repository root");
+  if (source.kind === "git") {
+    text(source.revision, "source revision");
+    const revision = (await git(repository, ["rev-parse", "--verify", "--end-of-options", `${source.revision}^{commit}`])).toString("utf8").trim();
+    return { repository, source: { kind: "git", revision } };
+  }
+  if (source.kind !== "working-tree" || source.revision !== undefined) fail("INVALID_EVIDENCE", "Use a git revision or working-tree source");
+  let baseRevision = null;
+  try { baseRevision = (await git(repository, ["rev-parse", "--verify", "HEAD"])).toString("utf8").trim(); }
+  catch (error) { if (error.code !== "SOURCE_GIT") throw error; }
+  return { repository, source: { kind: "working-tree", baseRevision } };
+}
+
+async function readSource(context, path) {
+  let bytes;
+  let blob = null;
+  if (context.source.kind === "git") {
+    const entry = (await git(context.repository, ["ls-tree", "-rz", context.source.revision, "--", path])).toString("utf8").split("\0").filter(Boolean);
+    const match = entry.length === 1 && /^(100644|100755) blob ([a-f0-9]+)\t(.+)$/u.exec(entry[0]);
+    if (!match || match[3] !== path) fail("SOURCE_BOUNDARY", `Expected a regular committed file at ${path}; symlinks and submodules are unsupported`);
+    blob = match[2];
+    bytes = await git(context.repository, ["cat-file", "blob", blob]);
+  } else {
+    let current = context.repository;
+    const parts = path.split("/");
+    for (let i = 0; i < parts.length; i++) {
+      current = join(current, parts[i]);
+      let stat;
+      try { stat = await fs.lstat(current); }
+      catch { fail("SOURCE_MISSING", `Cannot read working-tree source: ${path}`); }
+      if (stat.isSymbolicLink() || (i < parts.length - 1 ? !stat.isDirectory() : !stat.isFile())) {
+        fail("SOURCE_BOUNDARY", `Working-tree source must not follow symlinks: ${path}`);
+      }
+      if (i < parts.length - 1) {
+        try { await fs.lstat(join(current, ".git")); fail("SOURCE_BOUNDARY", `Nested repositories require a separate association: ${path}`); }
+        catch (error) { if (error.code !== "ENOENT") throw error; }
+      } else if (stat.size > MAX_SOURCE_BYTES) fail("SOURCE_SIZE", `Source file exceeds ${MAX_SOURCE_BYTES} bytes`);
+    }
+    const handle = await fs.open(current, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try { bytes = await handle.readFile(); } finally { await handle.close(); }
+  }
+  if (bytes.length > MAX_SOURCE_BYTES) fail("SOURCE_SIZE", `Source file exceeds ${MAX_SOURCE_BYTES} bytes`);
+  let content;
+  try { content = new TextDecoder("utf-8", { fatal: true }).decode(bytes); }
+  catch { fail("SOURCE_ENCODING", `Source must be UTF-8 text: ${path}`); }
+  if (content.includes("\0")) fail("SOURCE_ENCODING", `Binary source is unsupported: ${path}`);
+  const lines = content.split(/\r?\n/u);
+  if (content.endsWith("\n")) lines.pop();
+  return { sha256: sha256(bytes), blob, lines };
+}
+
+async function readNative(path) {
+  const bytes = await fs.readFile(path);
+  let scene;
+  try { scene = JSON.parse(bytes.toString("utf8")); }
+  catch { fail("INVALID_SCENE", "Expected a native Excalidraw JSON file"); }
+  const index = validateScene(scene);
+  return { bytes, scene, index };
+}
+
+function validateMapping(evidence, index) {
+  const identities = new Set();
+  const elements = new Set();
+  const references = new Set(evidence.references.map(reference => reference.id));
+  const nodes = new Map();
+  const identify = item => {
+    identifier(item.semanticId, "semanticId");
+    if (identities.has(item.semanticId) || elements.has(item.elementId)) fail("AMBIGUOUS_IDENTITY", "Semantic IDs and mapped element IDs must be unique");
+    const element = index.get(item.elementId);
+    if (!element || element.isDeleted) fail("UNKNOWN_TARGET", `No live element: ${item.elementId}`);
+    identities.add(item.semanticId);
+    elements.add(item.elementId);
+    return element;
+  };
+  const checkReferences = (item, allowEmpty = false) => {
+    if (!Array.isArray(item.referenceIds) || (!allowEmpty && !item.referenceIds.length) || new Set(item.referenceIds).size !== item.referenceIds.length ||
+      item.referenceIds.some(id => !references.has(id))) fail("INVALID_REFERENCE", `Invalid source references for ${item.semanticId}`);
+  };
+  for (const node of evidence.nodes) {
+    fields(node, ["semanticId", "elementId", "referenceIds"], "node");
+    const element = identify(node);
+    if (["arrow", "line"].includes(element.type)) fail("INVALID_MAPPING", "Map connections as relations, not nodes");
+    checkReferences(node);
+    nodes.set(node.semanticId, node);
+  }
+  for (const relation of evidence.relations) {
+    fields(relation, ["semanticId", "elementId", "from", "to", "kind", "claim", "referenceIds"], "relation");
+    const arrow = identify(relation);
+    if (!["import", "call", "assumption"].includes(relation.kind)) fail("INVALID_RELATION", "Relation kind must be import, call, or assumption");
+    text(relation.claim, "relation claim");
+    checkReferences(relation, relation.kind === "assumption");
+    const from = nodes.get(relation.from);
+    const to = nodes.get(relation.to);
+    if (!from || !to || arrow.type !== "arrow" || arrow.startBinding?.elementId !== from.elementId || arrow.endBinding?.elementId !== to.elementId) {
+      fail("INVALID_MAPPING", `Relation ${relation.semanticId} must match the arrow's native start/end bindings`);
+    }
+  }
+}
+
+export async function validateEvidence({ repositoryPath, inputPath, evidence }) {
+  text(repositoryPath, "repositoryPath");
+  text(inputPath, "inputPath");
+  fields(evidence, ["schemaVersion", "source", "scope", "references", "nodes", "relations"], "evidence");
+  if (evidence.schemaVersion !== 1) fail("INVALID_EVIDENCE", "Expected evidence schemaVersion 1");
+  fields(evidence.scope, ["question", "paths", "coverage", "unknowns"], "analysis scope");
+  text(evidence.scope.question, "analysis question");
+  if (evidence.scope.coverage !== "partial" || !Array.isArray(evidence.scope.paths) || !evidence.scope.paths.length || !Array.isArray(evidence.scope.unknowns)) {
+    fail("INVALID_SCOPE", "Declare scoped paths, partial coverage, and an unknowns array; complete analysis is not established by this module");
+  }
+  evidence.scope.paths.forEach(path => sourcePath(path, true));
+  evidence.scope.unknowns.forEach(value => text(value, "unknown"));
+  if (![evidence.references, evidence.nodes, evidence.relations].every(Array.isArray) || !evidence.nodes.length) fail("INVALID_EVIDENCE", "Provide references, at least one mapped node, and relations arrays");
+  const native = await readNative(inputPath);
+  const context = await sourceContext(repositoryPath, evidence.source);
+  const ids = new Set();
+  const sources = new Map();
+  const references = [];
+  for (const reference of evidence.references) {
+    fields(reference, ["id", "path", "startLine", "endLine", "symbol", "sha256"], "source reference");
+    identifier(reference.id, "reference ID");
+    if (ids.has(reference.id)) fail("AMBIGUOUS_IDENTITY", `Duplicate reference ID: ${reference.id}`);
+    ids.add(reference.id);
+    sourcePath(reference.path);
+    if (!evidence.scope.paths.some(path => path === "." || reference.path === path || reference.path.startsWith(`${path}/`))) fail("SOURCE_BOUNDARY", `Reference outside the declared scope: ${reference.path}`);
+    if (context.source.kind === "working-tree" && !HASH.test(reference.sha256 ?? "")) fail("INVALID_REFERENCE", "Working-tree references require the inspected file SHA-256");
+    if (reference.sha256 !== undefined && !HASH.test(reference.sha256)) fail("INVALID_REFERENCE", "Invalid source SHA-256");
+    if (!sources.has(reference.path)) sources.set(reference.path, await readSource(context, reference.path));
+    const source = sources.get(reference.path);
+    if (reference.sha256 !== undefined && reference.sha256 !== source.sha256) fail("STALE_SOURCE", `Source changed after inspection: ${reference.path}`);
+    if (!Number.isSafeInteger(reference.startLine) || !Number.isSafeInteger(reference.endLine) || reference.startLine < 1 || reference.endLine < reference.startLine || reference.endLine > source.lines.length) {
+      fail("INVALID_REFERENCE", `Invalid line range in ${reference.path}`);
+    }
+    const excerpt = source.lines.slice(reference.startLine - 1, reference.endLine).join("\n");
+    if (reference.symbol !== undefined) {
+      text(reference.symbol, "symbol");
+      if (/[\r\n]/u.test(reference.symbol)) fail("INVALID_REFERENCE", "A symbol must fit on one line");
+      const escaped = reference.symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (!new RegExp(`(?<![\\p{L}\\p{N}_$])${escaped}(?![\\p{L}\\p{N}_$])`, "u").test(excerpt)) fail("INVALID_REFERENCE", `Symbol is absent from the selected lines: ${reference.symbol}`);
+    }
+    references.push({ ...reference, sha256: source.sha256, blob: source.blob, excerpt });
+  }
+  validateMapping(evidence, native.index);
+  return {
+    ...structuredClone(evidence), source: context.source, repositoryPath: context.repository, references,
+    sceneHash: sha256(native.bytes),
+    validation: { sourceLocations: true, sceneMappings: true, semanticClaims: false, runtimeBehavior: false },
+  };
+}
+
+async function writeExclusive(path, bytes) {
+  const handle = await fs.open(path, "wx", 0o600);
+  try { await handle.writeFile(bytes); await handle.sync(); } finally { await handle.close(); }
+}
+
+async function saveBundle({ repositoryPath, inputPath, outputDir, evidence, generatedPath }, kind) {
+  text(outputDir, "outputDir");
+  const checked = await validateEvidence({ repositoryPath, inputPath, evidence });
+  const delivered = await readNative(inputPath);
+  if (sha256(delivered.bytes) !== checked.sceneHash) fail("STALE_INPUT", "The delivered scene changed during evidence validation");
+  let generated = null;
+  if (kind === "accepted-generated") {
+    if (typeof generatedPath !== "string" || !generatedPath.trim()) fail("INVALID_BASELINE", "An accepted generated baseline requires generatedPath");
+    generated = await readNative(generatedPath);
+    validateMapping(evidence, generated.index);
+  }
+  const directory = resolve(outputDir);
+  await fs.mkdir(dirname(directory), { recursive: true });
+  try { await fs.mkdir(directory); }
+  catch (error) { if (error.code === "EEXIST") fail("OUTPUT_EXISTS", "Use a new evidence bundle directory; existing baselines are immutable"); throw error; }
+  const artifact = (name, bytes) => ({ file: name, sha256: sha256(bytes) });
+  const baseline = { kind, priorBaseline: null, delivered: artifact("delivered.excalidraw", delivered.bytes), generated: null };
+  await writeExclusive(join(directory, baseline.delivered.file), delivered.bytes);
+  if (generated) {
+    baseline.generated = artifact("generated.excalidraw", generated.bytes);
+    await writeExclusive(join(directory, baseline.generated.file), generated.bytes);
+  }
+  const bundle = { schemaVersion: 1, status: "complete", evidence: checked, baseline };
+  const bytes = Buffer.from(`${JSON.stringify(bundle, null, 2)}\n`);
+  const bundlePath = join(directory, "evidence.json");
+  // Completion is published last; a failed attempt cannot masquerade as an
+  // accepted baseline. Native inputs are copied verbatim, never rewritten.
+  const temporary = join(directory, "evidence.pending.json");
+  await writeExclusive(temporary, bytes);
+  await fs.link(temporary, bundlePath);
+  await fs.unlink(temporary);
+  const directoryHandle = await fs.open(directory, "r");
+  try { await directoryHandle.sync(); } finally { await directoryHandle.close(); }
+  return { bundlePath, sha256: sha256(bytes), bundle };
+}
+
+export function associateEvidence(options) {
+  if (options.generatedPath !== undefined) fail("INVALID_BASELINE", "Association cannot invent a generated historical baseline");
+  return saveBundle(options, "association");
+}
+
+export function acceptEvidenceBaseline(options) {
+  return saveBundle(options, "accepted-generated");
+}
+
+export async function readEvidenceBundle(bundlePath, { expectedHash } = {}) {
+  const bytes = await fs.readFile(bundlePath);
+  if (expectedHash !== undefined && (!HASH.test(expectedHash) || sha256(bytes) !== expectedHash)) fail("CORRUPT_EVIDENCE", "Evidence manifest hash differs from the retained receipt");
+  let bundle;
+  try { bundle = JSON.parse(bytes.toString("utf8")); }
+  catch { fail("CORRUPT_EVIDENCE", "Invalid evidence manifest JSON"); }
+  if (!object(bundle) || bundle.schemaVersion !== 1 || bundle.status !== "complete" || !["association", "accepted-generated"].includes(bundle.baseline?.kind) ||
+    bundle.baseline.priorBaseline !== null || bundle.evidence?.schemaVersion !== 1 ||
+    ![bundle.evidence.references, bundle.evidence.nodes, bundle.evidence.relations].every(Array.isArray) ||
+    !bundle.evidence.nodes.length || bundle.evidence.scope?.coverage !== "partial" ||
+    bundle.evidence.validation?.sourceLocations !== true || bundle.evidence.validation?.sceneMappings !== true ||
+    bundle.evidence?.validation?.semanticClaims !== false || bundle.evidence?.validation?.runtimeBehavior !== false) fail("CORRUPT_EVIDENCE", "Invalid evidence baseline manifest");
+  const referenceIds = new Set();
+  for (const reference of bundle.evidence.references) {
+    if (!object(reference) || !ID.test(reference.id ?? "") || referenceIds.has(reference.id) ||
+      !HASH.test(reference.sha256 ?? "") || typeof reference.excerpt !== "string") fail("CORRUPT_EVIDENCE", "Invalid retained source reference");
+    referenceIds.add(reference.id);
+  }
+  if (bundle.evidence.sceneHash !== bundle.baseline.delivered?.sha256) fail("CORRUPT_EVIDENCE", "Evidence does not identify the delivered scene");
+  const readArtifact = async (entry, expectedName) => {
+    if (!object(entry) || entry.file !== expectedName || !HASH.test(entry.sha256 ?? "")) fail("CORRUPT_EVIDENCE", "Invalid baseline artifact reference");
+    const path = join(dirname(resolve(bundlePath)), expectedName);
+    if (!(await fs.lstat(path)).isFile()) fail("CORRUPT_EVIDENCE", "Baseline artifacts must be regular files");
+    const native = await readNative(path);
+    if (sha256(native.bytes) !== entry.sha256) fail("CORRUPT_EVIDENCE", `Changed baseline artifact: ${expectedName}`);
+    validateMapping(bundle.evidence, native.index);
+    return native.scene;
+  };
+  const deliveredScene = await readArtifact(bundle.baseline.delivered, "delivered.excalidraw");
+  let generatedScene = null;
+  if (bundle.baseline.kind === "accepted-generated") generatedScene = await readArtifact(bundle.baseline.generated, "generated.excalidraw");
+  else if (bundle.baseline.generated !== null) fail("CORRUPT_EVIDENCE", "An association must not claim a generated historical baseline");
+  return { bundle, deliveredScene, generatedScene };
+}

--- a/src/workflow-commands.js
+++ b/src/workflow-commands.js
@@ -1,0 +1,50 @@
+import { promises as fs } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline']);
+const fail = (code, message) => { throw Object.assign(new Error(message), { code }); };
+
+async function readRequest(requestPath) {
+  if (typeof requestPath !== 'string' || !requestPath.trim()) fail('INVALID_REQUEST', 'Provide a JSON request file with --request');
+  const path = resolve(requestPath);
+  const stat = await fs.stat(path);
+  if (!stat.isFile() || stat.size > 32 * 1024 * 1024) fail('INVALID_REQUEST', 'Request must be a JSON file no larger than 32 MiB');
+  let request;
+  try { request = JSON.parse(await fs.readFile(path, 'utf8')); }
+  catch { fail('INVALID_REQUEST', 'Request file contains invalid JSON'); }
+  if (!request || typeof request !== 'object' || Array.isArray(request)) fail('INVALID_REQUEST', 'Request must contain one JSON object');
+  return { request, directory: dirname(path) };
+}
+
+function requestOptions(request, directory, values, allowed, pathFields) {
+  if (Object.keys(request).some(key => !allowed.includes(key))) fail('INVALID_REQUEST', 'Request contains unsupported fields for this command');
+  const options = structuredClone(request);
+  for (const key of pathFields) {
+    if (options[key] === undefined) continue;
+    if (typeof options[key] !== 'string' || !options[key].trim()) fail('INVALID_REQUEST', `${key} must be a filesystem path`);
+    options[key] = resolve(directory, options[key]);
+  }
+  if (values.output !== undefined) {
+    if (!allowed.includes('outputDir')) fail('INVALID_REQUEST', '--output does not apply to this command');
+    const output = resolve(values.output);
+    if (options.outputDir !== undefined && output !== options.outputDir) fail('INVALID_REQUEST', '--output conflicts with request.outputDir');
+    options.outputDir = output;
+  }
+  return options;
+}
+
+/** JSON command boundary. It returns data; the CLI owns printing and exit codes.
+ * Filesystem paths in requests are relative to the request file, not shell cwd. */
+export async function workflowCommand(command, requestPath, values = {}) {
+  if (!WORKFLOW_COMMANDS.includes(command)) fail('UNKNOWN_COMMAND', `Unknown workflow command: ${command}`);
+  const { request, directory } = await readRequest(requestPath);
+  const paths = ['repositoryPath', 'inputPath'];
+  const allowed = [...paths, 'evidence'];
+  if (command !== 'validate-evidence') { paths.push('outputDir'); allowed.push('outputDir'); }
+  if (command === 'accept-baseline') { paths.push('generatedPath'); allowed.push('generatedPath'); }
+  const options = requestOptions(request, directory, values, allowed, paths);
+  const evidence = await import('./evidence.js');
+  if (command === 'validate-evidence') return evidence.validateEvidence(options);
+  if (command === 'associate-evidence') return evidence.associateEvidence(options);
+  return evidence.acceptEvidenceBaseline(options);
+}

--- a/test/evidence.test.js
+++ b/test/evidence.test.js
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { acceptEvidenceBaseline, associateEvidence, readEvidenceBundle, validateEvidence } from "../src/evidence.js";
+import { sha256 } from "../src/scene.js";
+
+const exec = promisify(execFile);
+const apiSource = 'import { run } from "./worker.js";\nexport function handle(input) {\n  return run(input);\n}\n';
+const workerSource = "export function run(input) { return input; }\n";
+
+async function fixture(t) {
+  const root = await fs.mkdtemp(join(tmpdir(), "toolkit evidence "));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const repositoryPath = join(root, "repository");
+  await fs.mkdir(join(repositoryPath, "src"), { recursive: true });
+  const git = async (...args) => (await exec("git", ["-C", repositoryPath, ...args])).stdout.trim();
+  await git("init", "-b", "main");
+  await fs.writeFile(join(repositoryPath, "src/api.js"), apiSource);
+  await fs.writeFile(join(repositoryPath, "src/worker.js"), workerSource);
+  await git("add", "src");
+  await git("-c", "user.name=Evidence fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgSign=false", "commit", "-m", "test: add request flow fixture");
+  const revision = await git("rev-parse", "HEAD");
+  const scene = {
+    type: "excalidraw", version: 2, source: "handwritten fixture", unknownTopLevel: { keep: true },
+    elements: [
+      { id: "api", type: "rectangle", x: 10, y: 20, width: 120, height: 80, customData: { manual: true }, boundElements: [{ id: "connection", type: "arrow" }] },
+      { id: "worker", type: "rectangle", x: 260, y: 20, width: 120, height: 80, boundElements: [{ id: "connection", type: "arrow" }] },
+      { id: "connection", type: "arrow", points: [[0, 0], [130, 0]], startBinding: { elementId: "api" }, endBinding: { elementId: "worker" } },
+      { id: "manual-note", type: "text", text: "Keep this handwritten note", x: 1, y: 200 },
+      { id: "manual-image", type: "image", fileId: "image-asset" },
+    ],
+    files: { "image-asset": { dataURL: "data:image/png;base64,retained" } },
+    appState: { viewBackgroundColor: "#fefefe", gridSize: 20 },
+  };
+  const inputPath = join(root, "handwritten diagram.excalidraw");
+  const bytes = Buffer.from(`${JSON.stringify(scene, null, 4)}\n\n`);
+  await fs.writeFile(inputPath, bytes);
+  const evidence = {
+    schemaVersion: 1, source: { kind: "git", revision: "HEAD" },
+    scope: { question: "How does handle reach run?", paths: ["src"], coverage: "partial", unknowns: ["Caller routing and runtime inputs were not traced."] },
+    references: [
+      { id: "api-import", path: "src/api.js", startLine: 1, endLine: 1, symbol: "run" },
+      { id: "api-call", path: "src/api.js", startLine: 3, endLine: 3, symbol: "run" },
+      { id: "worker-definition", path: "src/worker.js", startLine: 1, endLine: 1, symbol: "run" },
+    ],
+    nodes: [
+      { semanticId: "request:handler", elementId: "api", referenceIds: ["api-call"] },
+      { semanticId: "request:worker", elementId: "worker", referenceIds: ["worker-definition"] },
+    ],
+    relations: [{ semanticId: "request:import", elementId: "connection", from: "request:handler", to: "request:worker", kind: "import", claim: "api.js imports run from worker.js", referenceIds: ["api-import"] }],
+  };
+  return { root, repositoryPath, inputPath, bytes, scene, evidence, revision, git, outputDir: join(root, "bundle") };
+}
+
+test("committed references resolve immutable files, excerpts, and token locations despite dirty sources", async t => {
+  const f = await fixture(t);
+  await fs.writeFile(join(f.repositoryPath, "src/api.js"), "unrelated dirty working tree\n");
+  const checked = await validateEvidence(f);
+  assert.deepEqual(checked.source, { kind: "git", revision: f.revision });
+  assert.equal(checked.references[0].excerpt, apiSource.split("\n")[0]);
+  assert.equal(checked.references[0].sha256, sha256(apiSource));
+  assert.match(checked.references[0].blob, /^[a-f0-9]{40,64}$/);
+  assert.equal(checked.sceneHash, sha256(f.bytes));
+  assert.deepEqual(checked.nodes, f.evidence.nodes);
+  assert.equal(checked.nodes.length, 2); // Handwritten note and image remain outside the association.
+  assert.deepEqual(checked.scope.unknowns, f.evidence.scope.unknowns);
+});
+
+test("working-tree references require inspected content digests and reject stale sources", async t => {
+  const f = await fixture(t);
+  f.evidence.source = { kind: "working-tree" };
+  await assert.rejects(validateEvidence(f), { code: "INVALID_REFERENCE" });
+  for (const reference of f.evidence.references) reference.sha256 = sha256(reference.path === "src/api.js" ? apiSource : workerSource);
+  const checked = await validateEvidence(f);
+  assert.deepEqual(checked.source, { kind: "working-tree", baseRevision: f.revision });
+  assert.equal(checked.references[0].blob, null);
+  await fs.appendFile(join(f.repositoryPath, "src/api.js"), "// changed\n");
+  await assert.rejects(associateEvidence(f), { code: "STALE_SOURCE" });
+  await assert.rejects(fs.stat(f.outputDir), { code: "ENOENT" });
+});
+
+test("scope and file boundaries reject traversal, symlinks, and a repository subdirectory", async t => {
+  const f = await fixture(t);
+  for (const path of ["../outside.js", "/tmp/outside.js", ".git/config", "src/../src/api.js", "src\\api.js", "other/api.js"]) {
+    const evidence = structuredClone(f.evidence);
+    evidence.references[0].path = path;
+    await assert.rejects(validateEvidence({ ...f, evidence }), { code: "SOURCE_BOUNDARY" });
+  }
+  await assert.rejects(validateEvidence({ ...f, repositoryPath: join(f.repositoryPath, "src") }), { code: "SOURCE_BOUNDARY" });
+  await fs.symlink("api.js", join(f.repositoryPath, "src/link.js"));
+  await f.git("add", "src/link.js");
+  await f.git("-c", "user.name=Evidence fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgSign=false", "commit", "-m", "test: add symlink fixture");
+  f.evidence.references[0].path = "src/link.js";
+  await assert.rejects(validateEvidence(f), { code: "SOURCE_BOUNDARY" });
+  f.evidence.source = { kind: "working-tree" };
+  f.evidence.references[0].sha256 = sha256(apiSource);
+  await assert.rejects(validateEvidence(f), { code: "SOURCE_BOUNDARY" });
+});
+
+test("source references fail closed for nonexistent lines and ambiguous symbol selections", async t => {
+  const f = await fixture(t);
+  for (const replacement of [{ startLine: 0 }, { endLine: 200 }, { symbol: "runner" }, { symbol: "absent" }]) {
+    const evidence = structuredClone(f.evidence);
+    Object.assign(evidence.references[0], replacement);
+    await assert.rejects(validateEvidence({ ...f, evidence }), { code: "INVALID_REFERENCE" });
+  }
+  f.evidence.references.push(structuredClone(f.evidence.references[0]));
+  await assert.rejects(validateEvidence(f), { code: "AMBIGUOUS_IDENTITY" });
+});
+
+test("semantic identities and native relation endpoints cannot be guessed or duplicated", async t => {
+  const f = await fixture(t);
+  for (const update of [
+    evidence => { evidence.nodes[1].semanticId = evidence.nodes[0].semanticId; },
+    evidence => { evidence.nodes[1].elementId = evidence.nodes[0].elementId; },
+  ]) {
+    const evidence = structuredClone(f.evidence);
+    update(evidence);
+    await assert.rejects(validateEvidence({ ...f, evidence }), { code: "AMBIGUOUS_IDENTITY" });
+  }
+  let evidence = structuredClone(f.evidence);
+  evidence.nodes[0].elementId = "guessed-element";
+  await assert.rejects(validateEvidence({ ...f, evidence }), { code: "UNKNOWN_TARGET" });
+  evidence = structuredClone(f.evidence);
+  [evidence.relations[0].from, evidence.relations[0].to] = [evidence.relations[0].to, evidence.relations[0].from];
+  await assert.rejects(validateEvidence({ ...f, evidence }), { code: "INVALID_MAPPING" });
+});
+
+test("valid references never certify a claim, runtime behavior, or complete coverage", async t => {
+  const f = await fixture(t);
+  for (const kind of ["import", "call", "assumption"]) {
+    f.evidence.relations[0].kind = kind;
+    f.evidence.relations[0].claim = "Author assertion deliberately unsupported by the excerpt";
+    if (kind === "assumption") f.evidence.relations[0].referenceIds = [];
+    const checked = await validateEvidence(f);
+    assert.equal(checked.relations[0].kind, kind);
+    assert.deepEqual(checked.validation, { sourceLocations: true, sceneMappings: true, semanticClaims: false, runtimeBehavior: false });
+  }
+  f.evidence.relations[0].kind = "call";
+  await assert.rejects(validateEvidence(f), { code: "INVALID_REFERENCE" });
+  f.evidence.scope.coverage = "complete";
+  await assert.rejects(validateEvidence(f), { code: "INVALID_SCOPE" });
+  f.evidence.scope.coverage = "partial";
+  f.evidence.verified = true;
+  await assert.rejects(validateEvidence(f), { code: "INVALID_EVIDENCE" });
+});
+
+test("explicit association preserves exact native bytes and invents no generated history", async t => {
+  const f = await fixture(t);
+  const saved = await associateEvidence(f);
+  assert.equal(saved.bundle.baseline.kind, "association");
+  assert.equal(saved.bundle.baseline.priorBaseline, null);
+  assert.equal(saved.bundle.baseline.generated, null);
+  assert.deepEqual(await fs.readFile(join(f.outputDir, "delivered.excalidraw")), f.bytes);
+  assert.deepEqual(await fs.readFile(f.inputPath), f.bytes);
+  const read = await readEvidenceBundle(saved.bundlePath, { expectedHash: saved.sha256 });
+  assert.deepEqual(read.deliveredScene, f.scene);
+  assert.equal(read.generatedScene, null);
+  await assert.rejects(associateEvidence(f), { code: "OUTPUT_EXISTS" });
+  assert.deepEqual(await fs.readFile(join(f.outputDir, "delivered.excalidraw")), f.bytes);
+  assert.throws(() => associateEvidence({ ...f, generatedPath: f.inputPath }), { code: "INVALID_BASELINE" });
+});
+
+test("accepted generated and delivered baselines remain independently reconstructible", async t => {
+  const f = await fixture(t);
+  await assert.rejects(acceptEvidenceBaseline(f), { code: "INVALID_BASELINE" });
+  await assert.rejects(fs.stat(f.outputDir), { code: "ENOENT" });
+  const generated = structuredClone(f.scene);
+  generated.elements[0].x = 100;
+  generated.elements[0].customData.manual = false;
+  const generatedPath = join(f.root, "generated input.excalidraw");
+  const generatedBytes = Buffer.from(JSON.stringify(generated));
+  await fs.writeFile(generatedPath, generatedBytes);
+  const saved = await acceptEvidenceBaseline({ ...f, generatedPath });
+  assert.equal(saved.bundle.baseline.kind, "accepted-generated");
+  assert.deepEqual(await fs.readFile(join(f.outputDir, "generated.excalidraw")), generatedBytes);
+  await fs.unlink(f.inputPath);
+  await fs.unlink(generatedPath);
+  const read = await readEvidenceBundle(saved.bundlePath, { expectedHash: saved.sha256 });
+  assert.deepEqual(read.generatedScene, generated);
+  assert.deepEqual(read.deliveredScene, f.scene);
+  assert.equal(read.bundle.evidence.source.revision, f.revision);
+});
+
+test("bundle readers reject altered artifacts and manifest substitutions", async t => {
+  const f = await fixture(t);
+  const saved = await associateEvidence(f);
+  const deliveredPath = join(f.outputDir, "delivered.excalidraw");
+  await fs.appendFile(deliveredPath, " ");
+  await assert.rejects(readEvidenceBundle(saved.bundlePath), { code: "CORRUPT_EVIDENCE" });
+  await fs.writeFile(deliveredPath, f.bytes);
+  const changed = structuredClone(saved.bundle);
+  changed.baseline.delivered.file = "../handwritten diagram.excalidraw";
+  await fs.writeFile(saved.bundlePath, JSON.stringify(changed));
+  await assert.rejects(readEvidenceBundle(saved.bundlePath), { code: "CORRUPT_EVIDENCE" });
+  await assert.rejects(readEvidenceBundle(saved.bundlePath, { expectedHash: saved.sha256 }), { code: "CORRUPT_EVIDENCE" });
+});

--- a/test/workflow-commands.test.js
+++ b/test/workflow-commands.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import { workflowCommand } from '../src/workflow-commands.js';
+
+const exec = promisify(execFile);
+export async function workflowFixture(t) {
+  const root = await fs.realpath(await fs.mkdtemp(join(tmpdir(), 'toolkit-workflow-')));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const repositoryPath = join(root, 'source');
+  await fs.mkdir(repositoryPath);
+  const git = async (...args) => (await exec('git', ['-C', repositoryPath, ...args])).stdout.trim();
+  await git('init', '-b', 'main');
+  await fs.writeFile(join(repositoryPath, 'api.js'), 'export function handle() { return 1; }\n');
+  await git('add', '.');
+  await git('-c', 'user.name=Workflow fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgSign=false', 'commit', '-m', 'test: add workflow fixture');
+  const revision = await git('rev-parse', 'HEAD');
+  const scene = { type: 'excalidraw', version: 2, source: 'fixture', elements: [
+    { id: 'api', type: 'rectangle', x: 0, y: 0, width: 120, height: 80, boundElements: [] },
+  ], files: {}, appState: {}, unknownMetadata: { keep: true } };
+  const bytes = `${JSON.stringify(scene, null, 4)}\n\n`;
+  await fs.writeFile(join(root, 'input.excalidraw'), bytes);
+  const evidence = { schemaVersion: 1, source: { kind: 'git', revision },
+    scope: { question: 'Where is handle?', paths: ['api.js'], coverage: 'partial', unknowns: ['No runtime trace.'] },
+    references: [{ id: 'handle', path: 'api.js', startLine: 1, endLine: 1, symbol: 'handle' }],
+    nodes: [{ semanticId: 'request:handler', elementId: 'api', referenceIds: ['handle'] }], relations: [] };
+  const request = { repositoryPath: 'source', inputPath: 'input.excalidraw', evidence };
+  const requestPath = join(root, 'request.json');
+  const save = async value => fs.writeFile(requestPath, JSON.stringify(value));
+  await save(request);
+  return { root, repositoryPath, revision, scene, bytes, evidence, request, requestPath, save, git };
+}
+
+test('request-file boundary dispatches validation, association and explicit baseline acceptance', async t => {
+  const f = await workflowFixture(t);
+  const validated = await workflowCommand('validate-evidence', f.requestPath);
+  assert.equal(validated.source.revision, f.revision);
+  assert.equal(validated.repositoryPath, f.repositoryPath);
+  assert.equal(validated.validation.semanticClaims, false);
+  await f.save({ ...f.request, outputDir: 'associated' });
+  const associated = await workflowCommand('associate-evidence', f.requestPath);
+  assert.equal(associated.bundlePath, join(f.root, 'associated/evidence.json'));
+  assert.equal(await fs.readFile(join(f.root, 'associated/delivered.excalidraw'), 'utf8'), f.bytes);
+  assert.equal(associated.bundle.baseline.kind, 'association');
+  await f.save({ ...f.request, generatedPath: 'input.excalidraw' });
+  const accepted = await workflowCommand('accept-baseline', f.requestPath, { output: join(f.root, 'accepted') });
+  assert.equal(accepted.bundle.baseline.kind, 'accepted-generated');
+  assert.equal(await fs.readFile(join(f.root, 'input.excalidraw'), 'utf8'), f.bytes);
+});
+
+test('request validation fails clearly for malformed JSON, unsupported fields and conflicting CLI output', async t => {
+  const f = await workflowFixture(t);
+  await assert.rejects(workflowCommand('unknown-command', f.requestPath), { code: 'UNKNOWN_COMMAND' });
+  await fs.writeFile(f.requestPath, '{');
+  await assert.rejects(workflowCommand('validate-evidence', f.requestPath), { code: 'INVALID_REQUEST' });
+  await f.save({ ...f.request, generatedPath: 'input.excalidraw' });
+  await assert.rejects(workflowCommand('associate-evidence', f.requestPath), { code: 'INVALID_REQUEST' });
+  await f.save({ ...f.request, outputDir: 'one' });
+  await assert.rejects(workflowCommand('associate-evidence', f.requestPath, { output: join(f.root, 'two') }), { code: 'INVALID_REQUEST' });
+  await assert.rejects(fs.stat(join(f.root, 'one')), { code: 'ENOENT' });
+});
+
+test('installed CLI routes request files and emits source evidence as JSON', async t => {
+  const f = await workflowFixture(t);
+  const cli = fileURLToPath(new URL('../bin/cli.js', import.meta.url));
+  const checked = JSON.parse((await exec(process.execPath, [cli, 'validate-evidence', '--request', f.requestPath, '--json'], { cwd: tmpdir() })).stdout);
+  assert.equal(checked.source.revision, f.revision);
+  assert.equal(checked.validation.semanticClaims, false);
+  await f.save({ ...f.request, outputDir: 'cli-evidence' });
+  const associated = JSON.parse((await exec(process.execPath, [cli, 'associate-evidence', '--request', f.requestPath])).stdout);
+  assert.equal(associated.bundle.baseline.kind, 'association');
+  assert.equal(await fs.readFile(join(f.root, 'cli-evidence/delivered.excalidraw'), 'utf8'), f.bytes);
+});


### PR DESCRIPTION
Source-linked diagrams need retained evidence and a known generated baseline before later updates can distinguish code changes from manual edits. Add CLI commands to validate scoped source references, associate an existing native scene, and explicitly accept separate generated/delivered snapshots. Bundles preserve native bytes and record exact Git revisions or inspected working-tree digests, stable semantic IDs, relation kinds, scope and unknowns.

The existing coding agent performs the investigation and supplies the proposal. Location and binding checks do not certify semantic claims, runtime calls or complete coverage. Associating a handwritten diagram does not invent its generated history.

## Testing

- Real Git and CLI fixtures cover dirty checkouts, stale digests, scoped paths, ambiguous mappings, artifact tampering and exact native preservation (`test/evidence.test.js`, `test/workflow-commands.test.js`).
- Inspected the request-flow fixture's source claims and retained native baseline; unsupported delivery behavior remains an explicit assumption.
