### PR TITLE
[Maintenance]: refresh diagrams while preserving human edits

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,6 +37,8 @@ Usage:
   npx ${pkg.name} associate-evidence --request <json>  Retain an existing scene's evidence
   npx ${pkg.name} accept-baseline --request <json>  Accept generated/delivered snapshots
   npx ${pkg.name} explain-change --request <json>  Export source-linked revision views
+  npx ${pkg.name} refresh-diagram --request <json>  Stage a source refresh with previews
+  npx ${pkg.name} adopt-refresh --request <json>  Explicitly accept a reviewed refresh
   npx ${pkg.name} version    Print version
 
 Options: --home <directory>, --target <claude|codex|all>, --project <directory>,

--- a/docs/refresh.md
+++ b/docs/refresh.md
@@ -1,0 +1,176 @@
+# Refresh while retaining manual edits
+
+Refresh compares three native documents: the last accepted **generated** scene,
+the current human-edited scene, and a newly proposed generated scene. The prior
+delivered scene is retained as evidence of acceptance; it does not replace the
+generated scene as the comparison base. That distinction keeps manual adjustments
+visible across successive refreshes.
+
+Staging writes a candidate and a report. It never overwrites the human scene or
+advances its accepted baseline. Adoption is an explicit second call after the
+candidate, preview and source claims have been reviewed.
+
+## API
+
+```js
+import { stageRefresh, adoptRefresh } from "./src/refresh.js";
+
+const staged = await stageRefresh({
+  requestId: "queue-refactor-1",
+  baselineBundlePath: "/accepted/evidence.json",
+  baselineHash: retainedBaselineHash,
+  currentPath: "/diagrams/current.excalidraw",
+  generatedPath: "/proposals/next.excalidraw",
+  repositoryPath: "/repository/root",
+  evidence: nextEvidenceProposal,
+  removedSemanticIds: [],
+  outputDir: "/review/queue-refactor-1",
+});
+
+// Caller renders/inspects the candidate and reviews the source claims here.
+// Only call adoption when the user or configured workflow adopts this result.
+const accepted = await adoptRefresh({
+  receiptPath: staged.receiptPath,
+  expectedHash: staged.sha256,
+  outputDir: "/accepted/queue-refactor-1",
+});
+```
+
+The evidence proposal uses [evidence schema version 1](evidence.md). Staging checks
+its references against the proposed generated scene, resolves Git refs to exact
+commits and retains source file digests. Adoption checks those same pinned
+references again; a later `HEAD` cannot substitute a new commit. Changed
+working-tree source digests require a new proposal.
+
+`mergeGeneratedScenes({ baselineGenerated, current, proposedGenerated,
+baselineEvidence, proposedEvidence, removedSemanticIds })` exposes the pure merge
+for callers that already hold checked evidence and native scenes. It returns
+`{ status, candidate, changes, overrides, conflicts }`. The file API performs
+source-reference and artifact-hash checks in addition to that merge.
+
+## Merge rules
+
+Each explicit semantic ID retains its native element ID. Mapped nodes and arrows,
+plus their bound text, define the source-owned portion of the scene. Map a bound
+label through its container; do not map it twice. Everything outside that portion
+starts as the exact current scene content and remains untouched.
+
+For each supported native field:
+
+| Human compared with generated baseline | Proposed source compared with baseline | Result |
+| --- | --- | --- |
+| Unchanged | Changed | Apply the proposed field |
+| Changed | Unchanged | Keep the human override |
+| Changed | Changed to the same value | Keep that shared value |
+| Changed | Changed differently | Keep the human value and report a conflict |
+
+Fields include label content and typography, position/size, styles, groups/frames,
+arrow geometry and bindings. Arrays such as `points` and `boundElements` are one
+field, not guessed element-by-element merges. Unknown fields and volatile native
+metadata on existing elements remain current. Scene-level state, unmanaged objects
+and unused assets are retained. Source-owned images may introduce or update their
+referenced assets; incompatible manual asset changes are conflicts.
+An asset shared with a live unmanaged image cannot be replaced: the merge reports
+`UNMANAGED_ASSET_CONFLICT` and retains its current bytes. Give the source-owned image
+a new asset ID in the proposal, or explicitly reconcile ownership of every copy.
+
+New semantic IDs require new native IDs. A missing known semantic ID, a changed
+native ID, an ambiguous bound-label identity, or a human-deleted target requires
+reconciliation. Display text is never used to guess a rename. An association-only
+bundle has no historical generated baseline and also requires reconciliation.
+
+Removal requires `removedSemanticIds` explicitly listing known concepts absent
+from the new mapping. Their old references must lie within the new analysis scope.
+An old assumption without any source references has unknown removal scope and must
+be reconciled explicitly. The objects and dependent labels become native tombstones only when unchanged by
+the human; unrelated objects are never inferred to be obsolete from partial source
+coverage. A manually modified deletion target or a surviving native dependency
+blocks adoption. This module does not infer source completeness or prove that an
+authored removal was semantically justified.
+
+Native bindings are validated after merging. If incompatible partial changes would
+leave dangling or nonreciprocal bindings, `candidate` is `null` and the report has a
+topology conflict. Object spread and field assignment do not reroute bound arrows.
+The proposal must contain valid native geometry; callers must render and inspect
+the merged result for layout, text fit and readability before adoption.
+
+## Receipts and adoption
+
+`stageRefresh` returns `{ receiptPath, sha256, receipt, reused }`. Its immutable
+directory contains `refresh.json`, exact `current.excalidraw` and
+`generated.excalidraw` snapshots, and `candidate.excalidraw` when a valid native
+candidate exists. The receipt is published atomically after those files are synced.
+
+The receipt has `schemaVersion: 1`, the normalized `request`, its `requestDigest`,
+`proposedEvidence`, `changes`, `overrides`, `conflicts`, and relative artifact names
+with SHA-256 hashes. `changes` names changed semantic IDs, native IDs and fields;
+`overrides` names retained human fields. A field conflict includes the baseline,
+human and proposed value, with field presence recorded separately from `null`.
+
+| Status | Meaning | Adoption |
+| --- | --- | --- |
+| `ready` | Merge completed without identity/field/topology conflicts | Explicit adoption permitted after caller review |
+| `unchanged` | The accepted source revision, inspected file digests and analysis scope are unchanged | Returns the prior baseline; creates no new baseline |
+| `reconciliation-required` | Missing baseline, uncertain identity, competing edits or invalid merged topology | Blocked; resolve and stage a new request |
+
+The same source revision and scope keeps the current native bytes, even if a new
+generation proposes different layout. Scope identity includes the analysis
+question, declared paths and inspected file digests. Working-tree comparisons use
+the inspected digests rather than assuming HEAD represents uncommitted content.
+This prevents incidental regeneration from churning a previously accepted scene.
+
+Repeating an unchanged request into the same completed output verifies its retained
+files and returns its existing receipt. Different inputs cannot reuse that
+directory. Failed attempts can leave partial directories; choose a new output path
+for recovery. There is no shared mutable scene store or background process.
+
+`adoptRefresh` requires the retained receipt hash, verifies all native snapshots and
+the previous baseline, and refuses if the original human file has changed since
+staging. It copies the proposed generated and adopted candidate scenes into a new
+accepted evidence bundle. It then saves `adoption.json` linking old/new baseline
+hashes to the staged receipt hash. The prior baseline and human file remain intact.
+Repeated adoption into the same completed directory returns the same accepted
+bundle. An incomplete adoption directory requires a new output path.
+
+`adoption.json` provides lineage beside the version-1 evidence manifest, whose
+`priorBaseline` remains `null`. The caller selects the newly returned baseline and
+delivered copy for subsequent work only after adoption succeeds. No global pointer
+is updated. A failure before adoption returns cannot implicitly select a baseline.
+
+Retain receipt hashes independently. These checks detect accidental replacement;
+they do not authenticate an attacker who can rewrite both artifacts and their
+trusted hashes. The module does not merge atomically with arbitrary external
+editors, render previews, certify semantic claims, or publish artifacts.
+
+
+## Reviewing a staged refresh
+
+The `refresh-diagram` command retains a `previews.json` manifest alongside its
+native receipt. Open that receipt directly:
+
+```sh
+excalidraw-toolkit preview ./review/queue-refactor-1/refresh.json
+```
+
+Before shows the human scene at staging time; Source proposal shows the generated
+input; Candidate shows the merged output. A topology failure omits the Candidate
+tab instead of disguising the proposal as a successful merge. Partial candidates
+are visibly marked as needing reconciliation. The sidebar shows conflicts,
+preserved overrides, proposal revision, and scoped unknowns. Numeric conflict
+values are rounded to two decimal places for display; native files stay exact.
+
+Opening a refresh rechecks native and preview hashes, the preview manifest's
+receipt identity, source evidence and the three-way merge. Edited status or
+conflict metadata cannot turn a failed refresh into a ready preview. Keep the
+accepted baseline and inspected source repository available for these checks.
+`readVerifiedRefresh(receiptPath, { expectedHash })` exposes the read-only native
+and source verification for other local review clients.
+
+The screen has no adoption control. It reports the staged status; it does not
+infer whether a later command adopted that receipt. Use `adopt-refresh` explicitly
+after reviewing the candidate. Exporting a view copies that selected native scene
+or PNG and does not advance the accepted baseline.
+
+When a view has a retained PNG in `previews.json`, the review downloads those
+verified bytes. A separate source-proposal view without a retained PNG uses the
+native renderer; its download does not claim an earlier retained preview hash.

--- a/docs/workflow-commands.md
+++ b/docs/workflow-commands.md
@@ -16,6 +16,8 @@ does not load the browser renderer or require a model runtime.
 | `associate-evidence` | Validation fields plus `outputDir` | Immutable association of an existing scene; no generated history invented |
 | `accept-baseline` | Association fields plus `generatedPath` | Explicitly accepted generated and delivered native snapshots |
 | `explain-change` | `repositoryPath`, `base`, `head`, `repositoryUrl`, `target`, `required`, `outputDir` | Native before/after files, matching PNG viewport, source-linked report |
+| `refresh-diagram` | PR11 `stageRefresh` request fields | Native refresh receipt and before/after PNG manifest; no adoption |
+| `adopt-refresh` | `receiptPath`, retained `expectedHash`, new `outputDir` | Explicitly accepted baseline after successful reconciliation |
 
 The existing coding agent investigates the selected entry point and path, reads
 source files at the declared revision, constructs supported scene edits, and
@@ -53,3 +55,16 @@ node/relation ID arrays in `required`. Choose `article`, `slide`, `canvas`, or a
 explicit pixel target in `target`; the native renderer checks effective label
 sizes at that target before writing outputs. It preserves unchanged context and
 rejects missing required content. See `docs/explain.md` for the complete contract.
+
+`refresh-diagram` takes `requestId`, `baselineBundlePath`, `baselineHash`,
+`currentPath`, `generatedPath`, `repositoryPath`, scoped `evidence`, optional
+`removedSemanticIds`, and `outputDir`. It calls PR11 staging, then renders the
+current/candidate native scenes. A conflict remains `reconciliation-required`;
+if no valid candidate exists, the second image is named `proposal.png` rather
+than `after.png`. Review the native receipt's conflicts before adopting anything.
+
+Preview completion lives in `previews.json`, separately from `refresh.json`.
+Failed preview attempts remain incomplete; a retry reuses the checked native
+refresh and renders into a new attempt directory. Completed previews are reused
+only after their hashes verify. An explicit `adopt-refresh` call advances the
+accepted baseline; the current human scene is still an untouched input file.

