### PR TITLE
[PR Diagrams]: render source-linked changes at readable target sizes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -36,6 +36,7 @@ Usage:
   npx ${pkg.name} validate-evidence --request <json>  Check scoped source references
   npx ${pkg.name} associate-evidence --request <json>  Retain an existing scene's evidence
   npx ${pkg.name} accept-baseline --request <json>  Accept generated/delivered snapshots
+  npx ${pkg.name} explain-change --request <json>  Export source-linked revision views
   npx ${pkg.name} version    Print version
 
 Options: --home <directory>, --target <claude|codex|all>, --project <directory>,

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -1,0 +1,199 @@
+# Source-linked before/after comparisons
+
+Compare two scoped evidence bundles at exact Git revisions. The host agent supplies
+the diagrams, evidence and required content. This module compares their semantic
+identities, preserves both native files, and exports separate images at one shared
+viewport. It does not discover architecture, prove program behavior, change layout,
+or publish a PR comment.
+
+```js
+import { loadComparison, exportComparison } from "./src/explain.js";
+
+const request = {
+  repositoryPath: "/absolute/repository",
+  repositoryUrl: "https://github.com/owner/repository",
+  base: {
+    bundlePath: "/evidence/base/evidence.json",
+    expectedHash: "<retained manifest SHA-256>",
+    revision: "main",
+  },
+  head: {
+    bundlePath: "/evidence/head/evidence.json",
+    expectedHash: "<retained manifest SHA-256>",
+    revision: "feature-branch",
+  },
+  required: {
+    base: { nodes: ["request:api", "request:worker"], relations: ["request:direct"] },
+    head: {
+      nodes: ["request:api", "request:queue", "request:worker"],
+      relations: ["request:enqueue", "request:consume"],
+    },
+  },
+  target: "article",
+};
+
+// Read-only plan; refs resolve now, and every source location is checked again.
+const plan = await loadComparison(request);
+
+// Native rendering is injectable. Without adapters, the module loads the native
+// measureScene/renderScene exports from ./render.js.
+const result = await exportComparison(
+  { ...request, outputDir: "/new/pr-comparison" },
+  { measureScene, renderScene },
+);
+```
+
+Each bundle must describe the exact commit to which its requested revision resolves.
+An empty commit still has a different identity, even if all cited files match.
+Working-tree evidence is rejected for this workflow. Base and head paths, excerpts,
+blob IDs, digests and symbols are rechecked independently against their own commits;
+a dirty checkout does not change either side. Keep `expectedHash` from the accepted
+bundle receipt to detect manifest replacement. Source links use GitHub-compatible
+`/blob/<commit>/<path>#L<start>-L<end>` URLs over HTTPS, including GitHub Enterprise
+hosts. The URL is caller-supplied presentation metadata, not proof of remote origin.
+
+`planComparison({base, head, target, required, repositoryUrl})` is the pure API.
+Its base/head arguments are checked snapshots returned by `readEvidenceBundle`.
+It neither reads Git nor authenticates supplied objects; use `loadComparison` at an
+external input boundary. Both planning functions return separate base/head scenes,
+exact revisions, scopes, change records, target, required content and validation
+flags. `loadComparison` also retains input artifact paths and hashes.
+
+## Change meaning and stable context
+
+Change records use explicit semantic IDs and `added`, `removed`, `changed`, or
+`unchanged`. Node comparison includes the selected source excerpts and native label
+content. Relation comparison additionally includes endpoints, kind and authored claim.
+Moved source line numbers or changes elsewhere in the same file do not alone change
+a concept; both original citation locations remain in the report. Labels do not
+establish identity. A missing mapping is a removal from this scoped comparison,
+not proof that code was deleted or that unseen content no longer exists.
+
+The report keeps these certainty labels visible:
+
+| Label | Meaning |
+| --- | --- |
+| `source-located` | A node maps to checked source locations. |
+| `source-cited` | An authored import/call relationship has checked citations; the claim itself is unverified. |
+| `assumption` | An explicitly conjectural relationship, possibly without citations. |
+
+`semanticClaims`, `runtimeBehavior` and `completeCoverage` always remain false.
+Passing source-location, mapping, geometry or image checks never upgrades a claim.
+The fixture's direct call is replaced by an evidenced enqueue call and an explicitly
+assumed queue-to-worker delivery relationship. Its required sets name all three
+relationships across the two sides; omitting one fails before export.
+Every assumption relation must also have a native bound label beginning with
+`Assumption` (case-insensitive). Otherwise `UNLABELED_ASSUMPTION` stops the export.
+The label must remain visible and pass the same typography gate as other text;
+the sidecar report alone cannot make an unlabeled speculative arrow acceptable.
+
+Unchanged mapped nodes/relations, their bound labels, and common unchanged unmapped
+content must keep their geometry. A mismatch raises `UNSTABLE_CONTEXT` with the
+affected identities. The module leaves both inputs intact so the host can reconcile
+their layout explicitly. It does not guess new arrow routes. Native output files
+retain the accepted bytes, IDs, coordinates, manual notes and unknown properties.
+
+## Output dimensions and readability
+
+The target dimensions are the delivered PNG dimensions at one device pixel per
+output pixel. Inspect the images at that size; downscaling them in a document needs
+another check at that document's intended dimensions.
+
+| Target | Width × height | Padding | Minimum label font size |
+| --- | --- | --- | --- |
+| `article` | 1200 × 800 px | 40 px | 18 px |
+| `slide` | 1920 × 1080 px | 64 px | 24 px |
+| `canvas` | 1600 × 1000 px | 40 px | 16 px |
+
+For another intended size, supply
+`{name, width, height, padding, minimumFontSize}`. Width/height are positive integer
+pixels, capped at 8192 per axis. The typography thresholds are explicit product
+defaults, not a claim of universal accessibility at every viewing distance.
+
+`measureScene(scene)` must restore the native scene and load its actual bundled
+fonts, then return this contract without writing artifacts:
+
+```js
+{
+  renderer: "@excalidraw/excalidraw@0.18.1",
+  fontsLoaded: true,
+  bounds: { x: 40, y: 40, width: 840, height: 175 }, // native scene coordinates
+  visibleElementIds: ["api", "api-label", "worker", "worker-label", "direct", "note"],
+  text: [
+    { id: "api-label", fontSize: 28, x: 60, y: 60, width: 50, height: 35 },
+    // Every visible nonempty text element, measured with the loaded native font.
+  ],
+}
+```
+
+Text bounds must reflect the measured glyph/layout extents after native restoration,
+including extents that exceed stale declared element dimensions. Required mapped
+elements and their labels must be visible. Missing measurements fail; the module
+does not substitute estimated character widths. Both scene bounds and all text
+bounds contribute to a single union viewport. For union origin `(x, y)` and size
+`(w, h)`, the transform is:
+
+```text
+scale   = min(1, (target.width - 2*padding)/w, (target.height - 2*padding)/h)
+offsetX = (target.width - w*scale)/2 - x*scale
+offsetY = (target.height - h*scale)/2 - y*scale
+pixelX  = sceneX*scale + offsetX
+pixelY  = sceneY*scale + offsetY
+```
+
+Both images use this exact transform. Offsets are pixel translations, not scene
+origins. No native coordinates are rewritten. Every measured text element must keep
+`fontSize * scale >= minimumFontSize`. `checkReadability(plan, {base, head})` exposes
+this pure gate and returns the shared viewport, effective font sizes and renderer
+identities. `INSUFFICIENT_READABILITY` includes the failing side, element ID and
+effective size. Increase the target, recompose the view, or explicitly enlarge labels
+before retrying. The export does not silently shrink text to force success.
+
+`renderScene(scene, outputPath, {width, height, padding, scale, offsetX, offsetY})`
+must apply that affine transform to the loaded native scene, create an exclusive PNG
+at exactly `width × height`, and preserve the supplied scene. Adapters receive clones.
+Core checks PNG identity/dimensions and preserves native bytes. Renderer correctness,
+font loading, glyph coverage and clipping need an actual native integration check;
+test doubles are contract checks only. The typography gate does not certify diagram
+meaning, contrast, arrow routing, or overall visual quality. Inspect the actual
+delivered images before accepting the explanation; this API makes no model critique
+call and performs no automatic repair loop.
+
+## Artifacts and failure states
+
+A successful new directory contains `before.excalidraw`, `after.excalidraw`,
+`before.png`, `after.png`, `changes.md`, and `comparison.json`. The complete JSON
+receipt includes artifact hashes, separate source scopes/revisions, change records,
+citations, required content, measured viewport and narrow validation flags. Preserve
+its returned SHA-256 independently. Existing comparison directories are never
+overwritten; there is no implicit publishing or latest-result alias.
+
+Readability, missing content, source-validation and context-conflict failures happen
+before creating the output directory or invoking rendering. A later renderer or
+filesystem failure may leave partial artifacts, but no `comparison.json` completion
+receipt. Choose a new directory after resolving the failure. An output is successful
+only when that complete receipt exists and the artifact checks pass.
+
+Run `node --test test/explain.test.js` for the scoped comparison, revision, required
+content, geometry, target/readability, immutable-output and renderer-contract checks.
+These tests use temporary Git repositories and synthetic measurement/PNG doubles;
+they do not claim native visual acceptance.
+
+Open the completed receipt to review both native scenes and their source context:
+
+```sh
+excalidraw-toolkit preview ./comparison/comparison.json
+```
+
+The sidebar follows the selected Before/After view, showing native node labels,
+relationship claims, exact-revision source links, and scoped unknowns. Opening a
+receipt rechecks all retained native/PNG hashes and rebuilds the comparison from
+its evidence bundles and Git source. Keep those bundles and the source repository
+available. Hand-edited claims or stale files fail before a preview is served.
+This review checks source locations and diagram identity; it does not establish
+that a claim is semantically correct or that the runtime follows the depicted path.
+
+PNG downloads from a comparison review return the exact retained image for the
+selected view, preserving its declared article, slide or canvas dimensions. The
+local preview serves those checked bytes under its private token URL; it does not
+re-render the export at the review window's size.

--- a/docs/workflow-commands.md
+++ b/docs/workflow-commands.md
@@ -15,6 +15,7 @@ does not load the browser renderer or require a model runtime.
 | `validate-evidence` | `repositoryPath`, `inputPath`, `evidence` | Checked source locations, scene mappings and their limits; no files written |
 | `associate-evidence` | Validation fields plus `outputDir` | Immutable association of an existing scene; no generated history invented |
 | `accept-baseline` | Association fields plus `generatedPath` | Explicitly accepted generated and delivered native snapshots |
+| `explain-change` | `repositoryPath`, `base`, `head`, `repositoryUrl`, `target`, `required`, `outputDir` | Native before/after files, matching PNG viewport, source-linked report |
 
 The existing coding agent investigates the selected entry point and path, reads
 source files at the declared revision, constructs supported scene edits, and
@@ -45,3 +46,10 @@ Call `<installed CLI> associate-evidence --request /absolute/request.json`.
 Read the returned bundle/hash and inspect the saved native scene and preview.
 Baseline acceptance is an explicit action after the result is adopted; a source
 association alone is not a last-generated baseline.
+
+For `explain-change`, each `base`/`head` contains `bundlePath`, the requested
+`revision`, and retained `expectedHash`. Declare required base/head semantic
+node/relation ID arrays in `required`. Choose `article`, `slide`, `canvas`, or an
+explicit pixel target in `target`; the native renderer checks effective label
+sizes at that target before writing outputs. It preserves unchanged context and
+rejects missing required content. See `docs/explain.md` for the complete contract.

--- a/plugins/excalidraw/skills/scoped-edit/SKILL.md
+++ b/plugins/excalidraw/skills/scoped-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scoped-edit
-description: Edit a saved .excalidraw diagram while preserving manual content, or explain a scoped source request flow with cited native elements. Use the installed toolkit's supported file operations and evidence commands.
+description: Edit a saved .excalidraw diagram while preserving manual content, explain a scoped source flow, or compare a code change with source-linked diagrams. Use the installed toolkit's supported file operations and evidence commands.
 ---
 
 # Edit a saved Excalidraw scene
@@ -63,3 +63,18 @@ Use `accept-baseline` with an explicit `generatedPath` only after the generated
 result is adopted. Retain the returned bundle path and manifest hash for refresh.
 Request-file filesystem paths resolve relative to the request file. These commands
 return JSON; report their concrete errors and any unverified source or visual claim.
+
+## Compare a code change
+
+Retain source-evidence bundles for the exact base and head commits. Keep unchanged
+context in the same position, express source changes through supported operations,
+and list the required semantic nodes and relations on each side. Use
+`explain-change --request <file>` with `repositoryPath`, `base`, `head`,
+`repositoryUrl`, `required`, `target` and `outputDir`. Each side supplies its
+`bundlePath`, `revision` and retained `expectedHash`.
+
+Choose the user's article, slide or canvas output target before export. Readability
+failure requires a deliberate target or composition change; keep required content
+visible. Inspect both exported PNGs at their actual size and read the source-linked
+change report. Return editable native files, previews and the report with remaining
+assumptions. An exported source citation alone does not prove runtime behavior.

--- a/src/commands.js
+++ b/src/commands.js
@@ -18,7 +18,12 @@ export async function sceneCommand(command, inputPath, values) {
   let scene = readJSON(inputPath);
   let beforeScene;
   let changes;
-  if (scene?.type !== 'excalidraw') {
+  let review;
+  let previewPngs;
+  if (scene.schemaVersion === 1 && scene.status === 'complete' && scene.inputs?.base && scene.inputs?.head) {
+    const { readComparisonReview } = await import('./review-receipts.js');
+    ({ scene, beforeScene, review, previewPngs } = await readComparisonReview(inputPath));
+  } else if (scene?.type !== 'excalidraw') {
     const verified = await verifyReceipt(inputPath);
     changes = verified.receipt.changes;
     beforeScene = verified.beforeScene;
@@ -28,7 +33,7 @@ export async function sceneCommand(command, inputPath, values) {
   if (beforeScene) validateScene(beforeScene);
   const port = values.port === undefined ? 0 : Number(values.port);
   if (!Number.isInteger(port) || port < 0 || port > 65535) throw new Error('PORT_INVALID: use an integer from 0 to 65535');
-  const preview = await servePreview(scene, {beforeScene, changes, title: values.title || basename(inputPath).replace(/\.(excalidraw|json)$/, ''), port});
+  const preview = await servePreview(scene, {beforeScene, changes, review, previewPngs, title: values.title || review?.title || basename(inputPath).replace(/\.(excalidraw|json)$/, ''), port});
   if (!values['no-open']) openBrowser(preview.url);
   for (const signal of ['SIGINT', 'SIGTERM']) process.once(signal, async () => {await preview.close(); process.exit(0);});
   return {url: preview.url, inputPath: resolve(inputPath), mode: beforeScene ? 'comparison' : 'preview'};

--- a/src/explain.js
+++ b/src/explain.js
@@ -1,0 +1,278 @@
+import { promises as fs } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { readEvidenceBundle, validateEvidence } from "./evidence.js";
+import { sha256, validateScene } from "./scene.js";
+
+export const OUTPUT_TARGETS = Object.freeze({
+  article: Object.freeze({ name: "article", width: 1200, height: 800, padding: 40, minimumFontSize: 18 }),
+  slide: Object.freeze({ name: "slide", width: 1920, height: 1080, padding: 64, minimumFontSize: 24 }),
+  canvas: Object.freeze({ name: "canvas", width: 1600, height: 1000, padding: 40, minimumFontSize: 16 }),
+});
+const COMMIT = /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/;
+const GEOMETRY = ["x", "y", "width", "height", "angle", "points", "frameId", "groupIds"];
+const PNG = Buffer.from("89504e470d0a1a0a", "hex");
+function fail(code, message, details) { throw Object.assign(new Error(message), { code, ...(details ? { details } : {}) }); }
+function targetSize(target) {
+  const value = typeof target === "string" ? OUTPUT_TARGETS[target] : target;
+  if (!value || typeof value.name !== "string" || !value.name.trim() ||
+    ![value.width, value.height].every(n => Number.isSafeInteger(n) && n > 0 && n <= 8192) ||
+    !Number.isFinite(value.padding) || value.padding < 0 || value.padding * 2 >= Math.min(value.width, value.height) ||
+    !Number.isFinite(value.minimumFontSize) || value.minimumFontSize < 1) {
+    fail("INVALID_TARGET", "Choose article, slide, canvas, or explicit dimensions, padding and minimumFontSize (pixels)");
+  }
+  return { name: value.name, width: value.width, height: value.height, padding: value.padding, minimumFontSize: value.minimumFontSize };
+}
+function repositoryLink(value) {
+  let url;
+  try { url = new URL(value); } catch { fail("INVALID_SOURCE_URL", "Provide an HTTPS GitHub-compatible repository URL"); }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash || !/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(url.pathname)) {
+    fail("INVALID_SOURCE_URL", "Provide an HTTPS GitHub-compatible repository URL without credentials, query or fragment");
+  }
+  return `${url.origin}${url.pathname.replace(/\/$/, "").replace(/\.git$/, "")}`;
+}
+function projection(value, fields) { return Object.fromEntries(fields.filter(field => Object.hasOwn(value, field)).map(field => [field, value[field]])); }
+function pathSegment(value) { return encodeURIComponent(value).replace(/[!'()*]/g, char => `%${char.charCodeAt(0).toString(16).toUpperCase()}`); }
+function label(element, index) {
+  return element.type === "text" ? element.originalText ?? element.text : (element.boundElements ?? [])
+    .filter(binding => binding.type === "text").map(binding => index.get(binding.id)).map(text => text.originalText ?? text.text).join("\n");
+}
+function descriptions(side, kind, url) {
+  const evidence = side.bundle.evidence;
+  const index = validateScene(side.deliveredScene);
+  const references = new Map(evidence.references.map(reference => [reference.id, reference]));
+  return new Map(evidence[kind].map(item => {
+    const sources = item.referenceIds.map(id => {
+      const reference = references.get(id);
+      if (!reference) fail("INVALID_COMPARISON", `Missing source reference: ${id}`);
+      const { path, startLine, endLine, symbol, excerpt, sha256: hash, blob } = reference;
+      return { id, revision: evidence.source.revision, path, startLine, endLine, ...(symbol ? { symbol } : {}), excerpt, sha256: hash, blob,
+        url: `${url}/blob/${evidence.source.revision}/${path.split("/").map(pathSegment).join("/")}#L${startLine}-L${endLine}` };
+    });
+    const element = index.get(item.elementId);
+    if (!element || element.isDeleted) fail("MISSING_REQUIRED", `Mapped element is absent: ${item.elementId}`);
+    const caption = label(element, index);
+    if (kind === "relations" && item.kind === "assumption" && !/^assumption(?:\s|:|$)/iu.test(caption.trim())) {
+      fail("UNLABELED_ASSUMPTION", `Give ${item.semanticId} a native bound label starting with Assumption before exporting`);
+    }
+    return [item.semanticId, { ...structuredClone(item), label: caption, sources,
+      certainty: kind === "nodes" ? "source-located" : item.kind === "assumption" ? "assumption" : "source-cited",
+      semanticClaimsVerified: false, runtimeBehaviorVerified: false }];
+  }));
+}
+function meaning(item, kind) {
+  return { ...projection(item, kind === "nodes" ? ["label"] : ["from", "to", "kind", "claim", "label"]),
+    // Line movement or a change elsewhere in the file is citation churn, not a
+    // change to the selected concept. Excerpts still expose changed evidence.
+    sources: item.sources.map(source => projection(source, ["path", "symbol", "excerpt"]))
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))) };
+}
+function assertStable(base, head, changes) {
+  const before = validateScene(base.deliveredScene);
+  const after = validateScene(head.deliveredScene);
+  const conflicts = [];
+  const check = (a, b, semanticId) => {
+    if (!isDeepStrictEqual(projection(a, GEOMETRY), projection(b, GEOMETRY))) conflicts.push({ semanticId, baseElementId: a.id, headElementId: b.id });
+  };
+  for (const change of [...changes.nodes, ...changes.relations].filter(item => item.status === "unchanged")) {
+    const a = before.get(change.before.elementId);
+    const b = after.get(change.after.elementId);
+    check(a, b, change.semanticId);
+    const texts = element => (element.boundElements ?? []).filter(binding => binding.type === "text");
+    const oldTexts = texts(a), newTexts = texts(b);
+    if (oldTexts.length !== newTexts.length) fail("UNSTABLE_CONTEXT", `Changed label mapping for unchanged context: ${change.semanticId}`);
+    oldTexts.forEach((binding, i) => check(before.get(binding.id), after.get(newTexts[i].id), change.semanticId));
+  }
+  const mapped = new Set([...base.bundle.evidence.nodes, ...base.bundle.evidence.relations].map(item => item.elementId));
+  for (const [id, element] of before) {
+    const next = after.get(id);
+    if (mapped.has(id) || element.isDeleted || !next || next.isDeleted) continue;
+    const content = value => Object.fromEntries(Object.entries(value).filter(([key]) => ![...GEOMETRY, "version", "versionNonce", "updated"].includes(key)));
+    if (isDeepStrictEqual(content(element), content(next))) check(element, next, null);
+  }
+  if (conflicts.length) fail("UNSTABLE_CONTEXT", "Unchanged context moved between scenes; align it explicitly before comparison", conflicts);
+}
+
+// Pure planning over checked, retained snapshots. Use loadComparison at the I/O
+// boundary to recheck both snapshots against their requested Git revisions.
+export function planComparison({ base, head, target = "article", required, repositoryUrl }) {
+  const url = repositoryLink(repositoryUrl);
+  for (const [name, side] of Object.entries({ base, head })) {
+    const evidence = side?.bundle?.evidence;
+    if (evidence?.source?.kind !== "git" || !COMMIT.test(evidence.source.revision) || evidence.scope?.coverage !== "partial" ||
+      evidence.validation?.sourceLocations !== true || evidence.validation?.sceneMappings !== true ||
+      evidence.validation?.semanticClaims !== false || evidence.validation?.runtimeBehavior !== false) {
+      fail("INVALID_COMPARISON", `${name} requires checked evidence at an exact Git commit; working-tree evidence cannot stand in for a PR revision`);
+    }
+  }
+  if (base.bundle.evidence.repositoryPath !== head.bundle.evidence.repositoryPath) fail("INVALID_COMPARISON", "Compare revisions of one repository");
+  const changes = {};
+  for (const kind of ["nodes", "relations"]) {
+    const before = descriptions(base, kind, url), after = descriptions(head, kind, url);
+    for (const [name, entries] of [["base", before], ["head", after]]) {
+      const ids = required?.[name]?.[kind];
+      if (!Array.isArray(ids) || ids.some(id => typeof id !== "string") || new Set(ids).size !== ids.length || (kind === "nodes" && !ids.length)) {
+        fail("INVALID_REQUIRED", "Declare required base/head nodes and relations as explicit semantic ID arrays");
+      }
+      const missing = ids.filter(id => !entries.has(id));
+      if (missing.length) fail("MISSING_REQUIRED", `Missing required ${name} ${kind}`, missing);
+    }
+    changes[kind] = [...new Set([...before.keys(), ...after.keys()])].sort().map(semanticId => {
+      const a = before.get(semanticId), b = after.get(semanticId);
+      return { semanticId, status: !a ? "added" : !b ? "removed" : isDeepStrictEqual(meaning(a, kind), meaning(b, kind)) ? "unchanged" : "changed",
+        before: a ?? null, after: b ?? null };
+    });
+  }
+  assertStable(base, head, changes);
+  return { schemaVersion: 1, target: targetSize(target), required: structuredClone(required), repositoryUrl: url,
+    base: { revision: base.bundle.evidence.source.revision, scope: structuredClone(base.bundle.evidence.scope), scene: structuredClone(base.deliveredScene) },
+    head: { revision: head.bundle.evidence.source.revision, scope: structuredClone(head.bundle.evidence.scope), scene: structuredClone(head.deliveredScene) },
+    changes, validation: { sourceLocations: true, sceneMappings: true, requiredMappings: true, unchangedContext: true,
+      semanticClaims: false, runtimeBehavior: false, completeCoverage: false, renderedReadability: false } };
+}
+
+export async function loadComparison({ repositoryPath, base, head, ...options }) {
+  const load = async side => {
+    if (typeof side?.bundlePath !== "string" || typeof side.revision !== "string" || !side.revision.trim()) fail("INVALID_COMPARISON", "Each side requires bundlePath and the requested Git revision");
+    const snapshot = await readEvidenceBundle(side.bundlePath, { expectedHash: side.expectedHash });
+    const retained = snapshot.bundle.evidence;
+    if (retained.source.kind !== "git") fail("INVALID_COMPARISON", "PR comparisons require committed source evidence");
+    const proposal = projection(retained, ["schemaVersion", "scope", "nodes", "relations"]);
+    proposal.source = { kind: "git", revision: side.revision };
+    proposal.references = retained.references.map(reference => projection(reference, ["id", "path", "startLine", "endLine", "symbol", "sha256"]));
+    const inputPath = join(dirname(resolve(side.bundlePath)), "delivered.excalidraw");
+    const checked = await validateEvidence({ repositoryPath, inputPath, evidence: proposal });
+    if (checked.source.revision !== retained.source.revision) fail("REVISION_MISMATCH", "A bundle must describe the exact requested revision, even when its referenced files are unchanged");
+    if (checked.sceneHash !== retained.sceneHash || !isDeepStrictEqual(checked.references, retained.references)) fail("CORRUPT_EVIDENCE", "Retained evidence differs from the native scene or committed source");
+    return { ...snapshot, inputPath, bundle: { ...snapshot.bundle, evidence: checked } };
+  };
+  const [before, after] = await Promise.all([load(base), load(head)]);
+  const plan = planComparison({ ...options, base: before, head: after });
+  return { ...plan, inputs: {
+    base: { bundlePath: resolve(base.bundlePath), inputPath: before.inputPath, sha256: before.bundle.evidence.sceneHash },
+    head: { bundlePath: resolve(head.bundlePath), inputPath: after.inputPath, sha256: after.bundle.evidence.sceneHash },
+  } };
+}
+
+export function checkReadability(plan, measurements) {
+  const target = targetSize(plan.target);
+  const boxes = [], labels = [];
+  for (const side of ["base", "head"]) {
+    const metrics = measurements[side];
+    if (!metrics || !/^@excalidraw\/excalidraw@/.test(metrics.renderer ?? "") || metrics.fontsLoaded !== true || !Array.isArray(metrics.text) || !Array.isArray(metrics.visibleElementIds)) {
+      fail("INVALID_RENDER_METRICS", "Measure native restored scenes with loaded fonts before export");
+    }
+    const box = value => value && [value.x, value.y, value.width, value.height].every(Number.isFinite) && value.width >= 0 && value.height >= 0;
+    if (!box(metrics.bounds) || metrics.bounds.width <= 0 || metrics.bounds.height <= 0) fail("INVALID_RENDER_METRICS", "Native scene bounds must be finite and nonempty");
+    boxes.push(metrics.bounds);
+    const visible = new Set(metrics.visibleElementIds);
+    const required = [...plan.required[side].nodes, ...plan.required[side].relations];
+    const entries = [...plan.changes.nodes, ...plan.changes.relations].map(change => change[side === "base" ? "before" : "after"]).filter(Boolean);
+    const missing = entries.filter(item => required.includes(item.semanticId) && !visible.has(item.elementId)).map(item => item.semanticId);
+    if (missing.length) fail("MISSING_REQUIRED", `Required ${side} content is not visible in the native render`, missing);
+    const text = new Map();
+    const index = validateScene(plan[side].scene);
+    for (const metric of metrics.text) {
+      if (!metric || text.has(metric.id) || index.get(metric.id)?.type !== "text" || !visible.has(metric.id) || !box(metric) ||
+        !Number.isFinite(metric.fontSize) || metric.fontSize <= 0 || metric.height <= 0) fail("INVALID_RENDER_METRICS", "Invalid or duplicate native text metrics");
+      text.set(metric.id, metric);
+      boxes.push(metric);
+      labels.push({ side, ...metric });
+    }
+    for (const element of plan[side].scene.elements) {
+      if (!element.isDeleted && element.type === "text" && (element.text ?? "").trim() && element.opacity !== 0) {
+        if (!text.has(element.id)) fail("INVALID_RENDER_METRICS", `Native measurement omitted text: ${side}/${element.id}`);
+      }
+    }
+    for (const item of entries.filter(item => required.includes(item.semanticId))) {
+      const element = index.get(item.elementId);
+      const hiddenLabels = (element.boundElements ?? []).filter(binding => binding.type === "text" && !visible.has(binding.id));
+      if (hiddenLabels.length) fail("MISSING_REQUIRED", `Required ${side} content has a hidden label: ${item.semanticId}`);
+    }
+  }
+  const x = Math.min(...boxes.map(box => box.x)), y = Math.min(...boxes.map(box => box.y));
+  const width = Math.max(...boxes.map(box => box.x + box.width)) - x;
+  const height = Math.max(...boxes.map(box => box.y + box.height)) - y;
+  const { padding, minimumFontSize } = target;
+  const scale = Math.min(1, (target.width - 2 * padding) / width, (target.height - 2 * padding) / height);
+  const failures = labels.filter(label => label.fontSize * scale + 0.001 < minimumFontSize)
+    .map(label => ({ side: label.side, elementId: label.id, fontSize: label.fontSize, effectiveFontSize: label.fontSize * scale, minimumFontSize }));
+  if (failures.length) fail("INSUFFICIENT_READABILITY", "Labels are too small at the requested output size; enlarge the target, recompose the view, or explicitly increase label sizes", failures);
+  return { ...target, scale, offsetX: (target.width - width * scale) / 2 - x * scale, offsetY: (target.height - height * scale) / 2 - y * scale,
+    bounds: { x, y, width, height }, minimumEffectiveFontSize: labels.length ? Math.min(...labels.map(label => label.fontSize * scale)) : null,
+    labels: labels.map(label => ({ ...label, effectiveFontSize: label.fontSize * scale })),
+    renderers: { base: measurements.base.renderer, head: measurements.head.renderer } };
+}
+
+function markdown(report) {
+  const escape = value => String(value).replace(/[&<>]/g, char => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[char])).replace(/[\\`*_[\]]/g, "\\$&").replaceAll("\n", " ");
+  const lines = ["# Source-linked change comparison", "", `Base: ${report.base.revision}`, `Head: ${report.head.revision}`, "",
+    `Target: ${report.target.name}, ${report.target.width} × ${report.target.height} px; minimum label size ${report.target.minimumFontSize} px.`, "",
+    "Changes describe these scoped diagrams and selected source excerpts. A removed mapping does not prove source deletion. Source-cited claims are not semantically or runtime verified; assumptions remain assumptions.", ""];
+  for (const kind of ["nodes", "relations"]) {
+    lines.push(`## ${kind === "nodes" ? "Nodes" : "Relationships"}`, "");
+    for (const change of report.changes[kind]) {
+      lines.push(`- **${change.status}** ${escape(change.semanticId)}`);
+      for (const [side, item] of [["base", change.before], ["head", change.after]]) {
+        if (!item) continue;
+        const sources = item.sources.map(source => `[${escape(`${source.path}:${source.startLine}-${source.endLine}`)}](${source.url})`).join(", ");
+        lines.push(`  - ${side}: ${escape(item.claim ?? item.label)} — ${item.certainty}${sources ? `; ${sources}` : "; no source citation"}.`);
+      }
+    }
+    lines.push("");
+  }
+  for (const side of ["base", "head"]) {
+    lines.push(`## ${side === "base" ? "Base" : "Head"} scope`, "", escape(report[side].scope.question), "");
+    for (const unknown of report[side].scope.unknowns) lines.push(`- ${escape(unknown)}`);
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+async function writeExclusive(path, bytes) {
+  const handle = await fs.open(path, "wx", 0o600);
+  try { await handle.writeFile(bytes); await handle.sync(); } finally { await handle.close(); }
+}
+
+export async function exportComparison({ outputDir, ...request }, options = {}) {
+  if (typeof outputDir !== "string" || !outputDir.trim()) fail("INVALID_OUTPUT", "Provide a new output directory");
+  const plan = await loadComparison(request);
+  const renderer = options.measureScene && options.renderScene ? options : { ...(await import("./target-render.js")), ...options };
+  if (typeof renderer.measureScene !== "function" || typeof renderer.renderScene !== "function") fail("RENDERER_UNAVAILABLE", "A native measureScene and renderScene adapter is required");
+  const measured = await Promise.all(["base", "head"].map(side => renderer.measureScene(structuredClone(plan[side].scene))));
+  const viewport = checkReadability(plan, { base: measured[0], head: measured[1] });
+  const native = {};
+  for (const side of ["base", "head"]) {
+    native[side] = await fs.readFile(plan.inputs[side].inputPath);
+    if (sha256(native[side]) !== plan.inputs[side].sha256) fail("STALE_INPUT", `The ${side} native scene changed during planning`);
+  }
+  // No output directory or artifact exists before both readability checks pass.
+  const directory = resolve(outputDir);
+  await fs.mkdir(dirname(directory), { recursive: true });
+  try { await fs.mkdir(directory); } catch (error) { if (error.code === "EEXIST") fail("OUTPUT_EXISTS", "Comparison outputs are immutable; choose a new directory"); throw error; }
+  const artifacts = {};
+  for (const [side, name] of [["base", "before"], ["head", "after"]]) {
+    const nativeName = `${name}.excalidraw`, pngName = `${name}.png`;
+    await writeExclusive(join(directory, nativeName), native[side]);
+    await renderer.renderScene(structuredClone(plan[side].scene), join(directory, pngName), projection(viewport, ["width", "height", "padding", "scale", "offsetX", "offsetY"]));
+    const png = await fs.readFile(join(directory, pngName));
+    if (png.length < 33 || !png.subarray(0, 8).equals(PNG) || png.subarray(12, 16).toString() !== "IHDR" ||
+      png.readUInt32BE(16) !== viewport.width || png.readUInt32BE(20) !== viewport.height) fail("INVALID_RENDER", "Renderer must produce a PNG at the exact requested target dimensions");
+    if (!(await fs.readFile(join(directory, nativeName))).equals(native[side])) fail("PROTECTED_CHANGE", "The renderer changed a retained native artifact");
+    const imageHandle = await fs.open(join(directory, pngName), "r");
+    try { await imageHandle.sync(); } finally { await imageHandle.close(); }
+    for (const [file, bytes] of [[nativeName, native[side]], [pngName, png]]) artifacts[file] = { file, sha256: sha256(bytes) };
+  }
+  const report = { ...plan, base: projection(plan.base, ["revision", "scope"]), head: projection(plan.head, ["revision", "scope"]),
+    status: "complete", viewport, artifacts, validation: { ...plan.validation, renderedReadability: true, targetDimensions: true, semanticClaims: false, runtimeBehavior: false } };
+  const prose = Buffer.from(markdown(report));
+  await writeExclusive(join(directory, "changes.md"), prose);
+  artifacts["changes.md"] = { file: "changes.md", sha256: sha256(prose) };
+  const pending = join(directory, "comparison.pending.json"), reportPath = join(directory, "comparison.json");
+  const bytes = Buffer.from(`${JSON.stringify(report, null, 2)}\n`);
+  await writeExclusive(pending, bytes);
+  await fs.link(pending, reportPath);
+  await fs.unlink(pending);
+  const handle = await fs.open(directory, "r");
+  try { await handle.sync(); } finally { await handle.close(); }
+  return { reportPath, sha256: sha256(bytes), report };
+}

--- a/src/render.js
+++ b/src/render.js
@@ -6,12 +6,13 @@ import { randomBytes } from 'node:crypto';
 import { chromium } from 'playwright';
 const assets = resolve(dirname(fileURLToPath(import.meta.url)), '../dist/preview');
 const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="color-scheme" content="light"><title>Diagram review · Excalidraw Toolkit</title><link rel="stylesheet" href="./assets/preview.css"></head><body><div id="app"><p class="boot-message" role="status">Opening your diagram…</p></div><script type="module" src="./assets/preview.js"></script></body></html>`;
-export async function servePreview(scene, { port = 0, title, beforeScene, changes } = {}) {
+export async function servePreview(scene, { port = 0, title, beforeScene, changes, review, previewPngs } = {}) {
   if (!existsSync(resolve(assets, 'preview.js'))) throw new Error('PREVIEW_BUILD_MISSING: reinstall the packed toolkit or run npm run build');
   const token = randomBytes(18).toString('hex');
   const prefix = `/${token}/`;
   const bytes = JSON.stringify(scene);
-  const context = JSON.stringify({ title: typeof title === 'string' ? title : null, beforeScene: beforeScene ?? null, changes: Array.isArray(changes) ? changes : null });
+  const retainedPngs = Object.fromEntries(Object.entries(previewPngs ?? {}).filter(([view, png]) => ['before', 'after', 'proposal'].includes(view) && Buffer.isBuffer(png)).map(([view, png]) => [view, Buffer.from(png)]));
+  const context = JSON.stringify({ title: typeof title === 'string' ? title : null, beforeScene: beforeScene ?? null, changes: Array.isArray(changes) ? changes : null, review: review ?? null, retainedPngViews: Object.keys(retainedPngs) });
   const server = createServer((req, res) => {
     const pathname = new URL(req.url, 'http://127.0.0.1').pathname;
     res.setHeader('Cache-Control', 'no-store');
@@ -21,6 +22,8 @@ export async function servePreview(scene, { port = 0, title, beforeScene, change
     if (!resource) { res.setHeader('Content-Type', 'text/html'); res.end(html); return; }
     if (resource === 'scene') { res.setHeader('Content-Type', 'application/json'); res.end(bytes); return; }
     if (resource === 'context') { res.setHeader('Content-Type', 'application/json'); res.end(context); return; }
+    const pngView = /^exports\/(before|after|proposal)\.png$/.exec(resource)?.[1];
+    if (pngView && retainedPngs[pngView]) { res.setHeader('Content-Type', 'image/png'); res.end(retainedPngs[pngView]); return; }
     const file = resolve(assets, resource.replace(/^assets\//, ''));
     if (!resource.startsWith('assets/') || !file.startsWith(assets + '/') || !existsSync(file)) { res.writeHead(404); res.end(); return; }
     const mime = { '.js': 'text/javascript', '.css': 'text/css', '.woff2': 'font/woff2', '.woff': 'font/woff', '.ttf': 'font/ttf' }[extname(file)] || 'application/octet-stream';

--- a/src/review-receipts.js
+++ b/src/review-receipts.js
@@ -1,0 +1,79 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+import { sha256, validateScene } from './scene.js';
+
+const HASH = /^[a-f0-9]{64}$/;
+const fail = message => { throw Object.assign(new Error(message), { code: 'CORRUPT_REVIEW' }); };
+
+async function readReport(path, expectedHash) {
+  const bytes = await fs.readFile(path);
+  if (expectedHash !== undefined && (!HASH.test(expectedHash) || sha256(bytes) !== expectedHash)) fail('Review receipt differs from its retained hash');
+  let report;
+  try { report = JSON.parse(bytes.toString()); } catch { fail('Review receipt contains invalid JSON'); }
+  return { report, hash: sha256(bytes) };
+}
+
+async function artifact(directory, entry, name, native = false) {
+  if (entry?.file !== name || !HASH.test(entry.sha256 ?? '')) fail(`Invalid retained artifact: ${name}`);
+  const path = join(directory, name);
+  let bytes;
+  try {
+    if (!(await fs.lstat(path)).isFile()) fail(`Artifact must be a regular file: ${name}`);
+    bytes = await fs.readFile(path);
+  } catch { fail(`Cannot read retained artifact: ${name}`); }
+  if (sha256(bytes) !== entry.sha256) fail(`Retained artifact changed: ${name}`);
+  if (native) {
+    let scene;
+    try { scene = JSON.parse(bytes.toString()); validateScene(scene); } catch { fail(`Invalid native artifact: ${name}`); }
+    return { bytes, scene };
+  }
+  return { bytes };
+}
+
+export async function readComparisonReview(receiptPath, { expectedHash } = {}) {
+  const path = resolve(receiptPath);
+  const directory = dirname(path);
+  const { report, hash } = await readReport(path, expectedHash);
+  if (report?.schemaVersion !== 1 || report.status !== 'complete' || !report.inputs?.base || !report.inputs?.head || !report.artifacts) fail('Expected a completed source comparison receipt');
+  const before = await artifact(directory, report.artifacts['before.excalidraw'], 'before.excalidraw', true);
+  const after = await artifact(directory, report.artifacts['after.excalidraw'], 'after.excalidraw', true);
+  const previewPngs = {};
+  for (const name of ['before.png', 'after.png']) {
+    const { bytes } = await artifact(directory, report.artifacts[name], name);
+    if (bytes.length < 33 || bytes.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a' ||
+        bytes.readUInt32BE(16) !== report.target?.width || bytes.readUInt32BE(20) !== report.target?.height) fail('Retained PNG does not match the declared comparison dimensions');
+    previewPngs[name.slice(0, -4)] = bytes;
+  }
+  await artifact(directory, report.artifacts['changes.md'], 'changes.md');
+  const { readEvidenceBundle } = await import('./evidence.js');
+  const source = await readEvidenceBundle(report.inputs.base.bundlePath, { expectedHash: report.inputs.base.evidenceHash });
+  const { loadComparison } = await import('./explain.js');
+  const plan = await loadComparison({ repositoryPath: source.bundle.evidence.repositoryPath,
+    base: { bundlePath: report.inputs.base.bundlePath, expectedHash: report.inputs.base.evidenceHash, revision: report.base?.revision },
+    head: { bundlePath: report.inputs.head.bundlePath, expectedHash: report.inputs.head.evidenceHash, revision: report.head?.revision },
+    target: report.target, required: report.required, repositoryUrl: report.repositoryUrl });
+  // Source claims, labels and change kinds come from a freshly checked native
+  // comparison. Never display edited report metadata as a verified result.
+  if (!isDeepStrictEqual(plan.changes, report.changes) || !isDeepStrictEqual(plan.base.scope, report.base.scope) ||
+      !isDeepStrictEqual(plan.head.scope, report.head.scope) || !isDeepStrictEqual(before.scene, plan.base.scene) ||
+      !isDeepStrictEqual(after.scene, plan.head.scene) || sha256(before.bytes) !== plan.inputs.base.sha256 || sha256(after.bytes) !== plan.inputs.head.sha256) {
+    fail('Comparison claims, source scope or native identity differ from the checked evidence');
+  }
+  for (const side of ['base', 'head']) {
+    if (report.inputs[side].sha256 !== plan.inputs[side].sha256 || report.inputs[side].inputPath !== plan.inputs[side].inputPath) fail('Comparison input identity was changed');
+  }
+  const sides = {};
+  for (const [view, side] of [['before', 'base'], ['after', 'head']]) {
+    const itemKey = view;
+    const nodes = new Map(plan.changes.nodes.map(change => change[itemKey]).filter(Boolean).map(node => [node.semanticId, node.label || node.semanticId]));
+    sides[view] = { revision: plan[side].revision, scope: plan[side].scope,
+      relations: plan.changes.relations.filter(change => change[itemKey]).map(change => {
+        const relation = change[itemKey];
+        return { status: change.status, from: nodes.get(relation.from), to: nodes.get(relation.to), kind: relation.kind,
+          claim: relation.claim, sources: relation.sources.map(({ url, path, startLine, endLine }) => ({ url, path, startLine, endLine })) };
+      }) };
+  }
+  return { scene: after.scene, beforeScene: before.scene, previewPngs,
+    review: { kind: 'source-comparison', receiptHash: hash, title: 'Source comparison', viewLabels: { before: 'Before', after: 'After' }, sides } };
+}

--- a/src/target-render.js
+++ b/src/target-render.js
@@ -1,0 +1,65 @@
+import { promises as fs } from "node:fs";
+import { chromium } from "playwright";
+import { servePreview } from "./render.js";
+
+function fail(code, message) { throw Object.assign(new Error(message), { code }); }
+
+async function nativePage(scene, action, argument) {
+  const preview = await servePreview(structuredClone(scene));
+  let browser;
+  try {
+    browser = await chromium.launch();
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
+    const origin = new URL(preview.url).origin;
+    const failures = new Set();
+    page.on("requestfailed", request => { if (!request.url().endsWith("/favicon.ico")) failures.add(request.url()); });
+    page.on("response", response => { if (response.status() >= 400 && !response.url().endsWith("/favicon.ico")) failures.add(response.url()); });
+    await page.route("**/*", route => route.request().url().startsWith(`${origin}/`) || /^(data|blob):/.test(route.request().url()) ? route.continue() : route.abort());
+    await page.goto(preview.url);
+    await page.waitForFunction(() => window.previewReady || window.previewError, { timeout: 20000 });
+    const error = await page.evaluate(() => window.previewError);
+    if (error) fail("NATIVE_PREVIEW_FAILED", error);
+    if (!await page.evaluate(name => typeof window[name] === "function", action)) {
+      fail("TARGET_BUILD_MISSING", "The preview assets do not include the native target renderer; rebuild the preview bundle");
+    }
+    const result = await page.evaluate(async ({ action, scene, argument }) => {
+      let timeout;
+      try {
+        const value = await Promise.race([window[action](scene, argument), new Promise((_, reject) => {
+          timeout = setTimeout(() => reject(new Error("NATIVE_RENDER_TIMEOUT: native target preparation exceeded 30 seconds")), 30000);
+        })]);
+        return { value };
+      }
+      catch (error) { return { error: error.message }; }
+      finally { clearTimeout(timeout); }
+    }, { action, scene, argument });
+    if (failures.size) fail("NATIVE_ASSET_FAILED", `${failures.size} preview assets failed or attempted external access`);
+    if (result.error) {
+      const match = /^([A-Z][A-Z_]+):\s*(.*)$/s.exec(result.error);
+      fail(match?.[1] ?? "NATIVE_RENDER_FAILED", match?.[2] ?? result.error);
+    }
+    return { value: result.value, browser: browser.version() };
+  } finally {
+    if (browser) await browser.close();
+    await preview.close();
+  }
+}
+
+export async function measureScene(scene) {
+  return (await nativePage(scene, "measureScene")).value;
+}
+
+export async function renderScene(scene, outputPath, viewport) {
+  if (!viewport || ![viewport.width, viewport.height].every(value => Number.isSafeInteger(value) && value > 0 && value <= 8192) ||
+    ![viewport.scale, viewport.offsetX, viewport.offsetY].every(Number.isFinite) || viewport.scale <= 0 || viewport.scale > 1) {
+    fail("INVALID_TARGET", "Native target rendering requires exact pixel dimensions and a finite affine transform with 0 < scale <= 1");
+  }
+  const result = await nativePage(scene, "renderTargetPng", viewport);
+  if (typeof result.value !== "string" || !result.value.startsWith("data:image/png;base64,")) fail("INVALID_RENDER", "Native export did not return a PNG");
+  const png = Buffer.from(result.value.split(",")[1], "base64");
+  if (png.length < 33 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a" ||
+    png.readUInt32BE(16) !== viewport.width || png.readUInt32BE(20) !== viewport.height) fail("INVALID_RENDER", "Native PNG dimensions do not match the target");
+  const handle = await fs.open(outputPath, "wx", 0o600);
+  try { await handle.writeFile(png); await handle.sync(); } finally { await handle.close(); }
+  return { renderer: "@excalidraw/excalidraw@0.18.1", browser: result.browser };
+}

--- a/src/web/ReceiptDetails.jsx
+++ b/src/web/ReceiptDetails.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import './receipt-details.css';
+
+export function ReceiptDetails({ review, view }) {
+  if (!review) return null;
+  const side = review.sides[view];
+  return <div className="receipt-details">
+    <section className="sidebar-section">
+      <div className="section-heading"><h2>Source context</h2><span>{review.viewLabels[view]}</span></div>
+      <p className="receipt-question">{side.scope.question}</p>
+      <p className="receipt-revision">Revision <code title={side.revision}>{side.revision.slice(0, 10)}</code></p>
+      <p className="sidebar-note">A scoped view of the inspected source. Runtime behavior has not been verified.</p>
+    </section>
+    <section className="sidebar-section">
+      <div className="section-heading"><h2>Relationships</h2><span>{side.relations.length}</span></div>
+      <ul className="receipt-relations">{side.relations.map((relation, index) => <li key={index}>
+        <div className="receipt-relation-heading"><strong>{relation.from} → {relation.to}</strong><span className={`receipt-status is-${relation.status}`}>{relation.status}</span></div>
+        <p>{relation.claim}</p>
+        <span className="receipt-kind">{relation.kind === 'assumption' ? 'Assumption · unverified' : relation.kind === 'import' ? 'Import · not a runtime call' : 'Source-cited call'}</span>
+        {relation.sources.length > 0 && <ul className="receipt-sources">{relation.sources.map((source, i) => <li key={i}><a href={source.url} target="_blank" rel="noopener noreferrer">{source.path}:{source.startLine}–{source.endLine} <span aria-hidden="true">↗</span></a></li>)}</ul>}
+      </li>)}</ul>
+    </section>
+    <section className="sidebar-section">
+      <div className="section-heading"><h2>Scope & unknowns</h2></div>
+      <p className="sidebar-note">Partial analysis · {side.scope.paths.join(', ')}</p>
+      <ul className="receipt-unknowns">{side.scope.unknowns.map((unknown, index) => <li key={index}>{unknown}</li>)}</ul>
+    </section>
+  </div>;
+}

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -1,10 +1,11 @@
 import {measureLabel} from "./text.js";
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Excalidraw, exportToCanvas } from '@excalidraw/excalidraw';
+import { Excalidraw, exportToCanvas, exportToSvg, restoreElements, getCommonBounds, convertToExcalidrawElements, FONT_FAMILY } from '@excalidraw/excalidraw';
 import '@excalidraw/excalidraw/index.css';
 import './preview.css';
 import { elementLabel, summarizeEdits, formatTechnicalChanges, displayValue } from './edit-summary.js';
+import { ReceiptDetails } from './ReceiptDetails.jsx';
 
 window.EXCALIDRAW_ASSET_PATH = new URL('./assets/', window.location.href).href;
 let activeScene;
@@ -18,6 +19,105 @@ async function png() {
 window.renderPng = png;
 window.measureLabel = measureLabel;
 window.sceneForPreview = () => structuredClone(activeScene);
+
+// PR targets operate on render copies. Native SVG supplies the same baseline,
+// alignment and rotation as canvas export; CanvasTextMetrics supplies glyph ink.
+function targetElements(scene) {
+  validate(scene);
+  const elements = restoreElements(structuredClone(scene.elements), null).filter(element => !element.isDeleted);
+  if (elements.some(element => ['frame', 'magicframe', 'embeddable', 'iframe'].includes(element.type))) {
+    throw new Error('UNSUPPORTED_TARGET_SCENE: frames and live embeds need a separately qualified output view');
+  }
+  for (const element of elements.filter(element => element.type === 'text')) {
+    if (![1, 3, 5, 6, 7, 8, 9].includes(element.fontFamily)) throw new Error('UNSUPPORTED_FONT: target export requires a bundled font');
+    if (/[\p{Script=Hebrew}\p{Script=Arabic}]/u.test(element.text)) throw new Error('UNSUPPORTED_FONT_TEXT: RTL target text has not been qualified');
+    if (/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(element.text) && element.fontFamily !== 5) {
+      throw new Error('UNSUPPORTED_FONT_TEXT: CJK target labels require bundled Excalifont with Xiaolai fallback');
+    }
+  }
+  return elements;
+}
+function targetAppState(scene) {
+  return { ...scene.appState, exportWithDarkMode: false, exportScale: 1,
+    frameRendering: { enabled: false, outline: false, name: false, clip: false } };
+}
+async function loadTargetFonts(elements, scene) {
+  await exportToCanvas({ elements, files: structuredClone(scene.files || {}), appState: targetAppState(scene), exportPadding: 0,
+    getDimensions: () => ({ width: 1, height: 1, scale: 1 }) });
+  for (const element of elements.filter(element => element.type === 'text' && element.text.trim())) {
+    const family = Object.entries(FONT_FAMILY).find(([, id]) => id === element.fontFamily)[0];
+    const font = `${element.fontSize}px "${family}"${element.fontFamily === 5 ? ', "Xiaolai"' : ''}, "Segoe UI Emoji"`;
+    const faces = await document.fonts.load(font, element.text);
+    if (!faces.length || faces.some(face => face.status !== 'loaded') || !document.fonts.check(font, element.text)) throw new Error('FONT_UNAVAILABLE: a requested native font did not load');
+  }
+  await document.fonts.ready;
+}
+window.measureScene = async scene => {
+  const elements = targetElements(scene);
+  if (!elements.length) throw new Error('INVALID_RENDER_METRICS: a target scene must contain visible content');
+  await loadTargetFonts(elements, scene);
+  const [minX, minY, maxX, maxY] = getCommonBounds(elements);
+  const marker = 'https://toolkit.invalid/native-element/';
+  const tagged = elements.map(element => ({ ...element, link: `${marker}${encodeURIComponent(element.id)}` }));
+  const svg = await exportToSvg({ elements: tagged, files: structuredClone(scene.files || {}), appState: targetAppState(scene),
+    exportPadding: 0, skipInliningFonts: true });
+  svg.style.cssText = 'position:fixed;left:-100000px;top:0;visibility:hidden;pointer-events:none;';
+  document.body.appendChild(svg);
+  try {
+    const inverse = svg.getScreenCTM().inverse();
+    const canvas = document.createElement('canvas'), context = canvas.getContext('2d');
+    const index = new Map(elements.map(element => [element.id, element]));
+    const visibleElementIds = [], text = [];
+    for (const anchor of svg.querySelectorAll('a[href]')) {
+      const href = anchor.getAttribute('href');
+      if (!href.startsWith(marker)) continue;
+      const id = decodeURIComponent(href.slice(marker.length)), element = index.get(id);
+      if (!element || element.opacity === 0) continue;
+      visibleElementIds.push(id);
+      if (element.type !== 'text' || !element.text.trim()) continue;
+      const points = [];
+      for (const line of anchor.querySelectorAll('text')) {
+        const fontSize = Number.parseFloat(line.getAttribute('font-size'));
+        context.font = `${fontSize}px ${line.getAttribute('font-family')}`;
+        context.textAlign = ({ middle: 'center', end: 'right', start: 'left' })[line.getAttribute('text-anchor')] || 'left';
+        context.textBaseline = 'alphabetic';
+        context.direction = 'ltr';
+        const metrics = context.measureText(line.textContent);
+        if (![metrics.actualBoundingBoxLeft, metrics.actualBoundingBoxRight, metrics.actualBoundingBoxAscent, metrics.actualBoundingBoxDescent].every(Number.isFinite)) {
+          throw new Error('INVALID_RENDER_METRICS: this browser does not expose actual glyph bounds');
+        }
+        const x = Number(line.getAttribute('x')), y = Number(line.getAttribute('y'));
+        const matrix = inverse.multiply(line.getScreenCTM());
+        for (const [px, py] of [[x - metrics.actualBoundingBoxLeft, y - metrics.actualBoundingBoxAscent], [x + metrics.actualBoundingBoxRight, y - metrics.actualBoundingBoxAscent],
+          [x - metrics.actualBoundingBoxLeft, y + metrics.actualBoundingBoxDescent], [x + metrics.actualBoundingBoxRight, y + metrics.actualBoundingBoxDescent]]) {
+          const point = new DOMPoint(px, py).matrixTransform(matrix);
+          points.push({ x: point.x + minX, y: point.y + minY });
+        }
+      }
+      if (!points.length) throw new Error('INVALID_RENDER_METRICS: native SVG omitted a visible label');
+      const x = Math.min(...points.map(point => point.x)), y = Math.min(...points.map(point => point.y));
+      text.push({ id, fontSize: element.fontSize, x, y, width: Math.max(...points.map(point => point.x)) - x, height: Math.max(...points.map(point => point.y)) - y });
+    }
+    return { renderer: '@excalidraw/excalidraw@0.18.1', fontsLoaded: true,
+      bounds: { x: minX, y: minY, width: maxX - minX, height: maxY - minY }, visibleElementIds, text };
+  } finally { svg.remove(); }
+};
+window.renderTargetPng = async (scene, viewport) => {
+  const elements = targetElements(scene);
+  await loadTargetFonts(elements, scene);
+  const { width, height, scale, offsetX, offsetY } = viewport;
+  // The invisible anchor sets native export's scene origin. It exists only in
+  // this copy and avoids rendering twice or resampling an intermediate bitmap.
+  const anchor = convertToExcalidrawElements([{ type: 'rectangle', id: crypto.randomUUID(), x: -offsetX / scale, y: -offsetY / scale,
+    width: width / scale, height: height / scale, angle: 0, opacity: 0, strokeColor: 'transparent', backgroundColor: 'transparent' }]);
+  const canvas = await exportToCanvas({ elements: [...elements, ...anchor], files: structuredClone(scene.files || {}),
+    appState: { ...targetAppState(scene), exportBackground: true }, exportPadding: 0,
+    getDimensions: (nativeWidth, nativeHeight) => {
+      if (Math.abs(nativeWidth * scale - width) > 0.01 || Math.abs(nativeHeight * scale - height) > 0.01) throw new Error('TARGET_CLIPPING: the target viewport does not contain the native scene');
+      return { width, height, scale };
+    } });
+  return canvas.toDataURL('image/png');
+};
 
 function Icon({ name, size = 18 }) {
   const paths = {
@@ -120,7 +220,17 @@ function Review() {
   function selectView(next) { if (view !== next) { resetReadiness(); setError(''); setNotice(''); setView(next); } }
   async function exportPng() {
     setExporting(true); setError('');
-    try { download(await png(), `${filename}${context.beforeScene ? `-${view}` : ''}.png`); setNotice('PNG download started.'); }
+    try {
+      let url;
+      if (context.retainedPngViews?.includes(view)) {
+        const response = await fetch(`./exports/${view}.png`);
+        if (!response.ok) throw new Error('The retained PNG is unavailable. Reopen the receipt and try again.');
+        url = URL.createObjectURL(await response.blob());
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+      } else url = await png();
+      download(url, `${filename}${context.beforeScene ? `-${view}` : ''}.png`);
+      setNotice('PNG download started.');
+    }
     catch (error) { setError(`PNG export failed: ${error.message}`); }
     finally { setExporting(false); }
   }
@@ -148,15 +258,17 @@ function Review() {
       <aside id="scene-details" className="review-sidebar" data-open={detailsOpen} aria-label="Diagram details">
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
         <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
+        {context.review ? <ReceiptDetails review={context.review} view={view} /> : <>
         <EditSummary changes={changes} summary={summary} key={revision} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
         </section>
         {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
+        </>}
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>Review a copy. Keep your original.</span></div>
       </aside>
       <main id="diagram-workspace" className="diagram-workspace" tabIndex={-1}>
-        <div className="workspace-heading"><div><p className="eyebrow">{context.beforeScene ? 'Compare & review' : 'Your diagram'}</p><h1>{title}</h1><p className="workspace-description">{context.beforeScene ? 'A clear view of what changed, with the original close at hand.' : 'Explore the details. Take the editable file with you.'}</p></div><span className="review-badge"><span />Read-only preview</span></div>
+        <div className="workspace-heading"><div><p className="eyebrow">{context.beforeScene ? 'Compare & review' : 'Your diagram'}</p><h1>{title}</h1><p className="workspace-description">{context.review ? 'Trace each relationship to its source, and see what changed.' : context.beforeScene ? 'A clear view of what changed, with the original close at hand.' : 'Explore the details. Take the editable file with you.'}</p></div><span className="review-badge"><span />Read-only preview</span></div>
         {error && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{error}</span>{scene && <button aria-label="Dismiss error" onClick={() => setError('')}>×</button>}</div>}
         <div className="canvas-card">
           <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{context.beforeScene ? (view === 'after' ? 'Updated diagram' : 'Original diagram') : 'Canvas'}</span></div>

--- a/src/web/receipt-details.css
+++ b/src/web/receipt-details.css
@@ -1,0 +1,18 @@
+.receipt-details { margin-top: 2px; }
+.receipt-question { margin: 0 0 12px; font-family: Georgia, serif; font-size: 16px; line-height: 1.45; color: #554d40; }
+.receipt-revision { margin: 0 0 12px; font-size: 11px; color: #7b7265; }
+.receipt-revision code { font-size: 10px; background: #efebe1; border-radius: 4px; padding: 3px 5px; }
+.receipt-relations, .receipt-sources { list-style: none; padding: 0; margin: 0; }
+.receipt-relations { display: grid; gap: 20px; }
+.receipt-relation-heading { display: flex; align-items: start; justify-content: space-between; gap: 7px; }
+.receipt-relation-heading strong { font-size: 12px; line-height: 1.45; font-weight: 550; color: #5d5141; }
+.receipt-status { font-size: 9px; padding: 3px 5px; border-radius: 4px; background: #eeebe3; color: #796e5c; text-transform: capitalize; }
+.receipt-status.is-added { background: #e9eddf; color: #5d6c46; }
+.receipt-status.is-removed { background: #f2e5dd; color: #94674e; }
+.receipt-relations p { font-size: 12px; line-height: 1.6; color: #746a5a; margin: 8px 0; }
+.receipt-kind { display: block; font-size: 10px; color: #8b806f; line-height: 1.5; margin-bottom: 8px; }
+.receipt-sources { display: grid; gap: 5px; }
+.receipt-sources a { color: #9b6244; font-size: 11px; text-decoration-color: #cfb49f; text-underline-offset: 3px; overflow-wrap: anywhere; }
+.receipt-sources a:hover { color: #6f452f; }
+.receipt-unknowns { padding-left: 16px; margin: 11px 0 0; color: #7b715f; font-size: 11px; line-height: 1.65; }
+.receipt-unknowns li + li { margin-top: 8px; }

--- a/src/workflow-commands.js
+++ b/src/workflow-commands.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline']);
+export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline', 'explain-change']);
 const fail = (code, message) => { throw Object.assign(new Error(message), { code }); };
 
 async function readRequest(requestPath) {
@@ -35,9 +35,20 @@ function requestOptions(request, directory, values, allowed, pathFields) {
 
 /** JSON command boundary. It returns data; the CLI owns printing and exit codes.
  * Filesystem paths in requests are relative to the request file, not shell cwd. */
-export async function workflowCommand(command, requestPath, values = {}) {
+export async function workflowCommand(command, requestPath, values = {}, dependencies = {}) {
   if (!WORKFLOW_COMMANDS.includes(command)) fail('UNKNOWN_COMMAND', `Unknown workflow command: ${command}`);
   const { request, directory } = await readRequest(requestPath);
+  if (command === 'explain-change') {
+    const options = requestOptions(request, directory, values,
+      ['repositoryPath', 'base', 'head', 'target', 'required', 'repositoryUrl', 'outputDir'], ['repositoryPath', 'outputDir']);
+    for (const side of ['base', 'head']) {
+      if (!options[side] || typeof options[side] !== 'object' || Array.isArray(options[side])) fail('INVALID_REQUEST', `Provide the ${side} evidence bundle and revision`);
+      options[side] = requestOptions(options[side], directory, {}, ['bundlePath', 'revision', 'expectedHash'], ['bundlePath']);
+    }
+    const { exportComparison } = await import('./explain.js');
+    const renderer = dependencies.targetRenderer ?? await import('./target-render.js');
+    return exportComparison(options, renderer);
+  }
   const paths = ['repositoryPath', 'inputPath'];
   const allowed = [...paths, 'evidence'];
   if (command !== 'validate-evidence') { paths.push('outputDir'); allowed.push('outputDir'); }

--- a/test/explain.test.js
+++ b/test/explain.test.js
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { chromium } from "playwright";
+import { servePreview } from "../src/render.js";
+import { sha256 } from "../src/scene.js";
+import { readComparisonReview } from "../src/review-receipts.js";
+import { associateEvidence, readEvidenceBundle } from "../src/evidence.js";
+import { checkReadability, exportComparison, loadComparison, OUTPUT_TARGETS, planComparison } from "../src/explain.js";
+
+const exec = promisify(execFile);
+const repositoryUrl = "https://github.com/example/request-flow";
+function scene(queued = false) {
+  const elements = [];
+  for (const [id, x, text] of [["api", 40, "API"], ...(queued ? [["queue", 370, "Queue"]] : []), ["worker", 700, "Worker"]]) {
+    elements.push({ id, type: "rectangle", x, y: 40, width: 180, height: 80, angle: 0, boundElements: [{ id: `${id}-label`, type: "text" }] },
+      { id: `${id}-label`, type: "text", x: x + 20, y: 60, width: 120, height: 35, fontSize: 28, fontFamily: 5, lineHeight: 1.25,
+        text, originalText: text, angle: 0, containerId: id });
+  }
+  for (const [id, from, to] of queued ? [["enqueue", "api", "queue"], ["consume", "queue", "worker"]] : [["direct", "api", "worker"]]) {
+    const a = elements.find(element => element.id === from), b = elements.find(element => element.id === to);
+    a.boundElements.push({ id, type: "arrow" }); b.boundElements.push({ id, type: "arrow" });
+    elements.push({ id, type: "arrow", x: a.x + a.width, y: 80, width: b.x - a.x - a.width, height: 0, angle: 0,
+      points: [[0, 0], [b.x - a.x - a.width, 0]], startBinding: { elementId: from }, endBinding: { elementId: to } });
+    if (id === "consume") {
+      elements.at(-1).boundElements = [{ id: "consume-label", type: "text" }];
+      elements.push({ id: "consume-label", type: "text", x: 520, y: 135, width: 360, height: 35, fontSize: 28, fontFamily: 5, lineHeight: 1.25,
+        text: "Assumption: delivery", containerId: "consume" });
+    }
+  }
+  elements.push({ id: "note", type: "text", x: 40, y: 180, width: 600, height: 35, fontSize: 28, fontFamily: 5, lineHeight: 1.25,
+    text: "Runtime execution has not been observed.", customData: { manual: true } });
+  return { type: "excalidraw", version: 2, elements, files: {}, appState: { viewBackgroundColor: "#faf9f5" }, customTopLevel: "preserve" };
+}
+function proposal(revision, queued) {
+  return { schemaVersion: 1, source: { kind: "git", revision },
+    scope: { question: "How does the handler reach the worker?", paths: ["src"], coverage: "partial", unknowns: ["Runtime delivery and retry behavior were not observed."] },
+    references: [
+      { id: "handler", path: "src/api.js", startLine: 2, endLine: 2, symbol: "handle" },
+      { id: "worker", path: "src/worker.js", startLine: 1, endLine: 1, symbol: "run" },
+      ...(queued ? [{ id: "queue", path: "src/queue.js", startLine: 1, endLine: 1, symbol: "enqueue" }] : []),
+    ],
+    nodes: [
+      { semanticId: "request:api", elementId: "api", referenceIds: ["handler"] },
+      { semanticId: "request:worker", elementId: "worker", referenceIds: ["worker"] },
+      ...(queued ? [{ semanticId: "request:queue", elementId: "queue", referenceIds: ["queue"] }] : []),
+    ],
+    relations: queued ? [
+      { semanticId: "request:enqueue", elementId: "enqueue", from: "request:api", to: "request:queue", kind: "call", claim: "handle contains enqueue(input).", referenceIds: ["handler"] },
+      { semanticId: "request:consume", elementId: "consume", from: "request:queue", to: "request:worker", kind: "assumption", claim: "An external consumer delivers queued jobs to run; runtime wiring is unresolved.", referenceIds: [] },
+    ] : [{ semanticId: "request:direct", elementId: "direct", from: "request:api", to: "request:worker", kind: "call", claim: "handle contains run(input).", referenceIds: ["handler"] }],
+  };
+}
+async function fixture(t) {
+  const root = await fs.mkdtemp(join(tmpdir(), "toolkit explain "));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const repositoryPath = join(root, "repository");
+  await fs.mkdir(join(repositoryPath, "src"), { recursive: true });
+  const git = async (...args) => (await exec("git", ["-C", repositoryPath, ...args])).stdout.trim();
+  const commit = async message => {
+    await git("add", "src");
+    await git("-c", "user.name=Comparison fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgSign=false", "commit", "-m", message);
+    return git("rev-parse", "HEAD");
+  };
+  await git("init", "-b", "main");
+  await fs.writeFile(join(repositoryPath, "src/api.js"), 'import { run } from "./worker.js";\nexport function handle(input) { return run(input); }\n');
+  await fs.writeFile(join(repositoryPath, "src/worker.js"), "export function run(input) { return input; }\n");
+  const baseRevision = await commit("test: add direct call fixture");
+  const save = async (revision, queued) => {
+    const inputPath = join(root, queued ? "head.excalidraw" : "base.excalidraw");
+    await fs.writeFile(inputPath, `${JSON.stringify(scene(queued), null, 4)}\n\n`);
+    const saved = await associateEvidence({ repositoryPath, inputPath, evidence: proposal(revision, queued), outputDir: join(root, queued ? "head-bundle" : "base-bundle") });
+    return { bundlePath: saved.bundlePath, expectedHash: saved.sha256, revision };
+  };
+  const base = await save(baseRevision, false);
+  await fs.writeFile(join(repositoryPath, "src/api.js"), 'import { enqueue } from "./queue.js";\nexport function handle(input) { return enqueue(input); }\n');
+  await fs.writeFile(join(repositoryPath, "src/queue.js"), "export function enqueue(input) { return pending.push(input); }\n");
+  const headRevision = await commit("test: add queue fixture");
+  const head = await save(headRevision, true);
+  const required = { base: { nodes: ["request:api", "request:worker"], relations: ["request:direct"] },
+    head: { nodes: ["request:api", "request:queue", "request:worker"], relations: ["request:enqueue", "request:consume"] } };
+  return { root, git, repositoryPath, repositoryUrl, base, head, required, target: "article", outputDir: join(root, "comparison") };
+}
+// Contract doubles exercise export orchestration. They do not qualify the native
+// font renderer; actual rendering is covered by the renderer integration gate.
+function measureScene(document) {
+  return { renderer: "@excalidraw/excalidraw@test-contract", fontsLoaded: true, bounds: { x: 40, y: 40, width: 840, height: 175 },
+    visibleElementIds: document.elements.filter(element => !element.isDeleted && element.opacity !== 0).map(element => element.id),
+    text: document.elements.filter(element => element.type === "text").map(element => ({ id: element.id, x: element.x, y: element.y, width: element.width, height: element.height, fontSize: element.fontSize })) };
+}
+async function renderScene(document, path, viewport) {
+  const png = Buffer.alloc(33);
+  Buffer.from("89504e470d0a1a0a", "hex").copy(png);
+  png.writeUInt32BE(13, 8); png.write("IHDR", 12); png.writeUInt32BE(viewport.width, 16); png.writeUInt32BE(viewport.height, 20);
+  await fs.writeFile(path, png, { flag: "wx" });
+}
+
+test("direct call becomes an evidenced queue path with explicit required content and revision-specific links", async t => {
+  const f = await fixture(t);
+  await fs.writeFile(join(f.repositoryPath, "src/api.js"), "dirty checkout must not change either citation\n");
+  const plan = await loadComparison({ ...f, base: { ...f.base, revision: "HEAD~1" }, head: { ...f.head, revision: "HEAD" } });
+  assert.equal(plan.base.revision, f.base.revision); assert.equal(plan.head.revision, f.head.revision);
+  assert.deepEqual(plan.changes.nodes.map(({ semanticId, status }) => [semanticId, status]), [
+    ["request:api", "changed"], ["request:queue", "added"], ["request:worker", "unchanged"],
+  ]);
+  assert.deepEqual(plan.changes.relations.map(({ semanticId, status }) => [semanticId, status]), [
+    ["request:consume", "added"], ["request:direct", "removed"], ["request:enqueue", "added"],
+  ]);
+  for (const change of [...plan.changes.nodes, ...plan.changes.relations]) {
+    for (const [side, item] of [["base", change.before], ["head", change.after]]) {
+      if (!item) continue;
+      assert.equal(item.semanticClaimsVerified, false); assert.equal(item.runtimeBehaviorVerified, false);
+      for (const reference of item.sources) assert.ok(reference.url.includes(`/blob/${f[side].revision}/`));
+    }
+  }
+  assert.equal(plan.changes.relations.find(item => item.semanticId === "request:consume").after.certainty, "assumption");
+  assert.equal(plan.changes.relations.find(item => item.semanticId === "request:enqueue").after.certainty, "source-cited");
+  assert.deepEqual(plan.base.scene.elements.find(item => item.id === "note"), plan.head.scene.elements.find(item => item.id === "note"));
+  const missing = structuredClone(f.required); missing.head.relations.push("request:lost");
+  await assert.rejects(loadComparison({ ...f, required: missing }), { code: "MISSING_REQUIRED" });
+});
+
+test("exact commit identity is required even when selected source files are unchanged", async t => {
+  const f = await fixture(t);
+  await f.git("-c", "user.name=Comparison fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgSign=false", "commit", "--allow-empty", "-m", "test: advance unrelated revision");
+  await assert.rejects(loadComparison({ ...f, head: { ...f.head, revision: "HEAD" } }), { code: "REVISION_MISMATCH" });
+  const retained = JSON.parse(await fs.readFile(f.head.bundlePath, "utf8"));
+  retained.evidence.references[0].excerpt = "fabricated excerpt";
+  await fs.writeFile(f.head.bundlePath, JSON.stringify(retained));
+  await assert.rejects(loadComparison({ ...f, head: { ...f.head, expectedHash: undefined } }), { code: "CORRUPT_EVIDENCE" });
+});
+
+test("pure planning reports relation changes and refuses moved unchanged context without editing either scene", async t => {
+  const f = await fixture(t);
+  const base = await readEvidenceBundle(f.base.bundlePath), head = await readEvidenceBundle(f.head.bundlePath);
+  const before = structuredClone({ base, head });
+  planComparison({ ...f, base, head });
+  assert.deepEqual({ base, head }, before);
+  head.deliveredScene.elements.find(item => item.id === "worker").x += 10;
+  assert.throws(() => planComparison({ ...f, base, head }), { code: "UNSTABLE_CONTEXT" });
+  head.deliveredScene.elements.find(item => item.id === "worker").x -= 10;
+  const caption = head.deliveredScene.elements.find(item => item.id === "consume-label");
+  caption.text = "Delivery";
+  assert.throws(() => planComparison({ ...f, base, head }), { code: "UNLABELED_ASSUMPTION" });
+  caption.text = "Assumption: delivery";
+  base.bundle.evidence.relations[0].semanticId = "request:enqueue";
+  const required = structuredClone(f.required); required.base.relations = ["request:enqueue"];
+  const changed = planComparison({ ...f, base, head, required });
+  assert.equal(changed.changes.relations.find(item => item.semanticId === "request:enqueue").status, "changed");
+});
+
+test("shared native glyph bounds determine both output transforms and effective font-size gates", async t => {
+  const f = await fixture(t);
+  const plan = await loadComparison(f);
+  for (const target of Object.keys(OUTPUT_TARGETS)) {
+    const view = checkReadability({ ...plan, target: OUTPUT_TARGETS[target] }, { base: measureScene(plan.base.scene), head: measureScene(plan.head.scene) });
+    assert.equal(view.scale, 1);
+    assert.equal(view.offsetX + (view.bounds.x + view.bounds.width / 2) * view.scale, view.width / 2);
+    assert.equal(view.offsetY + (view.bounds.y + view.bounds.height / 2) * view.scale, view.height / 2);
+    assert.equal(view.minimumEffectiveFontSize, 28);
+  }
+  const measured = { base: measureScene(plan.base.scene), head: measureScene(plan.head.scene) };
+  // Real glyph extents can exceed stale declared element.width; include them.
+  measured.head.text[0].width = 3000;
+  assert.throws(() => checkReadability(plan, measured), { code: "INSUFFICIENT_READABILITY" });
+  measured.head = measureScene(plan.head.scene); measured.head.text.pop();
+  assert.throws(() => checkReadability(plan, measured), { code: "INVALID_RENDER_METRICS" });
+  measured.head = measureScene(plan.head.scene); measured.head.visibleElementIds = measured.head.visibleElementIds.filter(id => id !== "consume");
+  assert.throws(() => checkReadability(plan, measured), { code: "MISSING_REQUIRED" });
+});
+
+test("readability failure writes nothing and never calls the renderer", async t => {
+  const f = await fixture(t);
+  let rendered = false;
+  await assert.rejects(exportComparison({ ...f, target: { name: "narrow article", width: 400, height: 300, padding: 20, minimumFontSize: 18 } }, {
+    measureScene, renderScene() { rendered = true; },
+  }), { code: "INSUFFICIENT_READABILITY" });
+  assert.equal(rendered, false);
+  await assert.rejects(fs.stat(f.outputDir), { code: "ENOENT" });
+});
+
+test("export retains exact native bytes, one affine transform, assumptions, and immutable completion receipts", async t => {
+  const f = await fixture(t);
+  const calls = [];
+  const result = await exportComparison(f, { measureScene, renderScene: async (...args) => { calls.push(structuredClone(args[2])); await renderScene(...args); } });
+  assert.deepEqual(calls[0], calls[1]);
+  for (const [side, name] of [["base", "before"], ["head", "after"]]) {
+    assert.deepEqual(await fs.readFile(join(f.outputDir, `${name}.excalidraw`)), await fs.readFile(join(f.root, `${side}.excalidraw`)));
+  }
+  assert.equal(result.report.validation.renderedReadability, true);
+  assert.equal(result.report.validation.semanticClaims, false); assert.equal(result.report.validation.runtimeBehavior, false);
+  const md = await fs.readFile(join(f.outputDir, "changes.md"), "utf8");
+  assert.match(md, /assumption/); assert.match(md, /source-cited/); assert.ok(md.includes(f.base.revision)); assert.ok(md.includes(f.head.revision));
+  assert.ok(md.includes("request:consume")); assert.ok(md.includes("request:direct")); assert.ok(md.includes("request:enqueue"));
+  await assert.rejects(exportComparison(f, { measureScene, renderScene }), { code: "OUTPUT_EXISTS" });
+});
+
+test("incorrect rendered dimensions never publish a complete comparison", async t => {
+  const f = await fixture(t);
+  await assert.rejects(exportComparison(f, { measureScene, renderScene: (document, path, viewport) => renderScene(document, path, { ...viewport, width: 1 }) }), { code: "INVALID_RENDER" });
+  await assert.rejects(fs.stat(join(f.outputDir, "comparison.json")), { code: "ENOENT" });
+});
+
+
+test("comparison review derives source context and labels from checked evidence", async t => {
+  const f = await fixture(t);
+  const saved = await exportComparison(f, { measureScene, renderScene });
+  const review = await readComparisonReview(saved.reportPath, { expectedHash: saved.sha256 });
+  assert.deepEqual(review.beforeScene, scene(false));
+  assert.deepEqual(review.scene, scene(true));
+  assert.equal(review.review.sides.before.revision, f.base.revision);
+  assert.equal(review.review.sides.after.revision, f.head.revision);
+  const enqueue = review.review.sides.after.relations.find(item => item.to === 'Queue');
+  assert.equal(enqueue.from, 'API');
+  assert.equal(enqueue.claim, 'handle contains enqueue(input).');
+  assert.equal(enqueue.sources[0].url, `${repositoryUrl}/blob/${f.head.revision}/src/api.js#L2-L2`);
+  assert.deepEqual(review.review.sides.after.scope.unknowns, proposal(f.head.revision, true).scope.unknowns);
+  assert.equal(review.review.sides.after.relations.find(item => item.kind === 'assumption').sources.length, 0);
+});
+
+test("comparison review rejects changed artifacts and hand-edited claims or source locations", async t => {
+  const f = await fixture(t);
+  const saved = await exportComparison(f, { measureScene, renderScene });
+  const original = await fs.readFile(saved.reportPath);
+  for (const name of ['before.excalidraw', 'after.excalidraw', 'before.png', 'after.png', 'changes.md']) {
+    const path = join(f.outputDir, name), bytes = await fs.readFile(path);
+    await fs.writeFile(path, Buffer.concat([bytes, Buffer.from('changed')]));
+    await assert.rejects(readComparisonReview(saved.reportPath), { code: 'CORRUPT_REVIEW' });
+    await fs.writeFile(path, bytes);
+  }
+  for (const mutate of [
+    report => { report.changes.relations[2].after.claim = 'This executes exactly once.'; },
+    report => { report.changes.relations[2].after.sources[0].url = 'https://example.com/fabricated'; },
+    report => { report.head.scope.unknowns = []; },
+    report => { report.inputs.head.sha256 = '0'.repeat(64); },
+    report => { report.artifacts['after.excalidraw'].file = '../head.excalidraw'; },
+  ]) {
+    const report = JSON.parse(original); mutate(report);
+    await fs.writeFile(saved.reportPath, JSON.stringify(report));
+    await assert.rejects(readComparisonReview(saved.reportPath), { code: 'CORRUPT_REVIEW' });
+  }
+  await fs.writeFile(saved.reportPath, original);
+  await assert.rejects(readComparisonReview(saved.reportPath, { expectedHash: '0'.repeat(64) }), { code: 'CORRUPT_REVIEW' });
+  const bundle = JSON.parse(await fs.readFile(f.head.bundlePath, 'utf8'));
+  bundle.evidence.references[0].excerpt = 'fabricated excerpt';
+  await fs.writeFile(f.head.bundlePath, JSON.stringify(bundle));
+  await assert.rejects(readComparisonReview(saved.reportPath), { code: 'CORRUPT_EVIDENCE' });
+});
+
+test("comparison review rejects malformed receipts and symlink artifacts", async t => {
+  const f = await fixture(t);
+  const saved = await exportComparison(f, { measureScene, renderScene });
+  const original = await fs.readFile(saved.reportPath);
+  for (const bytes of ['{', 'null', '{}', '{"schemaVersion":1,"status":"complete"}']) {
+    await fs.writeFile(saved.reportPath, bytes);
+    await assert.rejects(readComparisonReview(saved.reportPath), { code: 'CORRUPT_REVIEW' });
+  }
+  await fs.writeFile(saved.reportPath, original);
+  const path = join(f.outputDir, 'after.excalidraw');
+  await fs.unlink(path);
+  await fs.symlink(join(f.root, 'head.excalidraw'), path);
+  await assert.rejects(readComparisonReview(saved.reportPath), { code: 'CORRUPT_REVIEW' });
+});
+
+
+test("preview CLI opens a comparison receipt with verified Before/After context", async t => {
+  const f = await fixture(t);
+  const saved = await exportComparison(f, { measureScene, renderScene });
+  const child = spawn(process.execPath, [new URL('../bin/cli.js', import.meta.url).pathname,
+    'preview', saved.reportPath, '--no-open', '--json'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  t.after(() => child.kill('SIGTERM'));
+  const result = await new Promise((resolve, reject) => {
+    let output = '', errors = '';
+    const timer = setTimeout(() => reject(new Error(`Preview did not start: ${errors}`)), 10000);
+    child.stderr.on('data', bytes => { errors += bytes; });
+    child.on('error', error => { clearTimeout(timer); reject(error); });
+    child.on('exit', code => { clearTimeout(timer); reject(new Error(`Preview exited ${code}: ${errors}`)); });
+    child.stdout.on('data', bytes => {
+      output += bytes;
+      try { const value = JSON.parse(output); clearTimeout(timer); resolve(value); } catch {}
+    });
+  });
+  assert.equal(result.mode, 'comparison');
+  const metadata = await (await fetch(`${result.url}context`)).json();
+  assert.equal(metadata.review.kind, 'source-comparison');
+  assert.equal(metadata.review.sides.after.revision, f.head.revision);
+  assert.deepEqual(metadata.beforeScene, scene(false));
+  assert.deepEqual(metadata.retainedPngViews, ['before', 'after']);
+  assert.equal(metadata.previewPngs, undefined);
+  for (const view of ['before', 'after']) {
+    const response = await fetch(`${result.url}exports/${view}.png`);
+    assert.equal(response.headers.get('content-type'), 'image/png');
+    assert.deepEqual(Buffer.from(await response.arrayBuffer()), await fs.readFile(join(f.outputDir, `${view}.png`)));
+  }
+  assert.equal((await fetch(`${result.url}exports/proposal.png`)).status, 404);
+  assert.equal((await fetch(new URL('/exports/after.png', result.url))).status, 404);
+});
+
+
+test('comparison PNG button downloads the exact native target image for each view', async t => {
+  const f = await fixture(t);
+  const renderer = await import('../src/target-render.js');
+  const saved = await exportComparison(f, renderer);
+  const loaded = await readComparisonReview(saved.reportPath);
+  const preview = await servePreview(loaded.scene, loaded);
+  t.after(() => preview.close());
+  const browser = await chromium.launch();
+  t.after(() => browser.close());
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  await page.goto(preview.url);
+  await page.waitForFunction(() => window.previewReady || window.previewError);
+  assert.equal(await page.evaluate(() => window.previewError), undefined);
+  for (const view of ['Before', 'After']) {
+    await page.getByRole('tab', { name: view, exact: true }).click();
+    await page.waitForFunction(() => window.previewReady);
+    const pending = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export PNG', exact: true }).click();
+    const download = await pending;
+    const bytes = await fs.readFile(await download.path());
+    assert.equal(bytes.readUInt32BE(16), saved.report.target.width);
+    assert.equal(bytes.readUInt32BE(20), saved.report.target.height);
+    assert.equal(sha256(bytes), saved.report.artifacts[`${view.toLowerCase()}.png`].sha256);
+  }
+});

--- a/test/target-render.test.js
+++ b/test/target-render.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { chromium } from "playwright";
+import { measureScene, renderScene } from "../src/target-render.js";
+
+const scene = elements => ({ type: "excalidraw", version: 2, elements, files: {}, appState: { viewBackgroundColor: "#faf9f5" } });
+const text = (id, value, extra = {}) => ({ id, type: "text", x: 30, y: 40, width: 1, height: 70,
+  fontSize: 28, fontFamily: 5, lineHeight: 1.25, angle: 0, textAlign: "left", verticalAlign: "top", text: value, opacity: 100, strokeColor: "#26251f", ...extra });
+async function output(t) {
+  const directory = await fs.mkdtemp(join(tmpdir(), "toolkit native target "));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  return join(directory, "target.png");
+}
+async function inkBounds(path) {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    return await page.evaluate(async data => {
+      const image = new Image(); image.src = data; await image.decode();
+      const canvas = document.createElement("canvas"); canvas.width = image.width; canvas.height = image.height;
+      const context = canvas.getContext("2d"); context.drawImage(image, 0, 0);
+      const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+      let x1 = Infinity, y1 = Infinity, x2 = -Infinity, y2 = -Infinity;
+      for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+        const i = (y * canvas.width + x) * 4;
+        if (Math.abs(pixels[i] - 250) + Math.abs(pixels[i + 1] - 249) + Math.abs(pixels[i + 2] - 245) > 30) {
+          x1 = Math.min(x1, x); y1 = Math.min(y1, y); x2 = Math.max(x2, x); y2 = Math.max(y2, y);
+        }
+      }
+      return { width: canvas.width, height: canvas.height, x1, y1, x2, y2 };
+    }, `data:image/png;base64,${(await fs.readFile(path)).toString("base64")}`);
+  } finally { await browser.close(); }
+}
+
+test("native glyph bounds include loaded Latin/CJK ink beyond stale declared width and match delivered pixels", async t => {
+  const input = scene([text("caption", "Shared worker\n共享缓存")]);
+  const original = structuredClone(input);
+  const metrics = await measureScene(input);
+  assert.equal(metrics.fontsLoaded, true); assert.equal(metrics.renderer, "@excalidraw/excalidraw@0.18.1");
+  assert.deepEqual(metrics.visibleElementIds, ["caption"]);
+  assert.ok(metrics.text[0].width > 100); assert.equal(metrics.text[0].fontSize, 28);
+  const path = await output(t);
+  await renderScene(input, path, { width: 700, height: 300, scale: 1, offsetX: 0, offsetY: 0 });
+  const ink = await inkBounds(path), glyph = metrics.text[0];
+  assert.equal(ink.width, 700); assert.equal(ink.height, 300);
+  assert.ok(Math.abs(ink.x1 - glyph.x) <= 3); assert.ok(Math.abs(ink.y1 - glyph.y) <= 3);
+  assert.ok(Math.abs(ink.x2 - glyph.x - glyph.width) <= 3); assert.ok(Math.abs(ink.y2 - glyph.y - glyph.height) <= 3);
+  assert.deepEqual(input, original);
+  await assert.rejects(renderScene(input, path, { width: 700, height: 300, scale: 1, offsetX: 0, offsetY: 0 }), { code: "EEXIST" });
+});
+
+test("native target export applies exact shared pixel scale and translation without saving the viewport anchor", async t => {
+  const input = scene([{ id: "box", type: "rectangle", x: 100, y: 100, width: 200, height: 100, angle: 0,
+    strokeColor: "#26251f", backgroundColor: "#26251f", fillStyle: "solid", strokeWidth: 1, roughness: 0, opacity: 100 }]);
+  const original = structuredClone(input), path = await output(t);
+  await renderScene(input, path, { width: 640, height: 400, scale: 0.5, offsetX: 25, offsetY: 35 });
+  const ink = await inkBounds(path);
+  assert.deepEqual([ink.width, ink.height], [640, 400]);
+  assert.ok(Math.abs(ink.x1 - 75) <= 1); assert.ok(Math.abs(ink.y1 - 85) <= 1);
+  assert.ok(Math.abs(ink.x2 - 175) <= 1); assert.ok(Math.abs(ink.y2 - 135) <= 1);
+  assert.deepEqual(input, original);
+});
+
+test("native bound-arrow label position comes from the arrow, not stale label coordinates", async () => {
+  const input = scene([
+    { id: "from", type: "rectangle", x: 100, y: 50, width: 100, height: 60, boundElements: [{ id: "arrow", type: "arrow" }] },
+    { id: "to", type: "rectangle", x: 400, y: 50, width: 100, height: 60, boundElements: [{ id: "arrow", type: "arrow" }] },
+    { id: "arrow", type: "arrow", x: 200, y: 80, width: 200, height: 0, angle: 0, points: [[0, 0], [200, 0]],
+      startBinding: { elementId: "from" }, endBinding: { elementId: "to" }, boundElements: [{ id: "caption", type: "text" }] },
+    text("caption", "Queue", { x: 999, y: 999, width: 90, height: 35, containerId: "arrow" }),
+  ]);
+  const metrics = await measureScene(input), caption = metrics.text.find(item => item.id === "caption");
+  assert.ok(caption.x > 230 && caption.x < 320); assert.ok(caption.y > 40 && caption.y < 90);
+  assert.equal(input.elements.at(-1).x, 999);
+});
+
+test("unqualified fonts/frames and a clipped target fail explicitly without output", async t => {
+  await assert.rejects(measureScene(scene([text("caption", "Worker", { fontFamily: 2 })])), { code: "UNSUPPORTED_FONT" });
+  await assert.rejects(measureScene(scene([{ id: "frame", type: "frame", x: 0, y: 0, width: 200, height: 200 }])), { code: "UNSUPPORTED_TARGET_SCENE" });
+  const path = await output(t);
+  await assert.rejects(renderScene(scene([text("caption", "Worker", { width: 200 })]), path,
+    { width: 100, height: 100, scale: 1, offsetX: 0, offsetY: 0 }), { code: "TARGET_CLIPPING" });
+  await assert.rejects(fs.stat(path), { code: "ENOENT" });
+});

--- a/test/workflow-commands.test.js
+++ b/test/workflow-commands.test.js
@@ -76,3 +76,35 @@ test('installed CLI routes request files and emits source evidence as JSON', asy
   assert.equal(associated.bundle.baseline.kind, 'association');
   assert.equal(await fs.readFile(join(f.root, 'cli-evidence/delivered.excalidraw'), 'utf8'), f.bytes);
 });
+
+test('explain-change dispatches source comparison and returns retained native/target artifacts', async t => {
+  const f = await workflowFixture(t);
+  await f.save({ ...f.request, outputDir: 'base' });
+  const base = await workflowCommand('associate-evidence', f.requestPath);
+  await f.save({ ...f.request, outputDir: 'head' });
+  const head = await workflowCommand('associate-evidence', f.requestPath);
+  await f.save({ repositoryPath: 'source',
+    base: { bundlePath: 'base/evidence.json', expectedHash: base.sha256, revision: f.revision },
+    head: { bundlePath: 'head/evidence.json', expectedHash: head.sha256, revision: f.revision },
+    target: 'article', repositoryUrl: 'https://github.com/example/repository', outputDir: 'comparison',
+    required: { base: { nodes: ['request:handler'], relations: [] }, head: { nodes: ['request:handler'], relations: [] } } });
+  const renders = [];
+  const targetRenderer = {
+    measureScene: async () => ({ renderer: '@excalidraw/excalidraw@0.18.1', fontsLoaded: true, visibleElementIds: ['api'], text: [], bounds: { x: 0, y: 0, width: 120, height: 80 } }),
+    renderScene: async (scene, path, viewport) => {
+      renders.push({ scene, viewport });
+      const png = Buffer.alloc(33); // Contract fixture; native rendering is separately qualified.
+      Buffer.from('89504e470d0a1a0a', 'hex').copy(png); png.write('IHDR', 12);
+      png.writeUInt32BE(viewport.width, 16); png.writeUInt32BE(viewport.height, 20);
+      await fs.writeFile(path, png);
+    },
+  };
+  const result = await workflowCommand('explain-change', f.requestPath, {}, { targetRenderer });
+  assert.equal(result.report.status, 'complete');
+  assert.equal(renders.length, 2);
+  assert.deepEqual(renders[0].viewport, renders[1].viewport);
+  assert.equal(result.report.viewport.width, 1200);
+  assert.equal(await fs.readFile(join(f.root, 'comparison/before.excalidraw'), 'utf8'), f.bytes);
+  assert.equal(await fs.readFile(join(f.root, 'comparison/after.excalidraw'), 'utf8'), f.bytes);
+  assert.equal(result.report.changes.nodes[0].status, 'unchanged');
+});


### PR DESCRIPTION
Add `explain-change` to turn two scoped evidence bundles into editable before/after diagrams, revision-specific source links and a semantic change report. Required node/relation IDs catch omitted content; unchanged context must retain its geometry. Assumed relationships need visible labels in the diagram.

Article, slide and canvas targets use loaded native fonts and measured glyph bounds to choose one shared viewport. Labels below the target's minimum effective size fail before output is written. The review workspace shows checked source context and Before/After views, and downloads the retained PNG at its exact target dimensions. Canonical native files keep their original bytes.

## Testing

- Native Chromium and CLI tests cover source identity, required content, stable context, Latin/CJK metrics, bound-arrow labels, unreadable/clipped targets, receipt tampering and retained PNG downloads.
- Inspected the direct-call → queue → worker comparison through computer use, including source links and claim labels. Actual article, canvas and slide exports were inspected at their delivered sizes.

Source investigation remains the host agent's work; these checks do not establish runtime behavior.