--- a/plugins/excalidraw/skills/scoped-edit/SKILL.md
+++ b/plugins/excalidraw/skills/scoped-edit/SKILL.md
@@ -78,3 +78,24 @@ failure requires a deliberate target or composition change; keep required conten
 visible. Inspect both exported PNGs at their actual size and read the source-linked
 change report. Return editable native files, previews and the report with remaining
 assumptions. An exported source citation alone does not prove runtime behavior.
+
+## Refresh after a source revision changes
+
+Keep the last accepted generated baseline and current human-edited native scene
+as separate inputs. Investigate the changed source within the recorded scope,
+prepare the proposed generated scene using stable identities, and update its
+evidence. Use `refresh-diagram --request <file>` with `requestId`,
+`baselineBundlePath`, `baselineHash`, `currentPath`, `generatedPath`,
+`repositoryPath`, `evidence`, `outputDir`, and any explicitly justified
+`removedSemanticIds`.
+
+Read the refresh receipt's overrides and conflicts, then inspect the actual
+before/after previews. `reconciliation-required` remains unfinished even if an
+image exists; a `proposal.png` shows only the source proposal when no valid merged
+candidate exists. Resolve uncertain identity mappings and conflicting human/source
+intent before staging again. Preserve custom labels, positions and unrelated notes.
+
+When the reviewed candidate is adopted, call `adopt-refresh --request <file>`
+with the refresh `receiptPath`, its retained `expectedHash`, and a new baseline
+`outputDir`. Retain the resulting bundle/hash for the next revision. The installer
+command `update` keeps its existing meaning.

--- a/src/commands.js
+++ b/src/commands.js
@@ -17,10 +17,14 @@ export async function sceneCommand(command, inputPath, values) {
   }
   let scene = readJSON(inputPath);
   let beforeScene;
+  let proposalScene;
   let changes;
   let review;
   let previewPngs;
-  if (scene.schemaVersion === 1 && scene.status === 'complete' && scene.inputs?.base && scene.inputs?.head) {
+  if (scene.schemaVersion === 1 && ['ready', 'unchanged', 'reconciliation-required'].includes(scene.status) && scene.requestDigest) {
+    const { readRefreshReview } = await import('./review-receipts.js');
+    ({ scene, beforeScene, proposalScene, review, previewPngs } = await readRefreshReview(inputPath));
+  } else if (scene.schemaVersion === 1 && scene.status === 'complete' && scene.inputs?.base && scene.inputs?.head) {
     const { readComparisonReview } = await import('./review-receipts.js');
     ({ scene, beforeScene, review, previewPngs } = await readComparisonReview(inputPath));
   } else if (scene?.type !== 'excalidraw') {
@@ -33,7 +37,7 @@ export async function sceneCommand(command, inputPath, values) {
   if (beforeScene) validateScene(beforeScene);
   const port = values.port === undefined ? 0 : Number(values.port);
   if (!Number.isInteger(port) || port < 0 || port > 65535) throw new Error('PORT_INVALID: use an integer from 0 to 65535');
-  const preview = await servePreview(scene, {beforeScene, changes, review, previewPngs, title: values.title || review?.title || basename(inputPath).replace(/\.(excalidraw|json)$/, ''), port});
+  const preview = await servePreview(scene, {beforeScene, proposalScene, changes, review, previewPngs, title: values.title || review?.title || basename(inputPath).replace(/\.(excalidraw|json)$/, ''), port});
   if (!values['no-open']) openBrowser(preview.url);
   for (const signal of ['SIGINT', 'SIGTERM']) process.once(signal, async () => {await preview.close(); process.exit(0);});
   return {url: preview.url, inputPath: resolve(inputPath), mode: beforeScene ? 'comparison' : 'preview'};

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -1,0 +1,319 @@
+import { promises as fs } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { acceptEvidenceBaseline, readEvidenceBundle, validateEvidence } from "./evidence.js";
+import { sha256, validateScene } from "./scene.js";
+
+const HASH = /^[a-f0-9]{64}$/;
+const EDITABLE = new Set([
+  "x", "y", "width", "height", "angle", "text", "originalText", "fontSize", "fontFamily",
+  "textAlign", "verticalAlign", "lineHeight", "autoResize", "strokeColor", "backgroundColor",
+  "fillStyle", "strokeWidth", "strokeStyle", "roughness", "opacity", "roundness", "points",
+  "startBinding", "endBinding", "boundElements", "containerId", "startArrowhead", "endArrowhead",
+  "elbowed", "fixedSegments", "frameId", "groupIds", "fileId", "scale",
+]);
+const same = isDeepStrictEqual;
+const clone = structuredClone;
+const live = element => element && !element.isDeleted;
+const valueAt = (object, field) => Object.hasOwn(object, field) ? { present: true, value: object[field] } : { present: false };
+function fail(code, message) { throw Object.assign(new Error(message), { code }); }
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  return JSON.stringify(value);
+}
+function sourceKey(evidence) {
+  return canonical({
+    source: evidence.source.kind === "git" ? evidence.source : { kind: "working-tree" },
+    question: evidence.scope.question, paths: [...evidence.scope.paths].sort(),
+    files: [...new Map(evidence.references.map(ref => [ref.path, ref.sha256])).entries()].sort(),
+  });
+}
+
+function identities(evidence, index) {
+  const ids = new Map();
+  const elements = new Set();
+  for (const item of [...evidence.nodes, ...evidence.relations]) {
+    if (ids.has(item.semanticId) || elements.has(item.elementId) || !live(index.get(item.elementId))) {
+      fail("RECONCILIATION_REQUIRED", "Semantic identities must map uniquely to live native elements");
+    }
+    ids.set(item.semanticId, item);
+    elements.add(item.elementId);
+  }
+  return ids;
+}
+
+function ownedText(index, element) {
+  const bindings = element.boundElements?.filter(binding => binding.type === "text") ?? [];
+  if (bindings.length > 1) fail("RECONCILIATION_REQUIRED", `Ambiguous bound text identity: ${element.id}`);
+  return bindings.length ? index.get(bindings[0].id) : null;
+}
+
+/** Pure merge; only explicitly associated native elements and their bound text are source-owned. */
+export function mergeGeneratedScenes({ baselineGenerated, current, proposedGenerated, baselineEvidence, proposedEvidence, removedSemanticIds = [] }) {
+  validateScene(current);
+  validateScene(proposedGenerated);
+  if (!baselineGenerated) return { status: "reconciliation-required", candidate: clone(current), changes: [], overrides: [], conflicts: [{ code: "MISSING_GENERATED_BASELINE" }] };
+  validateScene(baselineGenerated);
+  const before = new Map(baselineGenerated.elements.map(element => [element.id, element]));
+  const human = new Map(current.elements.map(element => [element.id, element]));
+  const proposed = new Map(proposedGenerated.elements.map(element => [element.id, element]));
+  const oldIds = identities(baselineEvidence, before);
+  const newIds = identities(proposedEvidence, proposed);
+  if (!Array.isArray(removedSemanticIds) || new Set(removedSemanticIds).size !== removedSemanticIds.length || removedSemanticIds.some(id => !oldIds.has(id) || newIds.has(id))) {
+    fail("INVALID_REMOVAL", "Removals must uniquely identify known semantic IDs absent from the new proposal");
+  }
+  const candidate = clone(current);
+  const next = new Map(candidate.elements.map(element => [element.id, element]));
+  const conflicts = [];
+  const changes = [];
+  const overrides = [];
+  const managed = new Set();
+  const conflict = (code, semanticId, elementId, extra = {}) => conflicts.push({ code, semanticId, elementId, ...extra });
+  const mergeElement = (semanticId, base, existing, update) => {
+    const id = base?.id ?? update.id;
+    if (managed.has(id)) { conflict("AMBIGUOUS_IDENTITY", semanticId, id); return; }
+    managed.add(id);
+    if (!base) {
+      if (human.has(id) || before.has(id)) { conflict("ELEMENT_ID_COLLISION", semanticId, id); return; }
+      const addition = clone(update);
+      candidate.elements.push(addition);
+      next.set(id, addition);
+      changes.push({ semanticId, elementId: id, kind: "add" });
+      return;
+    }
+    if (!live(existing)) { conflict("HUMAN_REMOVAL", semanticId, id); return; }
+    if (!live(update)) {
+      // Deleting a manually modified object needs reconciliation, even when the
+      // changed field is unknown to the source workflow.
+      if (!same(existing, base)) { conflict("DELETE_MODIFIED_ELEMENT", semanticId, id); return; }
+      next.get(id).isDeleted = true;
+      changes.push({ semanticId, elementId: id, kind: "remove" });
+      return;
+    }
+    if (base.type !== existing.type || base.type !== update.type) { conflict("ELEMENT_TYPE_CHANGED", semanticId, id); return; }
+    for (const field of EDITABLE) {
+      const b = valueAt(base, field), h = valueAt(existing, field), n = valueAt(update, field);
+      if (same(b, n)) {
+        if (!same(b, h)) overrides.push({ semanticId, elementId: id, field });
+        continue;
+      }
+      if (!same(b, h) && !same(h, n)) {
+        conflict("FIELD_CONFLICT", semanticId, id, { field, baseline: b, human: h, proposed: n });
+        continue;
+      }
+      if (same(h, n)) continue;
+      if (n.present) next.get(id)[field] = clone(n.value);
+      else delete next.get(id)[field];
+      changes.push({ semanticId, elementId: id, kind: "field", field });
+    }
+  };
+  for (const [semanticId, old] of oldIds) {
+    const replacement = newIds.get(semanticId);
+    const base = before.get(old.elementId);
+    if (!replacement && !removedSemanticIds.includes(semanticId)) {
+      conflict("UNRESOLVED_IDENTITY", semanticId, old.elementId); continue;
+    }
+    if (replacement && replacement.elementId !== old.elementId) {
+      conflict("NATIVE_ID_CHANGED", semanticId, old.elementId, { proposedElementId: replacement.elementId }); continue;
+    }
+    if (!replacement) {
+      const refs = baselineEvidence.references.filter(ref => old.referenceIds.includes(ref.id));
+      if (!refs.length) { conflict("REMOVAL_SCOPE_UNKNOWN", semanticId, old.elementId); continue; }
+      if (refs.some(ref => !proposedEvidence.scope.paths.some(path => path === "." || ref.path === path || ref.path.startsWith(`${path}/`)))) {
+        conflict("REMOVAL_OUTSIDE_SCOPE", semanticId, old.elementId); continue;
+      }
+    }
+    const update = replacement ? proposed.get(replacement.elementId) : null;
+    mergeElement(semanticId, base, human.get(base.id), update);
+    const oldText = ownedText(before, base);
+    const newText = update ? ownedText(proposed, update) : null;
+    if (oldText && newText && oldText.id !== newText.id) {
+      conflict("BOUND_TEXT_ID_CHANGED", semanticId, oldText.id, { proposedElementId: newText.id });
+    } else if (oldText || newText) mergeElement(semanticId, oldText, human.get((oldText ?? newText).id), newText);
+  }
+  for (const [semanticId, item] of newIds) {
+    if (oldIds.has(semanticId)) continue;
+    const update = proposed.get(item.elementId);
+    mergeElement(semanticId, null, human.get(item.elementId), update);
+    const bound = ownedText(proposed, update);
+    if (bound) mergeElement(semanticId, null, human.get(bound.id), bound);
+  }
+  // Asset dictionaries and scene-level state are otherwise retained verbatim.
+  for (const id of managed) {
+    const element = next.get(id);
+    if (!live(element) || element.type !== "image" || !element.fileId) continue;
+    const fileId = element.fileId;
+    const incoming = proposedGenerated.files?.[fileId];
+    if (incoming === undefined) continue;
+    const prior = baselineGenerated.files?.[fileId], existing = current.files?.[fileId];
+    if (same(prior, incoming) || same(existing, incoming)) continue;
+    const unmanagedConsumers = candidate.elements.filter(item => live(item) && item.type === "image" && item.fileId === fileId && !managed.has(item.id)).map(item => item.id);
+    if (unmanagedConsumers.length) {
+      conflicts.push({ code: "UNMANAGED_ASSET_CONFLICT", fileId, elementIds: unmanagedConsumers }); continue;
+    }
+    if (existing !== undefined && !same(existing, prior)) {
+      conflicts.push({ code: "ASSET_CONFLICT", fileId }); continue;
+    }
+    candidate.files ??= {};
+    candidate.files[fileId] = clone(incoming);
+    changes.push({ kind: "asset", fileId });
+  }
+  try { validateScene(candidate); }
+  catch (error) {
+    conflicts.push({ code: "TOPOLOGY_CONFLICT", detail: error.message });
+    return { status: "reconciliation-required", candidate: null, changes, overrides, conflicts };
+  }
+  return { status: conflicts.length ? "reconciliation-required" : "ready", candidate, changes, overrides, conflicts };
+}
+
+async function native(path) {
+  const bytes = await fs.readFile(path);
+  let scene;
+  try { scene = JSON.parse(bytes.toString("utf8")); }
+  catch { fail("INVALID_SCENE", "Expected native Excalidraw JSON"); }
+  validateScene(scene);
+  return { bytes, scene, sha256: sha256(bytes) };
+}
+async function write(path, bytes) {
+  const handle = await fs.open(path, "wx", 0o600);
+  try { await handle.writeFile(bytes); await handle.sync(); } finally { await handle.close(); }
+}
+async function publish(path, value) {
+  const bytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+  const pending = `${path}.pending`;
+  await write(pending, bytes);
+  await fs.link(pending, path);
+  await fs.unlink(pending);
+  const handle = await fs.open(dirname(path), "r");
+  try { await handle.sync(); } finally { await handle.close(); }
+  return sha256(bytes);
+}
+async function readReceipt(receiptPath, expectedHash) {
+  const bytes = await fs.readFile(receiptPath);
+  if (expectedHash !== undefined && (!HASH.test(expectedHash) || sha256(bytes) !== expectedHash)) fail("CORRUPT_REFRESH", "Refresh receipt hash differs");
+  let receipt;
+  try { receipt = JSON.parse(bytes.toString("utf8")); } catch { fail("CORRUPT_REFRESH", "Invalid refresh JSON"); }
+  if (receipt?.schemaVersion !== 1 || !["ready", "unchanged", "reconciliation-required"].includes(receipt.status) || !HASH.test(receipt.requestDigest ?? "") ||
+    !receipt.request || sha256(canonical(receipt.request)) !== receipt.requestDigest ||
+    ![receipt.conflicts, receipt.changes, receipt.overrides].every(Array.isArray) || !receipt.artifacts) fail("CORRUPT_REFRESH", "Invalid refresh receipt");
+  return { receipt, sha256: sha256(bytes) };
+}
+async function retainedNative(receiptPath, entry, name) {
+  if (!entry || entry.file !== name || !HASH.test(entry.sha256 ?? "")) fail("CORRUPT_REFRESH", "Invalid native artifact reference");
+  const path = join(dirname(resolve(receiptPath)), name);
+  if (!(await fs.lstat(path)).isFile()) fail("CORRUPT_REFRESH", "Native artifacts must be regular files");
+  const result = await native(path);
+  if (result.sha256 !== entry.sha256) fail("CORRUPT_REFRESH", `Changed artifact: ${name}`);
+  return { ...result, path };
+}
+
+function mergeRefresh(baseline, current, proposed, checked, removedSemanticIds) {
+  if (baseline?.generatedScene && sourceKey(baseline.bundle.evidence) === sourceKey(checked)) {
+    return { status: "unchanged", candidate: current, changes: [], overrides: [], conflicts: [] };
+  }
+  return mergeGeneratedScenes({ baselineGenerated: baseline?.generatedScene, current, proposedGenerated: proposed,
+    baselineEvidence: baseline?.bundle.evidence, proposedEvidence: checked, removedSemanticIds });
+}
+
+/** Read-only verification for review: recompute status and conflicts from retained inputs. */
+export async function readVerifiedRefresh(receiptPath, { expectedHash } = {}) {
+  const saved = await readReceipt(receiptPath, expectedHash);
+  const { receipt } = saved;
+  const current = await retainedNative(receiptPath, receipt.artifacts.current, "current.excalidraw");
+  const proposed = await retainedNative(receiptPath, receipt.artifacts.generated, "generated.excalidraw");
+  const candidate = receipt.artifacts.candidate ? await retainedNative(receiptPath, receipt.artifacts.candidate, "candidate.excalidraw") : null;
+  if (current.sha256 !== receipt.request.currentHash || proposed.sha256 !== receipt.request.generatedHash) fail("CORRUPT_REFRESH", "Retained native scenes differ from the refresh request");
+  const checked = await validateEvidence({ repositoryPath: receipt.request.repositoryPath, inputPath: proposed.path, evidence: receipt.request.evidence });
+  if (!same(checked, receipt.proposedEvidence)) fail("CORRUPT_REFRESH", "Proposed source evidence changed after staging");
+  let baseline = null;
+  if (receipt.request.baselineBundlePath) {
+    try { baseline = await readEvidenceBundle(receipt.request.baselineBundlePath, { expectedHash: receipt.request.baselineHash }); }
+    catch (error) { if (error.code !== "ENOENT") throw error; }
+  }
+  const merged = mergeRefresh(baseline, current.scene, proposed.scene, checked, receipt.request.removedSemanticIds);
+  if (merged.status !== receipt.status || !same(merged.changes, receipt.changes) || !same(merged.overrides, receipt.overrides) ||
+      !same(merged.conflicts, receipt.conflicts) || !same(merged.candidate, candidate?.scene ?? null)) fail("CORRUPT_REFRESH", "Refresh status, changes or conflicts differ from the retained three-way merge");
+  return { ...saved, current: current.scene, proposed: proposed.scene, candidate: merged.candidate, evidence: checked };
+}
+
+export async function stageRefresh({ requestId, baselineBundlePath, baselineHash, currentPath, generatedPath, repositoryPath, evidence, removedSemanticIds = [], outputDir }) {
+  if (typeof requestId !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(requestId)) fail("INVALID_REQUEST", "Provide a stable request ID");
+  if (typeof outputDir !== "string" || !outputDir.trim()) fail("INVALID_REQUEST", "Provide a new output directory");
+  if (baselineBundlePath && !HASH.test(baselineHash ?? "")) fail("INVALID_BASELINE", "Retain and provide the accepted baseline manifest hash");
+  const current = await native(currentPath);
+  const proposed = await native(generatedPath);
+  const checked = await validateEvidence({ repositoryPath, inputPath: generatedPath, evidence });
+  if (checked.sceneHash !== proposed.sha256) fail("STALE_INPUT", "Generated proposal changed during validation");
+  const pinnedEvidence = clone(evidence);
+  if (checked.source.kind === "git") pinnedEvidence.source = clone(checked.source);
+  pinnedEvidence.references = pinnedEvidence.references.map((reference, index) => ({ ...reference, sha256: checked.references[index].sha256 }));
+  let baseline = null;
+  if (baselineBundlePath) {
+    try { baseline = await readEvidenceBundle(baselineBundlePath, { expectedHash: baselineHash }); }
+    catch (error) { if (error.code !== "ENOENT") throw error; }
+  }
+  const request = {
+    requestId, baselineBundlePath: baselineBundlePath ? resolve(baselineBundlePath) : null, baselineHash: baselineHash ?? null,
+    currentPath: resolve(currentPath), currentHash: current.sha256, generatedPath: resolve(generatedPath), generatedHash: proposed.sha256,
+    repositoryPath: checked.repositoryPath, evidence: pinnedEvidence, removedSemanticIds,
+  };
+  const requestDigest = sha256(canonical(request));
+  const directory = resolve(outputDir);
+  const receiptPath = join(directory, "refresh.json");
+  try {
+    const existing = await readReceipt(receiptPath);
+    if (existing.receipt.requestDigest !== requestDigest) fail("REQUEST_CONFLICT", "This output directory belongs to a different refresh input");
+    await retainedNative(receiptPath, existing.receipt.artifacts.current, "current.excalidraw");
+    await retainedNative(receiptPath, existing.receipt.artifacts.generated, "generated.excalidraw");
+    if (existing.receipt.artifacts.candidate) await retainedNative(receiptPath, existing.receipt.artifacts.candidate, "candidate.excalidraw");
+    return { receiptPath, ...existing, reused: true };
+  } catch (error) { if (error.code !== "ENOENT") throw error; }
+  const merged = mergeRefresh(baseline, current.scene, proposed.scene, checked, removedSemanticIds);
+  await fs.mkdir(dirname(directory), { recursive: true });
+  try { await fs.mkdir(directory); }
+  catch (error) { if (error.code === "EEXIST") fail("INCOMPLETE_REFRESH", "Existing directory has no complete refresh receipt; use a new directory"); throw error; }
+  const artifacts = {};
+  for (const [key, value] of Object.entries({ current, generated: proposed, candidate: merged.candidate ? {
+    bytes: same(merged.candidate, current.scene) ? current.bytes : Buffer.from(`${JSON.stringify(merged.candidate, null, 2)}\n`),
+  } : null })) {
+    if (!value) { artifacts[key] = null; continue; }
+    artifacts[key] = { file: `${key}.excalidraw`, sha256: sha256(value.bytes) };
+    await write(join(directory, artifacts[key].file), value.bytes);
+  }
+  const { candidate, ...report } = merged;
+  const receipt = { schemaVersion: 1, requestDigest, request, ...report, proposedEvidence: checked, artifacts };
+  const receiptHash = await publish(receiptPath, receipt);
+  return { receiptPath, sha256: receiptHash, receipt, reused: false };
+}
+
+/** Explicit caller adoption; staging never changes the accepted baseline. */
+export async function adoptRefresh({ receiptPath, expectedHash, outputDir }) {
+  if (!HASH.test(expectedHash ?? "")) fail("INVALID_REQUEST", "Provide the retained refresh receipt hash");
+  const { receipt } = await readReceipt(receiptPath, expectedHash);
+  if (receipt.status === "reconciliation-required" || receipt.conflicts.length) fail("RECONCILIATION_REQUIRED", "Resolve conflicts and stage a new refresh before adoption");
+  const current = await retainedNative(receiptPath, receipt.artifacts.current, "current.excalidraw");
+  const generated = await retainedNative(receiptPath, receipt.artifacts.generated, "generated.excalidraw");
+  const candidate = await retainedNative(receiptPath, receipt.artifacts.candidate, "candidate.excalidraw");
+  if ((await native(receipt.request.currentPath)).sha256 !== current.sha256) fail("STALE_INPUT", "The human scene changed after staging; reconcile it before adoption");
+  await readEvidenceBundle(receipt.request.baselineBundlePath, { expectedHash: receipt.request.baselineHash });
+  if (receipt.status === "unchanged") return { adopted: false, bundlePath: receipt.request.baselineBundlePath, sha256: receipt.request.baselineHash };
+  if (typeof outputDir !== "string" || !outputDir.trim()) fail("INVALID_REQUEST", "Provide a new baseline output directory");
+  const adoptionPath = join(resolve(outputDir), "adoption.json");
+  try {
+    const prior = JSON.parse(await fs.readFile(adoptionPath, "utf8"));
+    if (prior.schemaVersion !== 1 || prior.refreshHash !== expectedHash || prior.priorBaselineHash !== receipt.request.baselineHash || !HASH.test(prior.acceptedHash ?? "")) fail("REQUEST_CONFLICT", "This baseline belongs to another refresh");
+    const accepted = await readEvidenceBundle(join(resolve(outputDir), "evidence.json"), { expectedHash: prior.acceptedHash });
+    return { adopted: true, bundlePath: join(resolve(outputDir), "evidence.json"), sha256: prior.acceptedHash, bundle: accepted.bundle, adoptionPath, reused: true };
+  } catch (error) { if (error.code !== "ENOENT") throw error; }
+  const accepted = await acceptEvidenceBaseline({
+    repositoryPath: receipt.request.repositoryPath, inputPath: candidate.path, generatedPath: generated.path,
+    evidence: receipt.request.evidence, outputDir,
+  });
+  await publish(adoptionPath, {
+    schemaVersion: 1, refreshPath: resolve(receiptPath), refreshHash: expectedHash,
+    priorBaselinePath: receipt.request.baselineBundlePath, priorBaselineHash: receipt.request.baselineHash,
+    acceptedHash: accepted.sha256,
+  });
+  return { adopted: true, ...accepted, adoptionPath, reused: false };
+}

--- a/src/render.js
+++ b/src/render.js
@@ -6,13 +6,13 @@ import { randomBytes } from 'node:crypto';
 import { chromium } from 'playwright';
 const assets = resolve(dirname(fileURLToPath(import.meta.url)), '../dist/preview');
 const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="color-scheme" content="light"><title>Diagram review · Excalidraw Toolkit</title><link rel="stylesheet" href="./assets/preview.css"></head><body><div id="app"><p class="boot-message" role="status">Opening your diagram…</p></div><script type="module" src="./assets/preview.js"></script></body></html>`;
-export async function servePreview(scene, { port = 0, title, beforeScene, changes, review, previewPngs } = {}) {
+export async function servePreview(scene, { port = 0, title, beforeScene, proposalScene, changes, review, previewPngs } = {}) {
   if (!existsSync(resolve(assets, 'preview.js'))) throw new Error('PREVIEW_BUILD_MISSING: reinstall the packed toolkit or run npm run build');
   const token = randomBytes(18).toString('hex');
   const prefix = `/${token}/`;
   const bytes = JSON.stringify(scene);
   const retainedPngs = Object.fromEntries(Object.entries(previewPngs ?? {}).filter(([view, png]) => ['before', 'after', 'proposal'].includes(view) && Buffer.isBuffer(png)).map(([view, png]) => [view, Buffer.from(png)]));
-  const context = JSON.stringify({ title: typeof title === 'string' ? title : null, beforeScene: beforeScene ?? null, changes: Array.isArray(changes) ? changes : null, review: review ?? null, retainedPngViews: Object.keys(retainedPngs) });
+  const context = JSON.stringify({ title: typeof title === 'string' ? title : null, beforeScene: beforeScene ?? null, proposalScene: proposalScene ?? null, changes: Array.isArray(changes) ? changes : null, review: review ?? null, retainedPngViews: Object.keys(retainedPngs) });
   const server = createServer((req, res) => {
     const pathname = new URL(req.url, 'http://127.0.0.1').pathname;
     res.setHeader('Cache-Control', 'no-store');

--- a/src/review-receipts.js
+++ b/src/review-receipts.js
@@ -77,3 +77,46 @@ export async function readComparisonReview(receiptPath, { expectedHash } = {}) {
   return { scene: after.scene, beforeScene: before.scene, previewPngs,
     review: { kind: 'source-comparison', receiptHash: hash, title: 'Source comparison', viewLabels: { before: 'Before', after: 'After' }, sides } };
 }
+
+
+export async function readRefreshReview(receiptPath, { expectedHash } = {}) {
+  const path = resolve(receiptPath), directory = dirname(path);
+  const { readVerifiedRefresh } = await import('./refresh.js');
+  const verified = await readVerifiedRefresh(path, { expectedHash });
+  const { receipt, current, proposed, candidate, evidence } = verified;
+  const { report: manifest } = await readReport(join(directory, 'previews.json'));
+  const expectedSides = candidate ? { before: 'current', after: 'candidate' } : { before: 'current', proposal: 'generated' };
+  if (manifest?.schemaVersion !== 1 || manifest.refreshHash !== verified.sha256 || manifest.refreshStatus !== receipt.status ||
+      !isDeepStrictEqual(Object.keys(manifest.images ?? {}).sort(), Object.keys(expectedSides).sort())) fail('Preview manifest does not identify this refresh');
+  const previewPngs = {};
+  for (const [side, native] of Object.entries(expectedSides)) {
+    const entry = manifest.images[side];
+    if (entry?.native !== native || !new RegExp(`^previews/[a-f0-9-]+/${side}\\.png$`).test(entry?.file ?? '')) fail('Invalid refresh preview reference');
+    // Reject symlinked parents as well as symlinked image files.
+    for (const parent of ['previews', dirname(entry.file)]) {
+      if (!(await fs.lstat(join(directory, parent))).isDirectory()) fail('Preview paths must remain inside the receipt directory');
+    }
+    const { bytes } = await artifact(directory, entry, entry.file);
+    if (bytes.length <= 8 || bytes.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a') fail('Invalid retained PNG');
+    previewPngs[side === 'proposal' ? 'after' : side] = bytes;
+  }
+  const labels = new Map();
+  for (const scene of [proposed, current]) {
+    const index = new Map(scene.elements.map(element => [element.id, element]));
+    for (const element of scene.elements) {
+      const texts = (element.boundElements ?? []).filter(item => item.type === 'text').map(item => index.get(item.id));
+      const label = element.type === 'text' ? element.originalText ?? element.text : texts.map(text => text?.originalText ?? text?.text).filter(Boolean).join(' ');
+      if (label) labels.set(element.id, label);
+    }
+  }
+  const nodeIds = new Map(evidence.nodes.map(item => [item.semanticId, item.elementId]));
+  for (const relation of evidence.relations) {
+    if (!labels.has(relation.elementId)) labels.set(relation.elementId, `${labels.get(nodeIds.get(relation.from)) || 'Source'} → ${labels.get(nodeIds.get(relation.to)) || 'Target'}`);
+  }
+  const describe = item => ({ ...item, label: labels.get(item.elementId) || 'Diagram element' });
+  return { previewPngs, scene: candidate ?? proposed, beforeScene: current, ...(candidate ? { proposalScene: proposed } : {}),
+    review: { kind: 'source-refresh', title: 'Source refresh', receiptHash: verified.sha256, status: receipt.status,
+      viewLabels: candidate ? { before: 'Before', proposal: 'Source proposal', after: receipt.status === 'reconciliation-required' ? 'Partial candidate' : 'Candidate' } : { before: 'Before', after: 'Source proposal' },
+      source: { revision: evidence.source.revision ?? 'Working tree', scope: evidence.scope },
+      conflicts: receipt.conflicts.map(describe), overrides: receipt.overrides.map(describe), changes: receipt.changes.map(describe) } };
+}

--- a/src/web/ReceiptDetails.jsx
+++ b/src/web/ReceiptDetails.jsx
@@ -3,6 +3,7 @@ import './receipt-details.css';
 
 export function ReceiptDetails({ review, view }) {
   if (!review) return null;
+  if (review.kind === 'source-refresh') return <RefreshDetails review={review} view={view} />;
   const side = review.sides[view];
   return <div className="receipt-details">
     <section className="sidebar-section">
@@ -24,6 +25,49 @@ export function ReceiptDetails({ review, view }) {
       <div className="section-heading"><h2>Scope & unknowns</h2></div>
       <p className="sidebar-note">Partial analysis · {side.scope.paths.join(', ')}</p>
       <ul className="receipt-unknowns">{side.scope.unknowns.map((unknown, index) => <li key={index}>{unknown}</li>)}</ul>
+    </section>
+  </div>;
+}
+
+
+const FIELD_NAMES = { x: 'Horizontal position', y: 'Vertical position', width: 'Width', height: 'Height', text: 'Label', originalText: 'Label source', strokeColor: 'Stroke', backgroundColor: 'Fill' };
+const CONFLICT_NAMES = { FIELD_CONFLICT: 'Both versions changed this field', MISSING_GENERATED_BASELINE: 'No accepted generated baseline', HUMAN_REMOVAL: 'Removed in your version', DELETE_MODIFIED_ELEMENT: 'Source removed an element you edited', UNRESOLVED_IDENTITY: 'Source identity needs reconciliation', NATIVE_ID_CHANGED: 'Native identity changed', ELEMENT_ID_COLLISION: 'Element identity already exists', BOUND_TEXT_ID_CHANGED: 'Bound label identity changed', TOPOLOGY_CONFLICT: 'Connections need reconciliation', ASSET_CONFLICT: 'Both versions changed an image' };
+function readableValue(value) {
+  if (!value?.present) return 'Unset';
+  if (typeof value.value === 'object') return 'Changed structure';
+  if (typeof value.value === 'number') return String(Math.round(value.value * 100) / 100);
+  return String(value.value);
+}
+function RefreshDetails({ review, view }) {
+  const blocked = review.status === 'reconciliation-required';
+  const conflicts = review.conflicts.filter(item => item.field !== 'originalText' || !review.conflicts.some(other => other.elementId === item.elementId && other.field === 'text' && JSON.stringify([other.baseline, other.human, other.proposed]) === JSON.stringify([item.baseline, item.human, item.proposed]))).sort((a, b) => Number(b.field === 'text') - Number(a.field === 'text'));
+  const grouped = new Map();
+  for (const item of review.overrides) {
+    if (!grouped.has(item.label)) grouped.set(item.label, new Set());
+    grouped.get(item.label).add(({ x: 'Position', y: 'Position', text: 'Label', originalText: 'Label', width: 'Size', height: 'Size', points: 'Connection route' })[item.field] || FIELD_NAMES[item.field] || 'Appearance');
+  }
+  return <div className="receipt-details">
+    <section className="sidebar-section">
+      <div className="section-heading"><h2>Refresh status</h2></div>
+      <p className="receipt-question">{blocked ? 'Needs reconciliation' : review.status === 'unchanged' ? 'Source is unchanged' : 'Candidate ready for review'}</p>
+      <p className="sidebar-note">{blocked ? 'Conflicts prevent adoption. Review the proposal and any partial candidate before staging a resolved refresh.' : 'Staging keeps your accepted baseline unchanged. Adoption is a separate explicit command; this receipt does not record whether it happened later.'}</p>
+      <p className="receipt-view-note">{view === 'before' ? 'Your diagram when refresh was staged.' : view === 'proposal' || review.viewLabels[view] === 'Source proposal' ? 'Generated from the inspected source, before preserving your overrides.' : blocked ? 'Partial candidate. Conflicts are unresolved.' : 'Merged candidate with your overrides preserved.'}</p>
+    </section>
+    {review.conflicts.length > 0 && <section className="sidebar-section">
+      <div className="section-heading"><h2>Conflicts</h2><span>{conflicts.length}</span></div>
+      <ul className="receipt-relations">{conflicts.map((item, index) => <li key={index}><strong>{item.label}{item.field ? ` · ${FIELD_NAMES[item.field] || item.field}` : ''}</strong><p>{CONFLICT_NAMES[item.code] || 'Manual reconciliation required'}</p>{item.code === 'FIELD_CONFLICT' && <dl className="receipt-conflict-values"><dt>Baseline</dt><dd>{readableValue(item.baseline)}</dd><dt>Yours</dt><dd>{readableValue(item.human)}</dd><dt>Proposal</dt><dd>{readableValue(item.proposed)}</dd></dl>}</li>)}</ul>
+    </section>}
+    <section className="sidebar-section">
+      <div className="section-heading"><h2>Preserved overrides</h2><span>{grouped.size}</span></div>
+      {review.overrides.length ? <ul className="receipt-unknowns">{[...grouped].map(([label, fields]) => <li key={label}>{label} · {[...fields].join(', ')}</li>)}</ul> : <p className="sidebar-note">No separate overrides were recorded.</p>}
+      <p className="sidebar-note">{review.changes.length} source {review.changes.length === 1 ? 'field change' : 'field changes'} recorded by this refresh.</p>
+    </section>
+    <section className="sidebar-section">
+      <div className="section-heading"><h2>Proposal scope & unknowns</h2></div>
+      <p className="receipt-question">{review.source.scope.question}</p>
+      <p className="receipt-revision">Revision <code title={review.source.revision}>{review.source.revision.slice(0, 10)}</code></p>
+      <p className="sidebar-note">Partial analysis · {review.source.scope.paths.join(', ')}. Runtime behavior has not been verified.</p>
+      <ul className="receipt-unknowns">{review.source.scope.unknowns.map((unknown, index) => <li key={index}>{unknown}</li>)}</ul>
     </section>
   </div>;
 }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -164,7 +164,9 @@ function Review() {
   const fileInput = useRef(null);
   const canvasPanel = useRef(null);
   const tabs = useRef([]);
-  const displayed = view === 'before' ? context.beforeScene : scene;
+  const displayed = view === 'before' ? context.beforeScene : view === 'proposal' ? context.proposalScene : scene;
+  const viewKeys = Object.keys(context.review?.viewLabels || { before: 'Before', after: 'After' });
+  const viewLabel = key => context.review?.viewLabels[key] || (key === 'before' ? 'Before' : 'After');
   activeScene = displayed;
   const elements = useMemo(() => displayed?.elements.filter(e => !e.isDeleted) || [], [displayed]);
   const title = context.title?.trim() || (typeof scene?.appState?.name === 'string' && scene.appState.name) || 'Diagram review';
@@ -186,7 +188,7 @@ function Review() {
       const response = await fetch(`./${resource}`);
       if (!response.ok) throw new Error('The diagram could not be loaded. Reopen the preview and try again.');
       return response.json();
-    })).then(([value, metadata]) => { validate(value); if (metadata.beforeScene) validate(metadata.beforeScene); setScene(value); setContext(metadata); }).catch(error => reportError(error.message));
+    })).then(([value, metadata]) => { validate(value); if (metadata.beforeScene) validate(metadata.beforeScene); if (metadata.proposalScene) validate(metadata.proposalScene); setScene(value); setContext(metadata); }).catch(error => reportError(error.message));
   }, []);
   useEffect(() => { document.title = `${title} · Excalidraw Toolkit`; }, [title]);
   useEffect(() => {
@@ -257,7 +259,7 @@ function Review() {
       <button className="sidebar-toggle" aria-expanded={detailsOpen} aria-controls="scene-details" onClick={() => setDetailsOpen(value => !value)}><Icon name="layers" size={16} /><span>Diagram details</span><span aria-hidden="true">{detailsOpen ? '−' : '+'}</span></button>
       <aside id="scene-details" className="review-sidebar" data-open={detailsOpen} aria-label="Diagram details">
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
-        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
+        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
         {context.review ? <ReceiptDetails review={context.review} view={view} /> : <>
         <EditSummary changes={changes} summary={summary} key={revision} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
@@ -268,11 +270,11 @@ function Review() {
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>Review a copy. Keep your original.</span></div>
       </aside>
       <main id="diagram-workspace" className="diagram-workspace" tabIndex={-1}>
-        <div className="workspace-heading"><div><p className="eyebrow">{context.beforeScene ? 'Compare & review' : 'Your diagram'}</p><h1>{title}</h1><p className="workspace-description">{context.review ? 'Trace each relationship to its source, and see what changed.' : context.beforeScene ? 'A clear view of what changed, with the original close at hand.' : 'Explore the details. Take the editable file with you.'}</p></div><span className="review-badge"><span />Read-only preview</span></div>
+        <div className="workspace-heading"><div><p className="eyebrow">{context.beforeScene ? 'Compare & review' : 'Your diagram'}</p><h1>{title}</h1><p className="workspace-description">{context.review?.kind === 'source-refresh' ? 'Compare the source proposal with your changes and the staged candidate.' : context.review ? 'Trace each relationship to its source, and see what changed.' : context.beforeScene ? 'A clear view of what changed, with the original close at hand.' : 'Explore the details. Take the editable file with you.'}</p></div><span className="review-badge"><span />Read-only preview</span></div>
         {error && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{error}</span>{scene && <button aria-label="Dismiss error" onClick={() => setError('')}>×</button>}</div>}
         <div className="canvas-card">
-          <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{context.beforeScene ? (view === 'after' ? 'Updated diagram' : 'Original diagram') : 'Canvas'}</span></div>
-            {context.beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{['before', 'after'].map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? 1 : 1 - index; selectView(['before', 'after'][next]); tabs.current[next]?.focus(); } }}>{item === 'before' ? 'Before' : 'After'}</button>)}</div>}
+          <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{context.review?.kind === 'source-refresh' ? viewLabel(view) : context.beforeScene ? (view === 'after' ? 'Updated diagram' : 'Original diagram') : 'Canvas'}</span></div>
+            {context.beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{viewKeys.map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? viewKeys.length - 1 : (index + (event.key === 'ArrowRight' ? 1 : viewKeys.length - 1)) % viewKeys.length; selectView(viewKeys[next]); tabs.current[next]?.focus(); } }}>{viewLabel(item)}</button>)}</div>}
             <button aria-label="Fit diagram" className="fit-button" disabled={!ready || !elements.length} onClick={fitDiagram}><Icon name="fit" size={15} /><span>Fit diagram</span></button>
           </div>
           <div ref={canvasPanel} id="canvas-panel" className="canvas-panel" role={context.beforeScene ? 'tabpanel' : 'region'} aria-labelledby={context.beforeScene ? `${view}-tab` : undefined} aria-label={context.beforeScene ? undefined : 'Diagram canvas'} aria-busy={!ready && !error}>
@@ -280,7 +282,7 @@ function Review() {
           </div>
           <div className="canvas-footer"><span id="status" role="status"><span className={`status-dot ${ready ? 'is-ready' : ''}`} />{ready ? `${elements.length} ${elements.length === 1 ? 'element' : 'elements'} · Viewing a read-only copy` : error ? 'Preview unavailable' : 'Preparing canvas…'}</span><span className="canvas-hint">Scroll to pan · Pinch to zoom</span></div>
         </div>
-        <div className="workspace-footer"><span>Made to stay editable.</span><span role="status" aria-live="polite">{notice || (context.beforeScene ? `Exports use the ${view} view.` : 'PNG for sharing. Excalidraw for what comes next.')}</span></div>
+        <div className="workspace-footer"><span>Made to stay editable.</span><span role="status" aria-live="polite">{notice || (context.beforeScene ? `Exports use the ${viewLabel(view).toLowerCase()} view.` : 'PNG for sharing. Excalidraw for what comes next.')}</span></div>
       </main>
     </div>
   </div>;

--- a/src/web/receipt-details.css
+++ b/src/web/receipt-details.css
@@ -16,3 +16,8 @@
 .receipt-sources a:hover { color: #6f452f; }
 .receipt-unknowns { padding-left: 16px; margin: 11px 0 0; color: #7b715f; font-size: 11px; line-height: 1.65; }
 .receipt-unknowns li + li { margin-top: 8px; }
+
+.receipt-view-note { margin: 12px 0 0; padding-left: 10px; border-left: 2px solid var(--clay); font-size: 12px; line-height: 1.6; }
+.receipt-conflict-values { display: grid; grid-template-columns: 55px minmax(0, 1fr); gap: 5px 8px; margin: 10px 0; font-size: 11px; line-height: 1.5; }
+.receipt-conflict-values dt { color: var(--muted); }
+.receipt-conflict-values dd { margin: 0; overflow-wrap: anywhere; }

--- a/src/workflow-commands.js
+++ b/src/workflow-commands.js
@@ -1,7 +1,9 @@
 import { promises as fs } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { sha256 } from './scene.js';
 
-export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline', 'explain-change']);
+export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline', 'explain-change', 'refresh-diagram', 'adopt-refresh']);
 const fail = (code, message) => { throw Object.assign(new Error(message), { code }); };
 
 async function readRequest(requestPath) {
@@ -33,11 +35,72 @@ function requestOptions(request, directory, values, allowed, pathFields) {
   return options;
 }
 
+async function refreshPreviews(result, renderer) {
+  const directory = dirname(result.receiptPath);
+  const manifestPath = join(directory, 'previews.json');
+  const verify = async () => {
+    const bytes = await fs.readFile(manifestPath);
+    const manifest = JSON.parse(bytes.toString());
+    if (manifest.refreshHash !== result.sha256 || manifest.schemaVersion !== 1 || manifest.refreshStatus !== result.receipt.status ||
+        !manifest.images?.before || !(manifest.images.after ?? manifest.images.proposal) || Object.keys(manifest.images).length !== 2) fail('CORRUPT_PREVIEW', 'Preview manifest identifies another or incomplete refresh');
+    for (const entry of Object.values(manifest.images)) {
+      if (!/^previews\/[a-f0-9-]+\/(before|after|proposal)\.png$/.test(entry.file) ||
+          !/^[a-f0-9]{64}$/.test(entry.sha256 ?? '')) fail('CORRUPT_PREVIEW', 'Invalid retained refresh preview reference');
+      let image;
+      try { image = await fs.readFile(join(directory, entry.file)); }
+      catch { fail('CORRUPT_PREVIEW', 'A retained refresh preview is unavailable'); }
+      if (sha256(image) !== entry.sha256) fail('CORRUPT_PREVIEW', 'A retained refresh preview changed');
+    }
+    return { manifestPath, sha256: sha256(bytes), manifest };
+  };
+  try { return await verify(); } catch (error) { if (error.code !== 'ENOENT') throw error; }
+  const attempt = `previews/${randomUUID()}`;
+  await fs.mkdir(join(directory, attempt), { recursive: true });
+  const images = {};
+  const sides = { before: 'current', ...(result.receipt.artifacts.candidate ? { after: 'candidate' } : { proposal: 'generated' }) };
+  for (const [side, key] of Object.entries(sides)) {
+    const native = result.receipt.artifacts[key];
+    const bytes = await fs.readFile(join(directory, native.file));
+    if (sha256(bytes) !== native.sha256) fail('CORRUPT_REFRESH', 'A refresh native artifact changed before preview');
+    const file = `${attempt}/${side}.png`;
+    await renderer(JSON.parse(bytes.toString()), join(directory, file));
+    const png = await fs.readFile(join(directory, file));
+    if (png.length <= 8 || png.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a') fail('INVALID_PREVIEW', 'Native renderer did not produce a PNG');
+    images[side] = { file, sha256: sha256(png), native: key };
+    const handle = await fs.open(join(directory, file), 'r');
+    try { await handle.sync(); } finally { await handle.close(); }
+  }
+  for (const entry of Object.values(result.receipt.artifacts).filter(Boolean)) {
+    if (sha256(await fs.readFile(join(directory, entry.file))) !== entry.sha256) fail('CORRUPT_REFRESH', 'Renderer changed a retained native artifact');
+  }
+  const bytes = `${JSON.stringify({ schemaVersion: 1, refreshHash: result.sha256, refreshStatus: result.receipt.status, images }, null, 2)}\n`;
+  const pending = join(directory, `${attempt}/manifest.pending.json`);
+  const handle = await fs.open(pending, 'wx', 0o600);
+  try { await handle.writeFile(bytes); await handle.sync(); } finally { await handle.close(); }
+  try { await fs.link(pending, manifestPath); } catch (error) { if (error.code !== 'EEXIST') throw error; }
+  await fs.unlink(pending);
+  return verify();
+}
+
 /** JSON command boundary. It returns data; the CLI owns printing and exit codes.
  * Filesystem paths in requests are relative to the request file, not shell cwd. */
 export async function workflowCommand(command, requestPath, values = {}, dependencies = {}) {
   if (!WORKFLOW_COMMANDS.includes(command)) fail('UNKNOWN_COMMAND', `Unknown workflow command: ${command}`);
   const { request, directory } = await readRequest(requestPath);
+  if (command === 'adopt-refresh') {
+    const options = requestOptions(request, directory, values, ['receiptPath', 'expectedHash', 'outputDir'], ['receiptPath', 'outputDir']);
+    const { adoptRefresh } = await import('./refresh.js');
+    return adoptRefresh(options);
+  }
+  if (command === 'refresh-diagram') {
+    const options = requestOptions(request, directory, values,
+      ['requestId', 'baselineBundlePath', 'baselineHash', 'currentPath', 'generatedPath', 'repositoryPath', 'evidence', 'removedSemanticIds', 'outputDir'],
+      ['baselineBundlePath', 'currentPath', 'generatedPath', 'repositoryPath', 'outputDir']);
+    const { stageRefresh } = await import('./refresh.js');
+    const result = await stageRefresh(options);
+    const renderer = dependencies.renderScene ?? (await import('./render.js')).renderScene;
+    return { ...result, previews: await refreshPreviews(result, renderer) };
+  }
   if (command === 'explain-change') {
     const options = requestOptions(request, directory, values,
       ['repositoryPath', 'base', 'head', 'target', 'required', 'repositoryUrl', 'outputDir'], ['repositoryPath', 'outputDir']);

--- a/test/refresh.test.js
+++ b/test/refresh.test.js
@@ -1,0 +1,405 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { acceptEvidenceBaseline, associateEvidence, readEvidenceBundle } from "../src/evidence.js";
+import { adoptRefresh, mergeGeneratedScenes, stageRefresh } from "../src/refresh.js";
+import { readRefreshReview } from "../src/review-receipts.js";
+import { validateScene, sha256 } from "../src/scene.js";
+
+const exec = promisify(execFile);
+const copy = structuredClone;
+function scene() {
+  return {
+    type: "excalidraw", version: 2, unknownScene: { preserve: true }, appState: { gridSize: 20 },
+    files: { unused: { dataURL: "retained asset" } },
+    elements: [
+      { id: "api", type: "rectangle", x: 0, y: 0, width: 100, height: 80, backgroundColor: "#fff", boundElements: [{ id: "flow", type: "arrow" }, { id: "api-label", type: "text" }] },
+      { id: "api-label", type: "text", text: "API", originalText: "API", x: 20, y: 20, width: 30, height: 20, containerId: "api" },
+      { id: "worker", type: "rectangle", x: 300, y: 0, width: 100, height: 80, backgroundColor: "#fff", customData: { annotation: "keep" }, boundElements: [{ id: "flow", type: "arrow" }, { id: "worker-label", type: "text" }] },
+      { id: "worker-label", type: "text", text: "Worker", originalText: "Worker", x: 320, y: 20, width: 60, height: 20, containerId: "worker" },
+      { id: "flow", type: "arrow", points: [[0, 0], [200, 0]], startBinding: { elementId: "api" }, endBinding: { elementId: "worker" } },
+      { id: "note", type: "text", text: "Human annotation", x: 0, y: 200, unknownElement: [1, 2] },
+    ],
+  };
+}
+function evidence() {
+  return {
+    schemaVersion: 1, source: { kind: "git", revision: "HEAD" },
+    scope: { question: "How does the request reach the worker?", paths: ["src"], coverage: "partial", unknowns: ["Runtime routing was not observed."] },
+    references: [{ id: "source", path: "src/flow.js", startLine: 1, endLine: 1, symbol: "handle" }],
+    nodes: [{ semanticId: "request:api", elementId: "api", referenceIds: ["source"] }, { semanticId: "request:worker", elementId: "worker", referenceIds: ["source"] }],
+    relations: [{ semanticId: "request:next", elementId: "flow", from: "request:api", to: "request:worker", kind: "assumption", claim: "This is an authored flow hypothesis.", referenceIds: ["source"] }],
+  };
+}
+const element = (scene, id) => scene.elements.find(element => element.id === id);
+function mergeFixture() {
+  return { baselineGenerated: scene(), current: scene(), proposedGenerated: scene(), baselineEvidence: evidence(), proposedEvidence: evidence() };
+}
+function addQueue(input) {
+  const { proposedGenerated: proposed, proposedEvidence: next } = input;
+  element(proposed, "flow").endBinding.elementId = "queue";
+  element(proposed, "flow").points = [[0, 0], [70, 0]];
+  element(proposed, "worker").boundElements = [{ id: "queued-flow", type: "arrow" }, { id: "worker-label", type: "text" }];
+  proposed.elements.push(
+    { id: "queue", type: "rectangle", x: 150, y: 0, width: 100, height: 80, boundElements: [{ id: "flow", type: "arrow" }, { id: "queued-flow", type: "arrow" }] },
+    { id: "queued-flow", type: "arrow", points: [[0, 0], [70, 0]], startBinding: { elementId: "queue" }, endBinding: { elementId: "worker" } },
+  );
+  next.nodes.push({ semanticId: "request:queue", elementId: "queue", referenceIds: ["source"] });
+  next.relations[0].to = "request:queue";
+  next.relations.push({ semanticId: "request:queue-to-worker", elementId: "queued-flow", from: "request:queue", to: "request:worker", kind: "assumption", claim: "The proposed queue forwards work.", referenceIds: ["source"] });
+}
+
+test("fieldwise refresh preserves moved components, custom labels and all unrelated content", () => {
+  const input = mergeFixture();
+  element(input.current, "worker").x = 450;
+  element(input.current, "worker-label").x = 470;
+  element(input.current, "worker-label").text = "My worker";
+  element(input.current, "worker-label").originalText = "My worker";
+  input.current.unknownScene = { manual: true };
+  element(input.proposedGenerated, "api").backgroundColor = "#a5d8ff";
+  element(input.proposedGenerated, "worker").customData = { unknown: "source cannot overwrite this" };
+  element(input.proposedGenerated, "note").text = "Source tries to overwrite a manual note";
+  input.proposedGenerated.appState.gridSize = 99;
+  const before = copy(input);
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "ready");
+  assert.equal(element(result.candidate, "api").backgroundColor, "#a5d8ff");
+  for (const id of ["worker", "worker-label", "note"]) assert.deepEqual(element(result.candidate, id), element(input.current, id));
+  assert.deepEqual(result.candidate.appState, input.current.appState);
+  assert.deepEqual(result.candidate.unknownScene, input.current.unknownScene);
+  assert.deepEqual(result.candidate.files, input.current.files);
+  assert.ok(result.overrides.some(change => change.elementId === "worker" && change.field === "x"));
+  assert.deepEqual(input, before);
+});
+
+test("different human and source labels produce explicit conflicts with each value", () => {
+  const input = mergeFixture();
+  element(input.current, "worker-label").text = "My worker";
+  element(input.proposedGenerated, "worker-label").text = "Queue worker";
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "reconciliation-required");
+  assert.deepEqual(result.conflicts[0], {
+    code: "FIELD_CONFLICT", semanticId: "request:worker", elementId: "worker-label", field: "text",
+    baseline: { present: true, value: "Worker" }, human: { present: true, value: "My worker" }, proposed: { present: true, value: "Queue worker" },
+  });
+  assert.equal(element(result.candidate, "worker-label").text, "My worker");
+  element(input.proposedGenerated, "worker-label").text = "My worker";
+  assert.equal(mergeGeneratedScenes(input).status, "ready");
+});
+
+test("source topology additions keep native identities and validate the resulting bindings", () => {
+  const input = mergeFixture();
+  addQueue(input);
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "ready");
+  validateScene(result.candidate);
+  assert.equal(element(result.candidate, "flow").endBinding.elementId, "queue");
+  assert.deepEqual(element(result.candidate, "note"), element(input.current, "note"));
+  assert.equal(result.candidate.elements.filter(item => item.id === "queue").length, 1);
+});
+
+test("uncertain renames and native ID replacement require reconciliation", () => {
+  const input = mergeFixture();
+  input.proposedEvidence.nodes[1].semanticId = "renamed:worker";
+  input.proposedEvidence.relations[0].to = "renamed:worker";
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "reconciliation-required");
+  assert.ok(result.conflicts.some(item => item.code === "UNRESOLVED_IDENTITY"));
+  assert.ok(result.conflicts.some(item => item.code === "ELEMENT_ID_COLLISION"));
+  assert.deepEqual(element(result.candidate, "worker"), element(input.current, "worker"));
+  const replacement = mergeFixture();
+  replacement.proposedGenerated.elements.push({ id: "new-api", type: "rectangle" });
+  replacement.proposedEvidence.nodes[0].elementId = "new-api";
+  assert.ok(mergeGeneratedScenes(replacement).conflicts.some(item => item.code === "NATIVE_ID_CHANGED"));
+});
+
+test("removal is explicit, scoped and blocked by manual changes or surviving dependencies", () => {
+  const input = mergeFixture();
+  input.proposedGenerated.elements = input.proposedGenerated.elements.filter(item => !["worker", "worker-label", "flow"].includes(item.id));
+  element(input.proposedGenerated, "api").boundElements = [{ id: "api-label", type: "text" }];
+  input.proposedEvidence.nodes.pop();
+  input.proposedEvidence.relations = [];
+  assert.equal(mergeGeneratedScenes(input).status, "reconciliation-required");
+  input.removedSemanticIds = ["request:worker", "request:next"];
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "ready");
+  for (const id of ["worker", "worker-label", "flow"]) assert.equal(element(result.candidate, id).isDeleted, true);
+  validateScene(result.candidate);
+  const changed = copy(input);
+  element(changed.current, "worker").customData.annotation = "A new human note";
+  assert.ok(mergeGeneratedScenes(changed).conflicts.some(item => item.code === "DELETE_MODIFIED_ELEMENT"));
+  const outside = copy(input);
+  outside.proposedEvidence.scope.paths = ["different-subsystem"];
+  assert.ok(mergeGeneratedScenes(outside).conflicts.some(item => item.code === "REMOVAL_OUTSIDE_SCOPE"));
+  const unknown = copy(input);
+  unknown.baselineEvidence.relations[0].referenceIds = [];
+  assert.ok(mergeGeneratedScenes(unknown).conflicts.some(item => item.code === "REMOVAL_SCOPE_UNKNOWN"));
+  const dependency = copy(input);
+  dependency.current.elements.push({ id: "manual-arrow", type: "arrow", endBinding: { elementId: "worker" } });
+  element(dependency.current, "worker").boundElements.push({ id: "manual-arrow", type: "arrow" });
+  assert.equal(mergeGeneratedScenes(dependency).status, "reconciliation-required");
+});
+
+test("broken candidate topology is never emitted as an adoptable native file", () => {
+  const input = mergeFixture();
+  addQueue(input);
+  element(input.current, "worker").boundElements.push({ id: "manual-label", type: "text" });
+  input.current.elements.push({ id: "manual-label", type: "text", containerId: "worker" });
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "reconciliation-required");
+  assert.equal(result.candidate, null);
+  assert.ok(result.conflicts.some(item => item.code === "TOPOLOGY_CONFLICT"));
+});
+
+test("a shared image asset cannot change unmanaged copies", () => {
+  const input = mergeFixture();
+  for (const value of [input.baselineGenerated, input.current, input.proposedGenerated]) {
+    value.files.shared = { dataURL: "original image" };
+    value.elements.push({ id: "source-image", type: "image", fileId: "shared" }, { id: "manual-image", type: "image", fileId: "shared" });
+  }
+  for (const value of [input.baselineEvidence, input.proposedEvidence]) value.nodes.push({ semanticId: "source:image", elementId: "source-image", referenceIds: ["source"] });
+  input.proposedGenerated.files.shared = { dataURL: "updated image" };
+  const result = mergeGeneratedScenes(input);
+  assert.equal(result.status, "reconciliation-required");
+  assert.deepEqual(result.conflicts, [{ code: "UNMANAGED_ASSET_CONFLICT", fileId: "shared", elementIds: ["manual-image"] }]);
+  assert.deepEqual(result.candidate.files.shared, input.current.files.shared);
+  assert.deepEqual(element(result.candidate, "manual-image"), element(input.current, "manual-image"));
+  assert.ok(!result.changes.some(change => change.kind === "asset"));
+
+  // A shared update is allowed when every consumer is explicitly source-owned.
+  for (const value of [input.baselineEvidence, input.proposedEvidence]) value.nodes.push({ semanticId: "source:image-copy", elementId: "manual-image", referenceIds: ["source"] });
+  const managed = mergeGeneratedScenes(input);
+  assert.equal(managed.status, "ready");
+  assert.deepEqual(managed.candidate.files.shared, input.proposedGenerated.files.shared);
+});
+
+async function diskFixture(t) {
+  const root = await fs.mkdtemp(join(tmpdir(), "toolkit refresh "));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const repositoryPath = join(root, "repo");
+  await fs.mkdir(join(repositoryPath, "src"), { recursive: true });
+  const git = async (...args) => (await exec("git", ["-C", repositoryPath, ...args])).stdout.trim();
+  await git("init", "-b", "main");
+  const commit = async code => {
+    await fs.writeFile(join(repositoryPath, "src/flow.js"), code);
+    await git("add", "src/flow.js");
+    await git("-c", "user.name=Refresh fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgSign=false", "commit", "-m", "test: update flow fixture");
+  };
+  await commit("export function handle() { return 'worker'; }\n");
+  const basePath = join(root, "base.excalidraw");
+  const currentPath = join(root, "human.excalidraw");
+  const generatedPath = join(root, "new.excalidraw");
+  const original = `${JSON.stringify(scene(), null, 4)}\n\n`;
+  await fs.writeFile(basePath, original);
+  await fs.writeFile(currentPath, original);
+  const base = await acceptEvidenceBaseline({ repositoryPath, inputPath: basePath, generatedPath: basePath, evidence: evidence(), outputDir: join(root, "base-bundle") });
+  await fs.writeFile(generatedPath, original);
+  return { root, basePath, original, repositoryPath, currentPath, generatedPath, baselineBundlePath: base.bundlePath, baselineHash: base.sha256, evidence: evidence(), outputDir: join(root, "stage"), requestId: "queue-refresh", commit, git };
+}
+
+test("staging and explicit adoption retain exact baselines, request hashes and manual overrides", async t => {
+  const f = await diskFixture(t);
+  await f.commit("export function handle() { return 'queue-worker'; }\n");
+  const human = scene();
+  element(human, "worker").x = 420;
+  await fs.writeFile(f.currentPath, JSON.stringify(human));
+  const proposed = scene();
+  element(proposed, "api").backgroundColor = "#a5d8ff";
+  await fs.writeFile(f.generatedPath, JSON.stringify(proposed));
+  const beforeBaseline = await fs.readFile(f.baselineBundlePath);
+  const beforeHuman = await fs.readFile(f.currentPath);
+  const saved = await stageRefresh(f);
+  assert.equal(saved.receipt.status, "ready");
+  assert.equal(saved.receipt.request.evidence.source.revision, await f.git("rev-parse", "HEAD"));
+  assert.equal((await stageRefresh(f)).reused, true);
+  assert.deepEqual(await fs.readFile(f.baselineBundlePath), beforeBaseline);
+  assert.deepEqual(await fs.readFile(f.currentPath), beforeHuman);
+  const outputDir = join(f.root, "adopted");
+  const adopted = await adoptRefresh({ receiptPath: saved.receiptPath, expectedHash: saved.sha256, outputDir });
+  assert.equal(adopted.adopted, true);
+  const retained = await readEvidenceBundle(adopted.bundlePath, { expectedHash: adopted.sha256 });
+  assert.deepEqual(retained.generatedScene, proposed);
+  assert.equal(element(retained.deliveredScene, "worker").x, 420);
+  assert.equal(element(retained.deliveredScene, "api").backgroundColor, "#a5d8ff");
+  const lineage = JSON.parse(await fs.readFile(adopted.adoptionPath, "utf8"));
+  assert.equal(lineage.priorBaselineHash, f.baselineHash);
+  assert.equal(lineage.refreshHash, saved.sha256);
+  assert.equal((await adoptRefresh({ receiptPath: saved.receiptPath, expectedHash: saved.sha256, outputDir })).reused, true);
+  assert.deepEqual(await fs.readFile(f.currentPath), beforeHuman);
+});
+
+test("the same source revision creates no scene churn and never advances the baseline", async t => {
+  const f = await diskFixture(t);
+  const regenerated = scene();
+  element(regenerated, "worker").x = 999;
+  await fs.writeFile(f.generatedPath, JSON.stringify(regenerated));
+  const saved = await stageRefresh(f);
+  assert.equal(saved.receipt.status, "unchanged");
+  assert.equal(await fs.readFile(join(f.outputDir, "candidate.excalidraw"), "utf8"), f.original);
+  const outputDir = join(f.root, "must-not-create");
+  const adopted = await adoptRefresh({ receiptPath: saved.receiptPath, expectedHash: saved.sha256, outputDir });
+  assert.equal(adopted.adopted, false);
+  assert.equal(adopted.bundlePath, f.baselineBundlePath);
+  await assert.rejects(fs.stat(outputDir), { code: "ENOENT" });
+});
+
+test("associations and missing baselines produce reconciliation receipts that cannot be adopted", async t => {
+  const f = await diskFixture(t);
+  const association = await associateEvidence({ repositoryPath: f.repositoryPath, inputPath: f.currentPath, evidence: f.evidence, outputDir: join(f.root, "association") });
+  for (const [name, baselineBundlePath, baselineHash] of [["associated", association.bundlePath, association.sha256], ["missing", undefined, undefined]]) {
+    const saved = await stageRefresh({ ...f, baselineBundlePath, baselineHash, outputDir: join(f.root, name) });
+    assert.equal(saved.receipt.status, "reconciliation-required");
+    assert.equal(saved.receipt.conflicts[0].code, "MISSING_GENERATED_BASELINE");
+    await assert.rejects(adoptRefresh({ receiptPath: saved.receiptPath, expectedHash: saved.sha256, outputDir: join(f.root, `${name}-adopt`) }), { code: "RECONCILIATION_REQUIRED" });
+  }
+});
+
+test("conflicts, later human edits and changed artifacts block adoption without writing a baseline", async t => {
+  const f = await diskFixture(t);
+  await f.commit("export function handle() { return 'new-worker'; }\n");
+  const proposed = scene();
+  element(proposed, "worker-label").text = "New worker";
+  await fs.writeFile(f.generatedPath, JSON.stringify(proposed));
+  const human = scene();
+  element(human, "worker-label").text = "My worker";
+  await fs.writeFile(f.currentPath, JSON.stringify(human));
+  const conflict = await stageRefresh(f);
+  await assert.rejects(adoptRefresh({ receiptPath: conflict.receiptPath, expectedHash: conflict.sha256, outputDir: join(f.root, "blocked") }), { code: "RECONCILIATION_REQUIRED" });
+  await assert.rejects(fs.stat(join(f.root, "blocked")), { code: "ENOENT" });
+  await fs.writeFile(f.currentPath, f.original);
+  const ready = await stageRefresh({ ...f, outputDir: join(f.root, "ready") });
+  await fs.appendFile(f.currentPath, " ");
+  await assert.rejects(adoptRefresh({ receiptPath: ready.receiptPath, expectedHash: ready.sha256, outputDir: join(f.root, "stale") }), { code: "STALE_INPUT" });
+  await fs.writeFile(f.currentPath, f.original);
+  await fs.appendFile(join(f.root, "ready/candidate.excalidraw"), " ");
+  await assert.rejects(adoptRefresh({ receiptPath: ready.receiptPath, expectedHash: ready.sha256, outputDir: join(f.root, "tampered") }), { code: "CORRUPT_REFRESH" });
+  await assert.rejects(fs.stat(join(f.root, "tampered")), { code: "ENOENT" });
+});
+
+test("a reused output cannot silently accept a different request or corrupted retained file", async t => {
+  const f = await diskFixture(t);
+  await stageRefresh(f);
+  await assert.rejects(stageRefresh({ ...f, requestId: "different" }), { code: "REQUEST_CONFLICT" });
+  await fs.appendFile(join(f.outputDir, "candidate.excalidraw"), " ");
+  await assert.rejects(stageRefresh(f), { code: "CORRUPT_REFRESH" });
+});
+
+
+async function reviewPreviews(saved) {
+  const directory = join(saved.receiptPath, '..');
+  await fs.mkdir(join(directory, 'previews/abcd'), { recursive: true });
+  const images = {};
+  for (const [side, native] of Object.entries({ before: 'current', ...(saved.receipt.artifacts.candidate ? { after: 'candidate' } : { proposal: 'generated' }) })) {
+    const file = `previews/abcd/${side}.png`, bytes = Buffer.alloc(33);
+    Buffer.from('89504e470d0a1a0a', 'hex').copy(bytes);
+    await fs.writeFile(join(directory, file), bytes);
+    images[side] = { file, sha256: sha256(bytes), native };
+  }
+  const manifest = { schemaVersion: 1, refreshHash: saved.sha256, refreshStatus: saved.receipt.status, images };
+  await fs.writeFile(join(directory, 'previews.json'), JSON.stringify(manifest));
+  return manifest;
+}
+
+test('refresh review checks native merge and distinguishes human, proposal and candidate', async t => {
+  const f = await diskFixture(t);
+  await f.commit("export function handle() { return 'queued'; }\n");
+  const human = scene(), proposed = scene();
+  element(human, 'worker').x = 420;
+  element(proposed, 'api').backgroundColor = '#a5d8ff';
+  await fs.writeFile(f.currentPath, JSON.stringify(human));
+  await fs.writeFile(f.generatedPath, JSON.stringify(proposed));
+  const saved = await stageRefresh(f);
+  await reviewPreviews(saved);
+  const beforeFiles = await fs.readdir(f.root);
+  const loaded = await readRefreshReview(saved.receiptPath, { expectedHash: saved.sha256 });
+  assert.deepEqual(loaded.beforeScene, human);
+  assert.deepEqual(loaded.proposalScene, proposed);
+  assert.equal(element(loaded.scene, 'worker').x, 420);
+  assert.equal(element(loaded.scene, 'api').backgroundColor, '#a5d8ff');
+  assert.deepEqual(loaded.review.viewLabels, { before: 'Before', proposal: 'Source proposal', after: 'Candidate' });
+  assert.equal(loaded.review.status, 'ready');
+  assert.deepEqual(Object.keys(loaded.previewPngs), ['before', 'after']);
+  const images = JSON.parse(await fs.readFile(join(f.outputDir, 'previews.json'))).images;
+  assert.equal(sha256(loaded.previewPngs.after), images.after.sha256);
+  assert.ok(loaded.review.overrides.some(item => item.label === 'Worker'));
+  assert.deepEqual(await fs.readdir(f.root), beforeFiles);
+});
+
+test('refresh review recomputes conflicts and rejects fabricated ready status', async t => {
+  const f = await diskFixture(t);
+  await f.commit("export function handle() { return 'queued'; }\n");
+  const human = scene(), proposed = scene();
+  element(human, 'worker-label').text = 'Ops worker';
+  element(proposed, 'worker-label').text = 'Queue worker';
+  await fs.writeFile(f.currentPath, JSON.stringify(human));
+  await fs.writeFile(f.generatedPath, JSON.stringify(proposed));
+  const saved = await stageRefresh(f);
+  await reviewPreviews(saved);
+  const loaded = await readRefreshReview(saved.receiptPath);
+  assert.equal(loaded.review.status, 'reconciliation-required');
+  assert.equal(loaded.review.viewLabels.after, 'Partial candidate');
+  assert.equal(loaded.review.conflicts[0].human.value, 'Ops worker');
+  const bytes = await fs.readFile(saved.receiptPath);
+  for (const change of [
+    receipt => { receipt.conflicts = []; receipt.status = 'ready'; },
+    receipt => { receipt.overrides.push({ elementId: 'api', field: 'x' }); },
+    receipt => { receipt.proposedEvidence.scope.unknowns = []; },
+  ]) {
+    const receipt = JSON.parse(bytes); change(receipt);
+    await fs.writeFile(saved.receiptPath, JSON.stringify(receipt));
+    await assert.rejects(readRefreshReview(saved.receiptPath), { code: 'CORRUPT_REFRESH' });
+  }
+  await fs.writeFile(saved.receiptPath, bytes);
+  await fs.appendFile(join(f.outputDir, 'candidate.excalidraw'), ' ');
+  await assert.rejects(readRefreshReview(saved.receiptPath), { code: 'CORRUPT_REFRESH' });
+});
+
+test('refresh review rejects mismatched preview manifests, PNGs and malformed receipts', async t => {
+  const f = await diskFixture(t), saved = await stageRefresh(f);
+  const manifest = await reviewPreviews(saved), path = join(f.outputDir, 'previews.json');
+  const receiptBytes = await fs.readFile(saved.receiptPath);
+  for (const content of ['null', '{}', '{']) {
+    await fs.writeFile(saved.receiptPath, content);
+    await assert.rejects(readRefreshReview(saved.receiptPath), { code: 'CORRUPT_REFRESH' });
+  }
+  await fs.writeFile(saved.receiptPath, receiptBytes);
+  for (const change of [
+    value => { value.refreshHash = '0'.repeat(64); },
+    value => { value.images.after.native = 'generated'; },
+    value => { value.images.after.file = '../after.png'; },
+  ]) {
+    const value = copy(manifest); change(value);
+    await fs.writeFile(path, JSON.stringify(value));
+    await assert.rejects(readRefreshReview(saved.receiptPath), { code: 'CORRUPT_REVIEW' });
+  }
+  await fs.writeFile(path, JSON.stringify(manifest));
+  await fs.appendFile(join(f.outputDir, manifest.images.after.file), 'changed');
+  await assert.rejects(readRefreshReview(saved.receiptPath), { code: 'CORRUPT_REVIEW' });
+});
+
+
+test('refresh review shows the source proposal when topology prevents a candidate', async t => {
+  const f = await diskFixture(t);
+  await f.commit("export function handle() { return 'queue'; }\n");
+  const input = mergeFixture();
+  addQueue(input);
+  element(input.current, 'worker').boundElements.push({ id: 'manual-label', type: 'text' });
+  input.current.elements.push({ id: 'manual-label', type: 'text', text: 'Manual', containerId: 'worker' });
+  await fs.writeFile(f.currentPath, JSON.stringify(input.current));
+  await fs.writeFile(f.generatedPath, JSON.stringify(input.proposedGenerated));
+  const saved = await stageRefresh({ ...f, evidence: input.proposedEvidence });
+  assert.equal(saved.receipt.artifacts.candidate, null);
+  await reviewPreviews(saved);
+  const loaded = await readRefreshReview(saved.receiptPath);
+  assert.deepEqual(loaded.review.viewLabels, { before: 'Before', after: 'Source proposal' });
+  assert.deepEqual(loaded.scene, input.proposedGenerated);
+  assert.equal(loaded.proposalScene, undefined);
+  const images = JSON.parse(await fs.readFile(join(f.outputDir, 'previews.json'))).images;
+  assert.equal(sha256(loaded.previewPngs.after), images.proposal.sha256);
+  assert.equal(loaded.review.status, 'reconciliation-required');
+  assert.ok(loaded.review.conflicts.some(item => item.code === 'TOPOLOGY_CONFLICT'));
+});

--- a/test/workflow-commands.test.js
+++ b/test/workflow-commands.test.js
@@ -108,3 +108,39 @@ test('explain-change dispatches source comparison and returns retained native/ta
   assert.equal(await fs.readFile(join(f.root, 'comparison/after.excalidraw'), 'utf8'), f.bytes);
   assert.equal(result.report.changes.nodes[0].status, 'unchanged');
 });
+
+test('refresh requests preserve a human move, recover preview failure, and require explicit adoption', async t => {
+  const f = await workflowFixture(t);
+  await f.save({ ...f.request, generatedPath: 'input.excalidraw', outputDir: 'baseline' });
+  const baseline = await workflowCommand('accept-baseline', f.requestPath);
+  const current = structuredClone(f.scene); current.elements[0].x = 30;
+  await fs.writeFile(join(f.root, 'human.excalidraw'), JSON.stringify(current));
+  const proposed = structuredClone(f.scene); proposed.elements[0].backgroundColor = '#d0ebff';
+  await fs.writeFile(join(f.root, 'generated.excalidraw'), JSON.stringify(proposed));
+  await fs.writeFile(join(f.repositoryPath, 'api.js'), 'export function handle() { return 2; }\n');
+  await f.git('add', '.');
+  await f.git('-c', 'user.name=Workflow fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgSign=false', 'commit', '-m', 'test: change workflow source');
+  const revision = await f.git('rev-parse', 'HEAD');
+  const request = { requestId: 'refresh-1', baselineBundlePath: 'baseline/evidence.json', baselineHash: baseline.sha256,
+    currentPath: 'human.excalidraw', generatedPath: 'generated.excalidraw', repositoryPath: 'source',
+    evidence: { ...f.evidence, source: { kind: 'git', revision } }, outputDir: 'refresh' };
+  await f.save(request);
+  await assert.rejects(workflowCommand('refresh-diagram', f.requestPath, {}, { renderScene: () => { throw new Error('Preview failed'); } }), /Preview failed/);
+  await assert.rejects(fs.stat(join(f.root, 'refresh/previews.json')), { code: 'ENOENT' });
+  const png = Buffer.from('89504e470d0a1a0a00000000', 'hex');
+  const result = await workflowCommand('refresh-diagram', f.requestPath, {}, { renderScene: async (_scene, path) => fs.writeFile(path, png) });
+  assert.equal(result.receipt.status, 'ready');
+  assert.equal(result.reused, true);
+  const candidate = JSON.parse(await fs.readFile(join(f.root, 'refresh/candidate.excalidraw')));
+  assert.equal(candidate.elements[0].x, 30);
+  assert.equal(candidate.elements[0].backgroundColor, '#d0ebff');
+  assert.deepEqual(Object.keys(result.previews.manifest.images), ['before', 'after']);
+  const again = await workflowCommand('refresh-diagram', f.requestPath, {}, { renderScene: () => assert.fail('Completed previews rendered again') });
+  assert.equal(again.previews.sha256, result.previews.sha256);
+  assert.equal(JSON.parse(await fs.readFile(join(f.root, 'baseline/evidence.json'))).evidence.source.revision, f.revision);
+  await f.save({ receiptPath: 'refresh/refresh.json', expectedHash: result.sha256, outputDir: 'adopted' });
+  const adopted = await workflowCommand('adopt-refresh', f.requestPath);
+  assert.equal(adopted.adopted, true);
+  assert.equal(adopted.bundle.evidence.source.revision, revision);
+  assert.equal(JSON.parse(await fs.readFile(join(f.root, 'human.excalidraw'))).elements[0].backgroundColor, undefined);
+});


### PR DESCRIPTION
Add `refresh-diagram` to merge the last accepted generated scene, the current human-edited scene and a new source proposal. Independent source changes apply while manual positions, labels, styles and unrelated content remain intact. Competing field changes, uncertain identities, missing generated baselines and shared unmanaged image assets produce explicit conflicts.

Staging retains an edited copy, native inputs, previews and a change report. Only `adopt-refresh` advances the accepted baseline. The review workspace distinguishes the human scene, source proposal and candidate, recomputes receipt claims, and shows conflicting values and blocked status. Repeating an unchanged source revision causes no scene churn.

## Testing

- Refresh/CLI fixtures cover field overrides, additions/removals, shared assets, broken bindings, retries, stale inputs, explicit adoption and altered review receipts.
- Native fixture and computer-use review confirmed the moved worker, custom `Ops worker` label and annotation survive. The competing label fixture visibly reports the conflict and cannot be adopted.
