### PR TITLE
[CI]: qualify scoped diagram updates as retained artifacts

### DIFF
--- a/bin/ci-refresh-runner.mjs
+++ b/bin/ci-refresh-runner.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { runPreparedRefresh } from '../src/ci-workflow.js';
+
+const { values } = parseArgs({ options: { proposal: { type: 'string' } } });
+if (!values.proposal) throw new Error('Provide --proposal for an already investigated refresh request');
+let input = '';
+for await (const chunk of process.stdin) {
+  input += chunk;
+  if (input.length > 32 * 1024 * 1024) throw new Error('CI request exceeds 32 MiB');
+}
+const result = await runPreparedRefresh(JSON.parse(input), values.proposal);
+process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,6 +39,7 @@ Usage:
   npx ${pkg.name} explain-change --request <json>  Export source-linked revision views
   npx ${pkg.name} refresh-diagram --request <json>  Stage a source refresh with previews
   npx ${pkg.name} adopt-refresh --request <json>  Explicitly accept a reviewed refresh
+  npx ${pkg.name} ci-diagram --request <json>  Run an explicitly configured source job
   npx ${pkg.name} version    Print version
 
 Options: --home <directory>, --target <claude|codex|all>, --project <directory>,

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,151 @@
+# Scoped Git and CI artifacts
+
+`runDiagramJob` is a thin invocation of a configured, existing diagram workflow.
+It does not choose a model, inspect an entire repository, run a second agent,
+adopt a refresh, overwrite the diagram, or publish a comment.
+
+Configure the source scope and a pinned accepted PR9/PR11 baseline:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "request-flow",
+  "sourcePaths": ["src/api", "src/worker"],
+  "diagramPath": "docs/request-flow.excalidraw",
+  "trigger": "manual",
+  "baseline": {"bundlePath": "baseline/evidence.json", "sha256": "<retained manifest SHA-256>"},
+  "output": "jobs",
+  "execution": {
+    "version": "reviewed-workflow-v1",
+    "executable": "/absolute/path/to/node",
+    "args": ["/absolute/path/to/reviewed-existing-workflow.mjs"],
+    "timeoutMs": 300000,
+    "forwardEnv": ["ANTHROPIC_API_KEY"]
+  }
+}
+```
+
+Replace the paths and manifest hash with verified values. The executable and
+literal argv are explicit; no shell expansion or command templates are supported.
+`forwardEnv` names explicitly authorized runtime credentials. GitHub and Actions
+credential variables are never forwarded. The minimal inherited environment is
+PATH, SYSTEMROOT and TMPDIR; CLI authentication using a home directory must be
+configured explicitly in a trusted workflow. This is a process boundary, not a
+sandbox against a malicious executable. Do not execute fork-controlled scripts,
+configuration or source with credentials.
+
+An event file declares `trigger`, full `baseRevision`, full `sourceRevision`,
+`headRef` (for example `refs/heads/main`) and `trusted: true`. The trusted flag
+comes from the CI controller's checked event policy, never an incoming PR file.
+Untrusted events fail before launching either the executable or an injected
+runner. Trigger values are `push`, `pull_request` and `manual`.
+
+```sh
+node examples/ci/run-job.mjs --repository /checkout --state /restored-state \
+  --config /trusted/diagram-job.json --event /trusted/event.json
+```
+
+`examples/ci/diagram-artifacts.yml` demonstrates a manual GitHub Actions trigger
+that restores an explicitly selected artifact from a prior trusted run. It needs
+a reviewed runtime adapter and its model access; missing access produces a failed
+job. Adapting it to push/PR events requires a trusted event classifier, current
+head fetching, and a persisted baseline source. Do not switch it to
+`pull_request_target` or execute a fork checkout with publishing credentials.
+
+## Existing workflow contract
+
+The executable reads one JSON request from stdin:
+
+```js
+{
+  schemaVersion: 1, requestId, repositoryPath, baseRevision, sourceRevision,
+  sourcePaths, baselineBundlePath, baselineHash, currentPath, outputDir
+}
+```
+
+Use the same source-evidence and `stageRefresh` commands as the interactive
+workflow. Supply the exact proposed source revision, preserve overrides, and
+render the resulting native candidate. Never automatically call `adoptRefresh`.
+Retain the staged refresh directory under outputDir, write the evidence and report,
+then emit one JSON object on stdout pointing to four regular public artifacts:
+
+```json
+{
+  "status": "ready",
+  "artifacts": {
+    "native": "candidate.excalidraw",
+    "preview": "preview.png",
+    "evidence": "evidence.json",
+    "report": "change-report.json"
+  }
+}
+```
+
+`unchanged` is also accepted. Evidence uses the raw PR9 schema with an exact Git
+revision and scope no wider than configured paths. The report contains
+`schemaVersion: 1`, the matching `status`, `sourceRevision`, `baseRevision`,
+`changes`, `overrides` and `conflicts` from the staged refresh, plus
+`refresh: { "file": "refresh/refresh.json", "sha256": "<retained refresh hash>" }`.
+The refresh receipt and its `current.excalidraw`, `generated.excalidraw` and
+`candidate.excalidraw` snapshots must remain in that directory. Use `stageRefresh`
+with the exact request ID, baseline, current scene and repository paths supplied
+by the controller. `runPreparedRefresh` already returns this contract.
+
+Qualification rechecks the source references and recomputes the three-way merge
+against the controller's retained baseline and current scene. The candidate,
+evidence and reported changes/overrides/conflicts must match that result. Rewriting
+candidate hashes cannot conceal a removed manual note or a lost human override.
+A runner cannot qualify an arbitrary replacement scene by claiming `ready`.
+
+The preview must use the toolkit's standard native PNG export (light background,
+30px padding). Pinned Chromium decodes it and compares every pixel with a fresh
+export of the verified candidate. Positive dimensions are limited to 16384px per
+side and 16 megapixels. `INVALID_PREVIEW` means the image is unreadable or outside
+those bounds; `PREVIEW_MISMATCH` means it does not match the candidate. Regenerate
+the preview using the toolkit renderer. Browser setup is required for this check;
+`PREVIEW_BROWSER_MISSING` directs the caller to `excalidraw-toolkit setup-preview`.
+
+Nonempty conflicts, missing refresh proof, stale references, invalid bindings,
+candidate/report mismatches, unreadable or mismatched previews, unavailable runtime
+or timeout produce a durable failed job. A successful child exit code alone is
+insufficient. Pixel correspondence and source-location checks do not prove source
+claims or visual readability; those remain the agent's acceptance obligations.
+
+For embedding, import `runDiagramJob(options, {runner})`. The injected runner has
+the same request/result contract and receives `{signal}`. It must honor aborts.
+The subprocess adapter kills its owned process group at the configured timeout.
+
+## Persistence and ordering
+
+Keep `stateDir` outside the checkout. Restore the complete accepted baseline
+directory and receipts before every ephemeral run, retaining their hashes. The
+job snapshots and verifies its baseline and committed diagram bytes. State keys
+use exact source/base commits, head ref, event policy and canonical configuration,
+so changing the checkout's absolute path does not change a completed job's key.
+
+Jobs live under `output/id/<job key>/job.json`. All attempts and artifact files
+are immutable namespaces. Duplicate completed/failed events reuse and verify
+their receipts. A different execution version explicitly permits a new attempt
+after a terminal failure. Crashed attempts on the same host can recover through
+an exclusive new claim; a foreign unfinished host remains busy. Restore completed
+receipts across runners, or explicitly reconcile an unfinished remote claim.
+
+Completed jobs record `verification.method: "three-way-native-v1"`, native preview
+dimensions/renderer identity and hashes of the retained refresh and input proof
+files. Duplicate/restored jobs verify those files without rerunning the agent or
+renderer. Older completed receipts without this qualification are rejected;
+change `execution.version` to create a fresh qualified job while retaining the old
+evidence. Upload the complete job directory, including input and proof files.
+
+The orchestrator checks the configured Git head before running and after artifact
+validation. Superseded jobs retain their evidence but cannot overwrite any newer
+job. There is no mutable `latest` output or implicit baseline advancement. Fetch
+current refs in CI immediately before each invocation; a stale local ref cannot
+establish remote currency. Publication adds a separate live GitHub head check.
+Use CI concurrency controls when multiple hosts share a publication destination;
+this module does not provide cross-host cancellation or distributed locks.
+
+After explicit adoption, persist the new accepted baseline and configure its
+manifest hash for future jobs. Artifact upload should run even on failure so the
+failed receipt survives. Visibility follows the repository's artifact access
+policy; configure public links only in the optional publisher.

--- a/docs/refresh.md
+++ b/docs/refresh.md
@@ -174,3 +174,10 @@ or PNG and does not advance the accepted baseline.
 When a view has a retained PNG in `previews.json`, the review downloads those
 verified bytes. A separate source-proposal view without a retained PNG uses the
 native renderer; its download does not claim an earlier retained preview hash.
+
+For a controller accepting a runner's result, `verifyRefresh(receiptPath,
+{ expectedHash, baselineBundlePath, baselineHash, currentPath, repositoryPath,
+requestId })` rechecks the retained proposal and recomputes the merge against the
+controller's own pinned inputs. It requires exact candidate/report agreement and
+returns the verified snapshots and checked evidence. CI uses this check before
+qualifying any result; a runner-supplied hash alone cannot establish preservation.

--- a/docs/workflow-commands.md
+++ b/docs/workflow-commands.md
@@ -18,6 +18,7 @@ does not load the browser renderer or require a model runtime.
 | `explain-change` | `repositoryPath`, `base`, `head`, `repositoryUrl`, `target`, `required`, `outputDir` | Native before/after files, matching PNG viewport, source-linked report |
 | `refresh-diagram` | PR11 `stageRefresh` request fields | Native refresh receipt and before/after PNG manifest; no adoption |
 | `adopt-refresh` | `receiptPath`, retained `expectedHash`, new `outputDir` | Explicitly accepted baseline after successful reconciliation |
+| `ci-diagram` | `repositoryPath`, `stateDir`, PR12 `config` and `event` | Immutable completed/failed/skipped/superseded job receipt |
 
 The existing coding agent investigates the selected entry point and path, reads
 source files at the declared revision, constructs supported scene edits, and
@@ -68,3 +69,18 @@ Failed preview attempts remain incomplete; a retry reuses the checked native
 refresh and renders into a new attempt directory. Completed previews are reused
 only after their hashes verify. An explicit `adopt-refresh` call advances the
 accepted baseline; the current human scene is still an untouched input file.
+
+`ci-diagram` invokes the explicit configured executable/argv contract described
+in `docs/ci.md`. It performs no model discovery or fallback inference. For a
+proposal already investigated by the existing coding agent, configure Node with
+literal args `[/absolute/toolkit/bin/ci-refresh-runner.mjs, --proposal,
+/absolute/prepared-proposal.json]`. That proposal contains
+`command: "refresh-diagram"`, `generatedPath`, exact-revision `evidence`, and
+optional `removedSemanticIds`. The adapter invokes the same refresh handler,
+renders previews, and produces the PR12 output manifest. Its generatedPath is
+relative to the proposal file. Staging and CI both leave adoption explicit.
+
+The prepared adapter cannot invent a proposal for a newer commit. Automated
+source investigation needs a separately configured existing agent workflow with
+its authorized model access. An absent model/runtime or a proposal at the wrong
+revision fails; neither is reported as successful automation.

--- a/examples/ci/diagram-artifacts.yml
+++ b/examples/ci/diagram-artifacts.yml
@@ -1,0 +1,66 @@
+# Copy into .github/workflows after configuring the reviewed runtime adapter.
+# The selected state artifact must contain baseline/ and prior jobs/ receipts.
+name: Scoped diagram artifacts
+on:
+  workflow_dispatch:
+    inputs:
+      state_run_id:
+        description: Trusted run containing the accepted diagram-state artifact
+        required: true
+      source_revision:
+        description: Exact trusted source commit
+        required: true
+      base_revision:
+        description: Exact previous source commit
+        required: true
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: diagram-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  diagram:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: toolkit
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+      - uses: actions/checkout@v4
+        with:
+          path: source
+          ref: ${{ inputs.source_revision }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: diagram-state
+          path: diagram-state
+          run-id: ${{ inputs.state_run_id }}
+          github-token: ${{ github.token }}
+      - name: Install trusted toolkit
+        working-directory: toolkit
+        run: npm ci
+      - name: Create explicit event
+        env:
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          BASE_REVISION: ${{ inputs.base_revision }}
+        run: |
+          git -C source update-ref refs/heads/diagram-event "$SOURCE_REVISION"
+          node --input-type=module -e 'import fs from "node:fs"; fs.writeFileSync("event.json", JSON.stringify({trigger:"manual",sourceRevision:process.env.SOURCE_REVISION,baseRevision:process.env.BASE_REVISION,headRef:"refs/heads/diagram-event",trusted:true}));'
+      - name: Produce reviewable artifacts
+        # Configure execution.executable/args in this trusted file. This workflow
+        # deliberately contains no invented model runtime or fallback credentials.
+        run: node toolkit/examples/ci/run-job.mjs --repository source --state diagram-state --config toolkit/diagram-job.json --event event.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: diagram-state
+          path: diagram-state
+          if-no-files-found: error
+          retention-days: 30

--- a/examples/ci/run-job.mjs
+++ b/examples/ci/run-job.mjs
@@ -1,0 +1,12 @@
+import { readFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+import { runDiagramJob } from '../../src/ci.js';
+
+const { values } = parseArgs({ options: Object.fromEntries(
+  ['repository', 'state', 'config', 'event'].map(name => [name, { type: 'string' }]),
+) });
+if (Object.keys(values).length !== 4) throw new Error('Provide --repository, --state, --config and --event');
+const result = await runDiagramJob({ repositoryPath: values.repository, stateDir: values.state,
+  config: JSON.parse(await readFile(values.config, 'utf8')), event: JSON.parse(await readFile(values.event, 'utf8')) });
+console.log(JSON.stringify(result, null, 2));
+if (result.receipt.status === 'failed') process.exitCode = 1;

--- a/plugins/excalidraw/skills/scoped-edit/SKILL.md
+++ b/plugins/excalidraw/skills/scoped-edit/SKILL.md
@@ -99,3 +99,17 @@ When the reviewed candidate is adopted, call `adopt-refresh --request <file>`
 with the refresh `receiptPath`, its retained `expectedHash`, and a new baseline
 `outputDir`. Retain the resulting bundle/hash for the next revision. The installer
 command `update` keeps its existing meaning.
+
+## Generate CI artifacts
+
+Use `ci-diagram --request <file>` only with the user's explicit source paths,
+diagram path, trigger, pinned accepted baseline, output state and execution budget.
+The request contains `repositoryPath`, `stateDir`, `config` and a trusted CI
+`event` with exact commits. Use the existing authorized agent/runtime to prepare
+source proposals, or the provided prepared-refresh adapter for an already
+investigated proposal. An unavailable model or runtime is a failed job.
+
+Persist the complete baseline and job state across runners. Inspect the job status:
+skipped and superseded work are not new completed diagram updates. Validate the
+actual native file and preview before reporting a relevant commit's result.
+Adoption remains explicit, and generation alone does not publish a PR comment.

--- a/src/ci-workflow.js
+++ b/src/ci-workflow.js
@@ -1,0 +1,38 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { workflowCommand } from './workflow-commands.js';
+
+const fail = (code, message) => { throw Object.assign(new Error(message), { code }); };
+
+/** Adapt an already investigated source proposal to the same interactive
+ * refresh command. This adapter performs no model inference or source guessing. */
+export async function runPreparedRefresh(job, proposalPath, dependencies = {}) {
+  const path = resolve(proposalPath);
+  const proposal = JSON.parse(await fs.readFile(path, 'utf8'));
+  if (!proposal || proposal.command !== 'refresh-diagram' ||
+      Object.keys(proposal).some(key => !['command', 'generatedPath', 'evidence', 'removedSemanticIds'].includes(key)) ||
+      typeof proposal.generatedPath !== 'string' || !proposal.generatedPath.trim() ||
+      proposal.evidence?.source?.kind !== 'git' || proposal.evidence.source.revision !== job.sourceRevision) {
+    fail('INVALID_PROPOSAL', 'Provide a prepared refresh-diagram proposal at the exact requested Git revision');
+  }
+  const requestPath = join(job.outputDir, 'refresh-request.json');
+  const request = { requestId: job.requestId, baselineBundlePath: job.baselineBundlePath, baselineHash: job.baselineHash,
+    currentPath: job.currentPath, generatedPath: resolve(dirname(path), proposal.generatedPath), repositoryPath: job.repositoryPath,
+    evidence: proposal.evidence, ...(proposal.removedSemanticIds ? { removedSemanticIds: proposal.removedSemanticIds } : {}),
+    outputDir: join(job.outputDir, 'refresh') };
+  await fs.writeFile(requestPath, JSON.stringify(request), { flag: 'wx' });
+  const result = await workflowCommand('refresh-diagram', requestPath, {}, dependencies);
+  if (!['ready', 'unchanged'].includes(result.receipt.status) || result.receipt.conflicts.length || !result.receipt.artifacts.candidate) {
+    fail('RECONCILIATION_REQUIRED', 'Prepared source refresh has unresolved conflicts; inspect its retained receipt and previews');
+  }
+  const report = { schemaVersion: 1, status: result.receipt.status, sourceRevision: job.sourceRevision, baseRevision: job.baseRevision,
+    changes: result.receipt.changes, conflicts: result.receipt.conflicts, overrides: result.receipt.overrides,
+    refresh: { file: 'refresh/refresh.json', sha256: result.sha256 }, previews: result.previews.manifest,
+    validation: { semanticClaims: false, runtimeBehavior: false, visualAcceptance: false } };
+  await fs.writeFile(join(job.outputDir, 'evidence.json'), JSON.stringify(proposal.evidence), { flag: 'wx' });
+  await fs.writeFile(join(job.outputDir, 'change-report.json'), JSON.stringify(report, null, 2), { flag: 'wx' });
+  return { status: result.receipt.status, artifacts: {
+    native: 'refresh/candidate.excalidraw', preview: `refresh/${result.previews.manifest.images.after.file}`,
+    evidence: 'evidence.json', report: 'change-report.json',
+  } };
+}

--- a/src/ci.js
+++ b/src/ci.js
@@ -1,0 +1,321 @@
+import { execFile, spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { hostname } from 'node:os';
+import { dirname, isAbsolute, join, posix, resolve } from 'node:path';
+import { isDeepStrictEqual, promisify } from 'node:util';
+import { randomUUID } from 'node:crypto';
+import { readEvidenceBundle, validateEvidence } from './evidence.js';
+import { sha256, validateScene } from './scene.js';
+import { verifyRefresh } from './refresh.js';
+
+const execute = promisify(execFile);
+const HASH = /^[a-f0-9]{64}$/;
+const REVISION = /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/;
+const MAX_BYTES = 32 * 1024 * 1024;
+const PNG = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const fail = (code, message) => { throw Object.assign(new Error(message), { code }); };
+const canonical = value => JSON.stringify(value, (_, item) => item && typeof item === 'object' && !Array.isArray(item)
+  ? Object.fromEntries(Object.entries(item).sort(([a], [b]) => a.localeCompare(b))) : item);
+const inside = (path, parent) => parent === '.' || path === parent || path.startsWith(`${parent}/`);
+
+function relativePath(value) {
+  if (typeof value !== 'string' || !value || isAbsolute(value) || /[\\\u0000\r\n]/u.test(value) ||
+      posix.normalize(value) !== value || value.split('/').some(part => ['..', '.', '.git'].includes(part))) {
+    fail('INVALID_CONFIG', 'Use normalized relative paths outside .git');
+  }
+  return value;
+}
+
+function checkedConfig(config) {
+  if (config?.schemaVersion !== 1 || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(config.id ?? '') ||
+      !Array.isArray(config.sourcePaths) || !config.sourcePaths.length ||
+      !['push', 'pull_request', 'manual'].includes(config.trigger) ||
+      !HASH.test(config.baseline?.sha256 ?? '') || typeof config.execution?.version !== 'string' || !config.execution.version.trim()) {
+    fail('INVALID_CONFIG', 'Declare schemaVersion, id, sourcePaths, trigger, pinned baseline and execution version');
+  }
+  config.sourcePaths.forEach(path => path === '.' || relativePath(path));
+  relativePath(config.diagramPath);
+  relativePath(config.baseline.bundlePath);
+  relativePath(config.output);
+  if (inside(config.baseline.bundlePath, config.output) || inside(config.output, dirname(config.baseline.bundlePath))) {
+    fail('INVALID_CONFIG', 'Keep the accepted baseline outside the job output directory');
+  }
+  const { executable, args, timeoutMs, forwardEnv = [] } = config.execution;
+  if (typeof executable !== 'string' || !isAbsolute(executable) || executable.includes('\0') ||
+      !Array.isArray(args) || args.some(arg => typeof arg !== 'string' || arg.includes('\0')) ||
+      !Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 3_600_000 ||
+      !Array.isArray(forwardEnv) || forwardEnv.some(name => !/^[A-Z][A-Z0-9_]*$/.test(name) || /^(GH_|GITHUB_|ACTIONS_)/.test(name))) {
+    fail('INVALID_CONFIG', 'Use an absolute executable, literal argv, a 1–3600000 ms budget, and explicit non-GitHub environment names');
+  }
+  return structuredClone(config);
+}
+
+async function git(repository, args) {
+  const { stdout } = await execute('git', ['--no-pager', '--literal-pathspecs', '-C', repository, ...args], {
+    encoding: 'buffer', timeout: 10000, maxBuffer: MAX_BYTES,
+    env: { PATH: process.env.PATH, GIT_TERMINAL_PROMPT: '0', GIT_NO_REPLACE_OBJECTS: '1', GIT_OPTIONAL_LOCKS: '0' },
+  });
+  return stdout;
+}
+
+async function revision(repository, value) {
+  return (await git(repository, ['rev-parse', '--verify', '--end-of-options', `${value}^{commit}`])).toString().trim();
+}
+
+async function regularFile(root, relative) {
+  relativePath(relative);
+  const rootStat = await fs.lstat(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) fail('ARTIFACT_BOUNDARY', 'Artifact roots must be regular directories');
+  let current = root;
+  const parts = relative.split('/');
+  for (let i = 0; i < parts.length; i++) {
+    current = join(current, parts[i]);
+    const stat = await fs.lstat(current);
+    if (stat.isSymbolicLink() || (i === parts.length - 1 ? !stat.isFile() : !stat.isDirectory())) {
+      fail('ARTIFACT_BOUNDARY', 'Artifacts and baselines must be regular files inside their declared directory');
+    }
+    if (i === parts.length - 1 && stat.size > MAX_BYTES) fail('ARTIFACT_SIZE', 'Artifact exceeds the 32 MiB limit');
+  }
+  return current;
+}
+
+async function write(path, bytes) {
+  const handle = await fs.open(path, 'wx', 0o600);
+  try { await handle.writeFile(bytes); await handle.sync(); } finally { await handle.close(); }
+}
+
+async function publish(path, value) {
+  const bytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+  const pending = `${path}.${randomUUID()}.pending`;
+  await write(pending, bytes);
+  try { await fs.link(pending, path); } finally { await fs.unlink(pending); }
+  const handle = await fs.open(dirname(path), 'r');
+  try { await handle.sync(); } finally { await handle.close(); }
+  return sha256(bytes);
+}
+
+async function readJSON(path) { return JSON.parse(await fs.readFile(path, 'utf8')); }
+
+// Claims are immutable generations, so two crash-recovery processes cannot
+// unlink each other's locks. A foreign host must use a separate restored state.
+async function claim(directory) {
+  const claims = join(directory, 'claims');
+  await fs.mkdir(claims, { recursive: true });
+  const names = (await fs.readdir(claims)).filter(name => /^\d+\.json$/.test(name));
+  const generation = Math.max(0, ...names.map(name => Number(name.slice(0, -5))));
+  if (generation) {
+    const owner = await readJSON(join(claims, `${generation}.json`));
+    if (owner.hostname !== hostname()) fail('JOB_BUSY', 'An unfinished job belongs to another runner; restore its completed receipt or use a separate state copy');
+    try { process.kill(owner.pid, 0); fail('JOB_BUSY', 'This exact job is already running'); }
+    catch (error) { if (error.code !== 'ESRCH') throw error; }
+  }
+  const attempt = randomUUID();
+  try { await publish(join(claims, `${generation + 1}.json`), { pid: process.pid, hostname: hostname(), attempt }); }
+  catch (error) { if (error.code === 'EEXIST') fail('JOB_BUSY', 'Another runner claimed this exact job'); throw error; }
+  return attempt;
+}
+
+/** The configured existing agent/workflow reads JSON on stdin and returns JSON
+ * on stdout. There is no shell, interpolation, automatic model, or fallback. */
+export function commandRunner(execution) {
+  return async (request, { signal }) => {
+    const env = Object.fromEntries(['PATH', 'SYSTEMROOT', 'TMPDIR', ...(execution.forwardEnv ?? [])]
+      .filter(name => !/^(GH_|GITHUB_|ACTIONS_)/.test(name) && process.env[name] !== undefined).map(name => [name, process.env[name]]));
+    return await new Promise((resolveResult, reject) => {
+      const child = spawn(execution.executable, execution.args, {
+        cwd: request.repositoryPath, env, stdio: ['pipe', 'pipe', 'pipe'], detached: process.platform !== 'win32',
+      });
+      const stdout = [];
+      let bytes = 0;
+      let failure;
+      const stop = error => {
+        failure ??= error;
+        try { if (process.platform === 'win32') child.kill('SIGKILL'); else process.kill(-child.pid, 'SIGKILL'); } catch {}
+      };
+      const aborted = () => stop(Object.assign(new Error('Configured execution budget expired'), { code: 'EXECUTION_TIMEOUT' }));
+      signal.addEventListener('abort', aborted, { once: true });
+      child.stdout.on('data', chunk => {
+        bytes += chunk.length;
+        if (bytes > MAX_BYTES) stop(Object.assign(new Error('Runner output exceeded its limit'), { code: 'RUNNER_OUTPUT' }));
+        else stdout.push(chunk);
+      });
+      child.stderr.on('data', chunk => { bytes += chunk.length; if (bytes > MAX_BYTES) stop(Object.assign(new Error('Runner logs exceeded their limit'), { code: 'RUNNER_OUTPUT' })); });
+      child.on('error', error => { failure ??= Object.assign(new Error('Configured runtime is unavailable'), { code: error.code ?? 'RUNTIME_UNAVAILABLE' }); });
+      child.stdin.on('error', () => {});
+      child.on('close', code => {
+        signal.removeEventListener('abort', aborted);
+        if (failure) return reject(failure);
+        if (code !== 0) return reject(Object.assign(new Error(`Configured runtime exited with code ${code}; no successful result was produced`), { code: 'RUNTIME_FAILED' }));
+        try { resolveResult(JSON.parse(Buffer.concat(stdout).toString('utf8'))); }
+        catch { reject(Object.assign(new Error('Runtime must return one JSON artifact manifest'), { code: 'RUNNER_OUTPUT' })); }
+      });
+      if (signal.aborted) aborted();
+      child.stdin.end(JSON.stringify(request));
+    });
+  };
+}
+
+async function verifyOutput(result, request) {
+  if (!['ready', 'unchanged'].includes(result?.status)) fail('UNQUALIFIED_RESULT', 'Runtime did not produce a ready or unchanged result');
+  const paths = {};
+  const artifacts = {};
+  for (const name of ['native', 'preview', 'evidence', 'report']) {
+    paths[name] = await regularFile(request.outputDir, result.artifacts?.[name]);
+    const bytes = await fs.readFile(paths[name]);
+    if (name === 'native') validateScene(JSON.parse(bytes.toString()));
+    if (name === 'preview' && (bytes.length <= PNG.length || !bytes.subarray(0, PNG.length).equals(PNG))) fail('INVALID_PREVIEW', 'Expected a native PNG preview');
+    artifacts[name] = { file: result.artifacts[name], sha256: sha256(bytes) };
+  }
+  const evidence = await readJSON(paths.evidence);
+  if (evidence.source?.kind !== 'git' || evidence.source.revision !== request.sourceRevision ||
+      !evidence.scope?.paths.every(path => request.sourcePaths.some(parent => inside(path, parent)))) {
+    fail('SOURCE_SCOPE', 'Output evidence must identify the exact job revision within configured paths');
+  }
+  const checked = await validateEvidence({ repositoryPath: request.repositoryPath, inputPath: paths.native, evidence });
+  if (checked.sceneHash !== artifacts.native.sha256) fail('STALE_ARTIFACT', 'Native output changed during validation');
+  const report = await readJSON(paths.report);
+  if (report.schemaVersion !== 1 || report.status !== result.status || report.sourceRevision !== request.sourceRevision ||
+      report.baseRevision !== request.baseRevision || !Array.isArray(report.changes) || !Array.isArray(report.conflicts) || report.conflicts.length) {
+    fail('UNQUALIFIED_RESULT', 'Change report must match the job and contain no unresolved conflicts');
+  }
+  if (!HASH.test(report.refresh?.sha256 ?? '')) fail('UNQUALIFIED_REFRESH', 'Return a retained stageRefresh receipt with its SHA-256 in report.refresh');
+  const refreshPath = await regularFile(request.outputDir, report.refresh.file);
+  const verified = await verifyRefresh(refreshPath, { expectedHash: report.refresh.sha256,
+    baselineBundlePath: request.baselineBundlePath, baselineHash: request.baselineHash,
+    currentPath: request.currentPath, repositoryPath: request.repositoryPath, requestId: request.requestId });
+  const { sceneHash: candidateHash, ...candidateEvidence } = checked;
+  const { sceneHash: generatedHash, ...generatedEvidence } = verified.checked;
+  if (verified.candidate.sha256 !== artifacts.native.sha256 || verified.receipt.status !== result.status ||
+      !isDeepStrictEqual(candidateEvidence, generatedEvidence) ||
+      ['changes', 'conflicts', 'overrides'].some(field => !isDeepStrictEqual(report[field], verified.receipt[field]))) {
+    fail('UNQUALIFIED_REFRESH', 'Native output, evidence or report differs from the verified three-way refresh');
+  }
+  const { verifyNativePreview } = await import('./render.js');
+  const preview = await verifyNativePreview(verified.candidate.scene, await fs.readFile(paths.preview));
+  const proof = { refresh: { file: report.refresh.file, sha256: report.refresh.sha256 } };
+  for (const name of ['current', 'generated']) proof[name] = {
+    file: posix.join(posix.dirname(report.refresh.file), `${name}.excalidraw`), sha256: verified[name].sha256,
+  };
+  for (const [name, entry] of Object.entries(artifacts)) {
+    if (sha256(await fs.readFile(paths[name])) !== entry.sha256) fail('STALE_ARTIFACT', 'Runtime artifacts changed during verification');
+  }
+  for (const entry of Object.values(proof)) {
+    if (sha256(await fs.readFile(await regularFile(request.outputDir, entry.file))) !== entry.sha256) fail('STALE_ARTIFACT', 'Refresh proof changed during qualification');
+  }
+  return { artifacts, proof, preview };
+}
+
+export async function readDiagramJob(receiptPath, { expectedHash } = {}) {
+  const bytes = await fs.readFile(receiptPath);
+  if (expectedHash !== undefined && sha256(bytes) !== expectedHash) fail('CORRUPT_JOB', 'Job receipt hash differs from the retained hash');
+  const receipt = JSON.parse(bytes.toString());
+  if (receipt.schemaVersion !== 1 || !HASH.test(receipt.jobKey ?? '') ||
+      !REVISION.test(receipt.sourceRevision ?? '') || !REVISION.test(receipt.baseRevision ?? '') ||
+      !['completed', 'failed', 'skipped', 'superseded'].includes(receipt.status)) fail('CORRUPT_JOB', 'Invalid job receipt');
+  if (receipt.status === 'completed' && (!HASH.test(receipt.baselineHash ?? '') || receipt.trusted !== true ||
+      !['ready', 'unchanged'].includes(receipt.result) || ['native', 'preview', 'evidence', 'report'].some(name => !receipt.artifacts?.[name]) ||
+      receipt.verification?.method !== 'three-way-native-v1' || receipt.verification.preview?.pixelMatch !== true ||
+      ['refresh', 'current', 'generated', 'baseline', 'baselineGenerated', 'baselineDelivered', 'input'].some(name => !receipt.verification.artifacts?.[name]))) {
+    fail('CORRUPT_JOB', 'A completed job must retain its qualified artifacts and accepted baseline');
+  }
+  for (const entry of [...Object.values(receipt.artifacts ?? {}), ...Object.values(receipt.verification?.artifacts ?? {})]) {
+    let bytes;
+    try { bytes = await fs.readFile(await regularFile(dirname(resolve(receiptPath)), entry.file)); }
+    catch { fail('CORRUPT_JOB', 'A retained job artifact is missing or outside its boundary'); }
+    if (!HASH.test(entry.sha256 ?? '') || sha256(bytes) !== entry.sha256) fail('CORRUPT_JOB', 'A retained job artifact changed');
+  }
+  return { receiptPath: resolve(receiptPath), sha256: sha256(bytes), receipt };
+}
+
+/** stateDir is a restored, trusted artifact directory, not the source checkout.
+ * Outputs are immutable per revision/configuration; baseline adoption is separate. */
+export async function runDiagramJob({ repositoryPath, stateDir, config: unchecked, event }, { runner } = {}) {
+  const config = checkedConfig(unchecked);
+  if (!REVISION.test(event?.sourceRevision ?? '') || !REVISION.test(event?.baseRevision ?? '') ||
+      !/^refs\/(heads|remotes|pull)\/[A-Za-z0-9._/-]+$/.test(event?.headRef ?? '') || event.headRef.includes('..') ||
+      !['push', 'pull_request', 'manual'].includes(event.trigger) || typeof event.trusted !== 'boolean') fail('INVALID_EVENT', 'Use exact commits, an explicit head ref, trigger, and trusted event classification');
+  const repository = await fs.realpath(resolve(repositoryPath));
+  const top = (await git(repository, ['rev-parse', '--show-toplevel'])).toString().trim();
+  if (await fs.realpath(top) !== repository) fail('SOURCE_BOUNDARY', 'repositoryPath must identify the repository root');
+  const state = resolve(stateDir);
+  if (state === repository || state.startsWith(`${repository}/`)) fail('STATE_BOUNDARY', 'Persist trusted CI state outside the source checkout');
+  await fs.mkdir(state, { recursive: true });
+  const keyInput = { config, sourceRevision: event.sourceRevision, baseRevision: event.baseRevision, headRef: event.headRef, trigger: event.trigger, trusted: event.trusted };
+  const jobKey = sha256(canonical(keyInput));
+  const directory = join(state, config.output, config.id, jobKey);
+  const receiptPath = join(directory, 'job.json');
+  try { return { ...(await readDiagramJob(receiptPath)), duplicate: true }; }
+  catch (error) { if (error.code !== 'ENOENT') throw error; }
+  await fs.mkdir(directory, { recursive: true });
+  const attempt = await claim(directory);
+  const attemptDir = join(directory, 'attempts', attempt);
+  await fs.mkdir(attemptDir, { recursive: true });
+  const receipt = { schemaVersion: 1, jobKey, configId: config.id, sourceRevision: event.sourceRevision,
+    baseRevision: event.baseRevision, headRef: event.headRef, trusted: event.trusted, config, attempt, artifacts: {} };
+  await write(join(attemptDir, 'request.json'), `${JSON.stringify(keyInput, null, 2)}\n`);
+  try {
+    if (!event.trusted) fail('UNTRUSTED_EXECUTION', 'Untrusted source events cannot execute a credentialed diagram workflow');
+    if (event.trigger !== config.trigger) { receipt.status = 'skipped'; receipt.reason = 'trigger-not-configured'; }
+    else if (await revision(repository, event.headRef) !== event.sourceRevision) { receipt.status = 'superseded'; receipt.reason = 'source-head-changed'; }
+    else {
+      if (await revision(repository, event.baseRevision) !== event.baseRevision || await revision(repository, event.sourceRevision) !== event.sourceRevision) fail('INVALID_EVENT', 'Exact source commits are unavailable');
+      const changedPaths = (await git(repository, ['diff', '--name-only', '-z', '--no-renames', event.baseRevision, event.sourceRevision, '--'])).toString().split('\0').filter(Boolean);
+      receipt.changedPaths = changedPaths.filter(path => config.sourcePaths.some(parent => inside(path, parent)));
+      if (!receipt.changedPaths.length) { receipt.status = 'skipped'; receipt.reason = 'no-relevant-source-changes'; }
+      else {
+        const baselinePath = await regularFile(state, config.baseline.bundlePath);
+        const baseline = await readEvidenceBundle(baselinePath, { expectedHash: config.baseline.sha256 });
+        if (!baseline.generatedScene) fail('MISSING_BASELINE', 'CI refresh requires an explicitly accepted generated baseline');
+        const inputDir = join(attemptDir, 'input');
+        const outputDir = join(attemptDir, 'output');
+        await fs.mkdir(inputDir); await fs.mkdir(outputDir);
+        for (const file of ['evidence.json', 'delivered.excalidraw', 'generated.excalidraw']) {
+          const path = await regularFile(dirname(baselinePath), file);
+          await write(join(inputDir, file), await fs.readFile(path));
+        }
+        await readEvidenceBundle(join(inputDir, 'evidence.json'), { expectedHash: config.baseline.sha256 });
+        const tree = (await git(repository, ['ls-tree', '-z', event.sourceRevision, '--', config.diagramPath])).toString();
+        const entry = /^(100644|100755) blob ([a-f0-9]+)\t([^\0]+)\0$/.exec(tree);
+        if (!entry || entry[3] !== config.diagramPath) fail('INVALID_DIAGRAM', 'Diagram must be a regular file at the exact source revision');
+        const currentBytes = await git(repository, ['cat-file', 'blob', entry[2]]);
+        validateScene(JSON.parse(currentBytes.toString()));
+        const currentPath = join(inputDir, 'current.excalidraw');
+        await write(currentPath, currentBytes);
+        const request = { schemaVersion: 1, requestId: jobKey, repositoryPath: repository,
+          baseRevision: event.baseRevision, sourceRevision: event.sourceRevision, sourcePaths: config.sourcePaths,
+          baselineBundlePath: join(inputDir, 'evidence.json'), baselineHash: config.baseline.sha256, currentPath, outputDir };
+        const controller = new AbortController();
+        let timer;
+        const timeout = new Promise((_, reject) => { timer = setTimeout(() => {
+          controller.abort(); reject(Object.assign(new Error('Configured execution budget expired'), { code: 'EXECUTION_TIMEOUT' }));
+        }, config.execution.timeoutMs); });
+        let result;
+        try { result = await Promise.race([(runner ?? commandRunner(config.execution))(structuredClone(request), { signal: controller.signal }), timeout]); }
+        finally { clearTimeout(timer); }
+        const { artifacts, proof, preview } = await verifyOutput(result, request);
+        await readEvidenceBundle(join(inputDir, 'evidence.json'), { expectedHash: config.baseline.sha256 });
+        if (sha256(await fs.readFile(currentPath)) !== sha256(currentBytes)) fail('STALE_INPUT', 'Runtime changed the retained native input');
+        receipt.artifacts = Object.fromEntries(Object.entries(artifacts).map(([name, item]) => [name, {
+          ...item, file: `attempts/${attempt}/output/${item.file}`,
+        }]));
+        const retained = Object.fromEntries(Object.entries(proof).map(([name, item]) => [name, { ...item, file: `attempts/${attempt}/output/${item.file}` }]));
+        for (const [name, file] of Object.entries({ baseline: 'evidence.json', baselineGenerated: 'generated.excalidraw', baselineDelivered: 'delivered.excalidraw', input: 'current.excalidraw' })) {
+          retained[name] = { file: `attempts/${attempt}/input/${file}`, sha256: sha256(await fs.readFile(join(inputDir, file))) };
+        }
+        receipt.verification = { method: 'three-way-native-v1', preview, artifacts: retained };
+        receipt.baselineHash = config.baseline.sha256;
+        receipt.result = result.status;
+        receipt.status = await revision(repository, event.headRef) === event.sourceRevision ? 'completed' : 'superseded';
+        if (receipt.status === 'superseded') receipt.reason = 'source-head-changed';
+      }
+    }
+  } catch (error) {
+    receipt.status = 'failed';
+    // Do not retain runtime stderr or credentials in a public failure artifact.
+    receipt.error = { code: error.code ?? 'JOB_FAILED', message: ['EXECUTION_TIMEOUT', 'RUNTIME_FAILED', 'RUNTIME_UNAVAILABLE', 'UNQUALIFIED_RESULT', 'UNQUALIFIED_REFRESH', 'INVALID_PREVIEW', 'PREVIEW_MISMATCH', 'PREVIEW_BROWSER_MISSING', 'UNTRUSTED_EXECUTION', 'MISSING_BASELINE'].includes(error.code)
+      ? error.message : `Diagram job failed (${error.code ?? 'validation-error'}); no output was qualified` };
+    receipt.artifacts = {};
+  }
+  const hash = await publish(receiptPath, receipt);
+  return { receiptPath, sha256: hash, receipt, duplicate: false };
+}

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -237,6 +237,34 @@ export async function readVerifiedRefresh(receiptPath, { expectedHash } = {}) {
   return { ...saved, current: current.scene, proposed: proposed.scene, candidate: merged.candidate, evidence: checked };
 }
 
+/** Recompute a runner's retained refresh against controller-owned inputs. A
+ * matching receipt hash alone does not establish that its merge was correct. */
+export async function verifyRefresh(receiptPath, { expectedHash, baselineBundlePath, baselineHash, currentPath, repositoryPath, requestId }) {
+  if (!HASH.test(expectedHash ?? "") || !HASH.test(baselineHash ?? "")) fail("UNQUALIFIED_REFRESH", "Retain the refresh and accepted baseline hashes");
+  const { receipt } = await readReceipt(receiptPath, expectedHash);
+  if (receipt.request.requestId !== requestId || receipt.request.baselineHash !== baselineHash ||
+      receipt.request.baselineBundlePath !== resolve(baselineBundlePath) || receipt.request.currentPath !== resolve(currentPath) ||
+      receipt.request.repositoryPath !== resolve(repositoryPath)) fail("UNQUALIFIED_REFRESH", "Refresh request does not identify the controller's retained inputs");
+  const baseline = await readEvidenceBundle(baselineBundlePath, { expectedHash: baselineHash });
+  const trustedCurrent = await native(currentPath);
+  const current = await retainedNative(receiptPath, receipt.artifacts.current, "current.excalidraw");
+  const generated = await retainedNative(receiptPath, receipt.artifacts.generated, "generated.excalidraw");
+  const candidate = await retainedNative(receiptPath, receipt.artifacts.candidate, "candidate.excalidraw");
+  if (current.sha256 !== trustedCurrent.sha256 || receipt.request.currentHash !== current.sha256 || receipt.request.generatedHash !== generated.sha256) {
+    fail("UNQUALIFIED_REFRESH", "Refresh snapshots do not match the controller's current scene or generated input hash");
+  }
+  const checked = await validateEvidence({ repositoryPath, inputPath: generated.path, evidence: receipt.request.evidence });
+  if (!same(checked, receipt.proposedEvidence)) fail("UNQUALIFIED_REFRESH", "Refresh evidence differs from its checked generated scene and source");
+  const merged = mergeRefresh(baseline, current.scene, generated.scene, checked, receipt.request.removedSemanticIds);
+  if (merged.status === "reconciliation-required" || merged.conflicts.length ||
+      !same(merged.candidate, candidate.scene) || receipt.status !== merged.status ||
+      ["changes", "overrides", "conflicts"].some(field => !same(receipt[field], merged[field])) ||
+      (merged.status === "unchanged" && candidate.sha256 !== current.sha256)) {
+    fail("UNQUALIFIED_REFRESH", "Candidate or report differs from the recomputed three-way refresh; preserve human overrides and resolve conflicts before retrying");
+  }
+  return { receipt, checked, current, generated, candidate };
+}
+
 export async function stageRefresh({ requestId, baselineBundlePath, baselineHash, currentPath, generatedPath, repositoryPath, evidence, removedSemanticIds = [], outputDir }) {
   if (typeof requestId !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(requestId)) fail("INVALID_REQUEST", "Provide a stable request ID");
   if (typeof outputDir !== "string" || !outputDir.trim()) fail("INVALID_REQUEST", "Provide a new output directory");

--- a/src/render.js
+++ b/src/render.js
@@ -33,11 +33,11 @@ export async function servePreview(scene, { port = 0, title, beforeScene, propos
   await new Promise((ok, fail) => { server.once('error', fail); server.listen(port, '127.0.0.1', ok); });
   return { url: `http://127.0.0.1:${server.address().port}${prefix}`, close: () => new Promise(resolve => { server.closeAllConnections(); server.close(resolve); }) };
 }
-export async function renderScene(scene, outputPath) {
+async function withNativePage(scene, usePage) {
   const preview = await servePreview(scene);
   let browser;
   try {
-    if (!rendererStatus().ready) throw new Error('PREVIEW_BROWSER_MISSING: run excalidraw-toolkit setup-preview to install the pinned Chromium renderer');
+    if (!rendererStatus().ready) throw Object.assign(new Error('Run excalidraw-toolkit setup-preview to install the pinned Chromium renderer'), { code: 'PREVIEW_BROWSER_MISSING' });
     browser = await chromium.launch();
     const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
     const origin = new URL(preview.url).origin;
@@ -49,13 +49,49 @@ export async function renderScene(scene, outputPath) {
     await page.waitForFunction(() => window.previewReady || window.previewError, { timeout: 20000 });
     const error = await page.evaluate(() => window.previewError);
     if (error) throw new Error(error);
-    const data = await page.evaluate(() => window.renderPng());
+    const result = await usePage(page, browser);
     if (failedAssets.size) throw new Error(`PREVIEW_ASSET_FAILED: ${[...failedAssets].join(', ')}`);
+    return result;
+  } finally { if (browser) await browser.close(); await preview.close(); }
+}
+
+export async function renderScene(scene, outputPath) {
+  const result = await withNativePage(scene, async (page, browser) => {
+    const data = await page.evaluate(() => window.renderPng());
     const png = Buffer.from(data.split(',')[1], 'base64');
     if (png.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a') throw new Error('PREVIEW_INVALID: expected a PNG');
-    writeFileSync(outputPath, png, { flag: 'wx', mode: 0o600 });
-    return { renderer: '@excalidraw/excalidraw@0.18.1', browser: browser.version() };
-  } finally { if (browser) await browser.close(); await preview.close(); }
+    return { png, metadata: { renderer: '@excalidraw/excalidraw@0.18.1', browser: browser.version() } };
+  });
+  writeFileSync(outputPath, result.png, { flag: 'wx', mode: 0o600 });
+  return result.metadata;
+}
+
+/** Decode the supplied image and compare pixels with a fresh standard native
+ * export. This verifies correspondence, not layout quality or source claims. */
+export async function verifyNativePreview(scene, bytes) {
+  const invalid = message => { throw Object.assign(new Error(message), { code: 'INVALID_PREVIEW' }); };
+  if (!Buffer.isBuffer(bytes) || bytes.length < 33 || bytes.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a' ||
+      bytes.readUInt32BE(8) !== 13 || bytes.toString('ascii', 12, 16) !== 'IHDR') invalid('Preview must contain a complete PNG header and image data');
+  const width = bytes.readUInt32BE(16), height = bytes.readUInt32BE(20);
+  if (!width || !height || width > 16384 || height > 16384 || width * height > 16777216) invalid('Preview dimensions must be positive, at most 16384px per side and 16 megapixels');
+  return withNativePage(scene, async (page, browser) => {
+    const decoded = await page.evaluate(async actual => {
+      const read = async src => {
+        const image = new Image(); image.src = src; await image.decode();
+        const canvas = document.createElement('canvas'); canvas.width = image.naturalWidth; canvas.height = image.naturalHeight;
+        const context = canvas.getContext('2d'); context.drawImage(image, 0, 0);
+        return { width: canvas.width, height: canvas.height, pixels: context.getImageData(0, 0, canvas.width, canvas.height).data };
+      };
+      let provided;
+      try { provided = await read(actual); } catch { return { invalid: true }; }
+      const expected = await read(await window.renderPng());
+      const matches = provided.width === expected.width && provided.height === expected.height && provided.pixels.every((value, index) => value === expected.pixels[index]);
+      return { width: provided.width, height: provided.height, matches };
+    }, `data:image/png;base64,${bytes.toString('base64')}`);
+    if (decoded.invalid) invalid('Preview PNG cannot be decoded; render the retained candidate again');
+    if (!decoded.matches) throw Object.assign(new Error('Preview pixels differ from the retained candidate; use the toolkit standard native PNG export'), { code: 'PREVIEW_MISMATCH' });
+    return { width: decoded.width, height: decoded.height, renderer: '@excalidraw/excalidraw@0.18.1', browser: browser.version(), pixelMatch: true };
+  });
 }
 
 export function rendererStatus() {

--- a/src/workflow-commands.js
+++ b/src/workflow-commands.js
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { sha256 } from './scene.js';
 
-export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline', 'explain-change', 'refresh-diagram', 'adopt-refresh']);
+export const WORKFLOW_COMMANDS = Object.freeze(['validate-evidence', 'associate-evidence', 'accept-baseline', 'explain-change', 'refresh-diagram', 'adopt-refresh', 'ci-diagram']);
 const fail = (code, message) => { throw Object.assign(new Error(message), { code }); };
 
 async function readRequest(requestPath) {
@@ -87,6 +87,11 @@ async function refreshPreviews(result, renderer) {
 export async function workflowCommand(command, requestPath, values = {}, dependencies = {}) {
   if (!WORKFLOW_COMMANDS.includes(command)) fail('UNKNOWN_COMMAND', `Unknown workflow command: ${command}`);
   const { request, directory } = await readRequest(requestPath);
+  if (command === 'ci-diagram') {
+    const options = requestOptions(request, directory, values, ['repositoryPath', 'stateDir', 'config', 'event'], ['repositoryPath', 'stateDir']);
+    const { runDiagramJob } = await import('./ci.js');
+    return runDiagramJob(options, dependencies.runner ? { runner: dependencies.runner } : {});
+  }
   if (command === 'adopt-refresh') {
     const options = requestOptions(request, directory, values, ['receiptPath', 'expectedHash', 'outputDir'], ['receiptPath', 'outputDir']);
     const { adoptRefresh } = await import('./refresh.js');

--- a/test/ci.test.js
+++ b/test/ci.test.js
@@ -48,7 +48,8 @@ async function fixture(t) {
   const sourceRevision = await commit();
   const config = { schemaVersion: 1, id: 'request-flow', sourcePaths: ['src'], diagramPath: 'flow.excalidraw', trigger: 'push',
     baseline: { bundlePath: 'baseline/evidence.json', sha256: baseline.sha256 }, output: 'jobs',
-    execution: { version: 'fixture-v1', executable: process.execPath, args: [], timeoutMs: 5000 } };
+    // Real Chromium rendering and nested refreshes need headroom on shared CI runners.
+    execution: { version: 'fixture-v1', executable: process.execPath, args: [], timeoutMs: 30000 } };
   const event = { trigger: 'push', baseRevision, sourceRevision, headRef: 'refs/heads/main', trusted: true };
   const runner = async request => {
     const generated = JSON.parse(await fs.readFile(join(dirname(request.baselineBundlePath), 'generated.excalidraw')));
@@ -189,8 +190,8 @@ test('stale events and events superseded during execution never replace newer ou
     newResult = await runDiagramJob({ ...f, event: { ...f.event, baseRevision: f.event.sourceRevision, sourceRevision } }, { runner: f.runner });
     return f.runner(request);
   } });
-  assert.equal(old.receipt.status, 'superseded');
-  assert.equal(newResult.receipt.status, 'completed');
+  assert.equal(old.receipt.status, 'superseded', JSON.stringify(old.receipt.error));
+  assert.equal(newResult.receipt.status, 'completed', JSON.stringify(newResult.receipt.error));
   assert.notEqual(old.receiptPath, newResult.receiptPath);
   assert.equal((await readDiagramJob(newResult.receiptPath)).sha256, newResult.sha256);
   const stale = await runDiagramJob({ ...f, config: { ...f.config, id: 'late-event' } }, { runner: () => assert.fail('Stale executed') });

--- a/test/ci.test.js
+++ b/test/ci.test.js
@@ -1,0 +1,343 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import { runDiagramJob, readDiagramJob, commandRunner } from '../src/ci.js';
+import { acceptEvidenceBaseline } from '../src/evidence.js';
+import { sha256 } from '../src/scene.js';
+import { runPreparedRefresh } from '../src/ci-workflow.js';
+
+const exec = promisify(execFile);
+
+async function fixture(t) {
+  const root = await fs.mkdtemp(join(tmpdir(), 'toolkit-ci-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const repositoryPath = join(root, 'repository');
+  const stateDir = join(root, 'state');
+  await fs.mkdir(join(repositoryPath, 'src'), { recursive: true });
+  const git = async (...args) => (await exec('git', ['-C', repositoryPath, ...args])).stdout.trim();
+  await git('init', '-b', 'main');
+  const commit = async () => {
+    await git('add', '.');
+    await git('-c', 'user.name=CI fixture', '-c', 'user.email=ci@example.invalid', '-c', 'commit.gpgSign=false', 'commit', '-m', 'test: update CI fixture');
+    return git('rev-parse', 'HEAD');
+  };
+  const scene = JSON.parse(await fs.readFile(new URL('./fixtures/annotated.excalidraw', import.meta.url), 'utf8'));
+  for (const element of scene.elements) {
+    if (element.id === 'service') element.id = 'api';
+    if (element.containerId === 'service') element.containerId = 'api';
+    if (element.startBinding?.elementId === 'service') element.startBinding.elementId = 'api';
+    if (element.endBinding?.elementId === 'service') element.endBinding.elementId = 'api';
+  }
+  scene.unknown = { retained: true };
+  const inputPath = join(repositoryPath, 'flow.excalidraw');
+  const original = JSON.stringify(scene, null, 4) + '\n\n';
+  await fs.writeFile(inputPath, original);
+  await fs.writeFile(join(repositoryPath, 'src/api.js'), 'export function handle() { return 1; }\n');
+  const baseRevision = await commit();
+  const evidence = revision => ({ schemaVersion: 1, source: { kind: 'git', revision },
+    scope: { question: 'What does handle return?', paths: ['src'], coverage: 'partial', unknowns: ['Runtime behavior is not established.'] },
+    references: [{ id: 'handle', path: 'src/api.js', startLine: 1, endLine: 1, symbol: 'handle' }],
+    nodes: [{ semanticId: 'api', elementId: 'api', referenceIds: ['handle'] }], relations: [] });
+  const baseline = await acceptEvidenceBaseline({ repositoryPath, inputPath, generatedPath: inputPath, outputDir: join(stateDir, 'baseline'), evidence: evidence(baseRevision) });
+  await fs.writeFile(join(repositoryPath, 'src/api.js'), 'export function handle() { return 2; }\n');
+  const sourceRevision = await commit();
+  const config = { schemaVersion: 1, id: 'request-flow', sourcePaths: ['src'], diagramPath: 'flow.excalidraw', trigger: 'push',
+    baseline: { bundlePath: 'baseline/evidence.json', sha256: baseline.sha256 }, output: 'jobs',
+    execution: { version: 'fixture-v1', executable: process.execPath, args: [], timeoutMs: 5000 } };
+  const event = { trigger: 'push', baseRevision, sourceRevision, headRef: 'refs/heads/main', trusted: true };
+  const runner = async request => {
+    const generated = JSON.parse(await fs.readFile(join(dirname(request.baselineBundlePath), 'generated.excalidraw')));
+    generated.elements[0].backgroundColor = '#d0ebff';
+    const generatedPath = join(request.outputDir, 'proposed.excalidraw');
+    const proposalPath = join(request.outputDir, 'proposal.json');
+    await fs.writeFile(generatedPath, JSON.stringify(generated));
+    await fs.writeFile(proposalPath, JSON.stringify({ command: 'refresh-diagram', generatedPath, evidence: evidence(request.sourceRevision) }));
+    return runPreparedRefresh(request, proposalPath);
+  };
+  return { root, repositoryPath, stateDir, config, event, runner, evidence, git, commit, original, inputPath };
+}
+
+test('relevant commit produces verified immutable artifacts, duplicate event reuses them', async t => {
+  const f = await fixture(t);
+  let calls = 0;
+  const result = await runDiagramJob(f, { runner: async request => { calls++; return f.runner(request); } });
+  assert.equal(result.receipt.status, 'completed');
+  assert.deepEqual(result.receipt.changedPaths, ['src/api.js']);
+  assert.equal(Object.keys(result.receipt.artifacts).length, 4);
+  assert.equal(await fs.readFile(f.inputPath, 'utf8'), f.original);
+  const reused = await runDiagramJob(f, { runner: () => assert.fail('Duplicate executed') });
+  assert.equal(calls, 1);
+  assert.equal(reused.duplicate, true);
+  assert.equal(reused.sha256, result.sha256);
+  await fs.appendFile(join(dirname(result.receiptPath), result.receipt.artifacts.native.file), ' ');
+  await assert.rejects(runDiagramJob(f), { code: 'CORRUPT_JOB' });
+});
+
+test('qualification preserves manual fields, annotations and assets and retains the merge proof', async t => {
+  const f = await fixture(t);
+  const human = JSON.parse(f.original);
+  human.elements[0].strokeColor = '#e03131';
+  human.elements.find(element => element.id === 'note').text = 'A manual note that must survive';
+  human.files.asset = { ...human.files.asset, humanMetadata: 'retain the complete asset' };
+  await fs.writeFile(f.inputPath, JSON.stringify(human));
+  const sourceRevision = await f.commit();
+  const options = { ...f, event: { ...f.event, sourceRevision } };
+  const result = await runDiagramJob(options, { runner: f.runner });
+  assert.equal(result.receipt.status, 'completed', JSON.stringify(result.receipt.error));
+  assert.equal(result.receipt.verification.preview.pixelMatch, true);
+  const candidate = JSON.parse(await fs.readFile(join(dirname(result.receiptPath), result.receipt.artifacts.native.file)));
+  assert.equal(candidate.elements[0].strokeColor, '#e03131');
+  assert.deepEqual(candidate.elements.find(element => element.id === 'note'), human.elements.find(element => element.id === 'note'));
+  assert.deepEqual(candidate.files, human.files);
+  assert.ok(candidate.elements[0].backgroundColor !== human.elements[0].backgroundColor);
+  await fs.appendFile(join(dirname(result.receiptPath), result.receipt.verification.artifacts.generated.file), ' ');
+  await assert.rejects(runDiagramJob(options, { runner: () => assert.fail('Corrupt proof reran the agent') }), { code: 'CORRUPT_JOB' });
+});
+
+test('candidate preservation is recomputed even when a runner rewrites matching artifact hashes', async t => {
+  const f = await fixture(t);
+  const human = JSON.parse(f.original);
+  human.elements[0].strokeColor = '#e03131';
+  await fs.writeFile(f.inputPath, JSON.stringify(human));
+  const sourceRevision = await f.commit();
+  for (const id of ['drop-note', 'erase-manual-override']) {
+    const result = await runDiagramJob({ ...f, config: { ...f.config, id }, event: { ...f.event, sourceRevision } }, { runner: async request => {
+      const result = await f.runner(request);
+      const candidatePath = join(request.outputDir, result.artifacts.native);
+      const candidate = JSON.parse(await fs.readFile(candidatePath));
+      if (id === 'drop-note') candidate.elements = candidate.elements.filter(element => element.id !== 'note');
+      else candidate.elements[0].strokeColor = JSON.parse(f.original).elements[0].strokeColor;
+      const bytes = JSON.stringify(candidate);
+      await fs.writeFile(candidatePath, bytes);
+      const reportPath = join(request.outputDir, result.artifacts.report);
+      const report = JSON.parse(await fs.readFile(reportPath));
+      const refreshPath = join(request.outputDir, report.refresh.file);
+      const refresh = JSON.parse(await fs.readFile(refreshPath));
+      refresh.artifacts.candidate.sha256 = sha256(bytes);
+      refresh.overrides = []; report.overrides = [];
+      const receiptBytes = JSON.stringify(refresh);
+      await fs.writeFile(refreshPath, receiptBytes);
+      report.refresh.sha256 = sha256(receiptBytes);
+      await fs.writeFile(reportPath, JSON.stringify(report));
+      return result;
+    } });
+    assert.equal(result.receipt.status, 'failed', id);
+    assert.equal(result.receipt.error.code, 'UNQUALIFIED_REFRESH', id);
+    assert.deepEqual(result.receipt.artifacts, {});
+  }
+});
+
+test('CI rejects missing refresh proof, false reports, truncated PNGs and a different native preview', async t => {
+  const f = await fixture(t);
+  const cases = {
+    'missing-proof': ['UNQUALIFIED_REFRESH', async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.report), report = JSON.parse(await fs.readFile(path));
+      delete report.refresh; await fs.writeFile(path, JSON.stringify(report));
+    }],
+    'false-report': ['UNQUALIFIED_REFRESH', async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.report), report = JSON.parse(await fs.readFile(path));
+      report.changes = []; await fs.writeFile(path, JSON.stringify(report));
+    }],
+    'signature-only': ['INVALID_PREVIEW', async (request, result) => {
+      await fs.writeFile(join(request.outputDir, result.artifacts.preview), Buffer.from('89504e470d0a1a0a00', 'hex'));
+    }],
+    'header-without-image': ['INVALID_PREVIEW', async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.preview);
+      await fs.writeFile(path, (await fs.readFile(path)).subarray(0, 33));
+    }],
+    'wrong-native-pixels': ['PREVIEW_MISMATCH', async (request, result) => {
+      const report = JSON.parse(await fs.readFile(join(request.outputDir, result.artifacts.report)));
+      const before = await fs.readFile(join(request.outputDir, dirname(report.refresh.file), report.previews.images.before.file));
+      const path = join(request.outputDir, result.artifacts.preview), after = await fs.readFile(path);
+      assert.deepEqual(before.subarray(16, 24), after.subarray(16, 24), 'the mismatch has the same dimensions');
+      await fs.writeFile(path, before);
+    }],
+  };
+  for (const [id, [code, modify]] of Object.entries(cases)) {
+    const result = await runDiagramJob({ ...f, config: { ...f.config, id } }, { runner: async request => {
+      const result = await f.runner(request); await modify(request, result); return result;
+    } });
+    assert.equal(result.receipt.status, 'failed', id);
+    assert.equal(result.receipt.error.code, code, `${id}: ${JSON.stringify(result.receipt.error)}`);
+    assert.deepEqual(result.receipt.artifacts, {});
+  }
+});
+
+test('irrelevant and nonconfigured events skip without reading a missing baseline or launching a runtime', async t => {
+  const f = await fixture(t);
+  await fs.writeFile(join(f.repositoryPath, 'README.md'), 'irrelevant\n');
+  const sourceRevision = await f.commit();
+  await fs.rm(join(f.stateDir, 'baseline'), { recursive: true });
+  const result = await runDiagramJob({ ...f, event: { ...f.event, baseRevision: f.event.sourceRevision, sourceRevision } }, { runner: () => assert.fail('Irrelevant executed') });
+  assert.equal(result.receipt.status, 'skipped');
+  assert.equal(result.receipt.reason, 'no-relevant-source-changes');
+  const wrong = await runDiagramJob({ ...f, event: { ...f.event, trigger: 'manual' } }, { runner: () => assert.fail('Wrong trigger executed') });
+  assert.equal(wrong.receipt.reason, 'trigger-not-configured');
+});
+
+test('stale events and events superseded during execution never replace newer outputs', async t => {
+  const f = await fixture(t);
+  let newResult;
+  const old = await runDiagramJob(f, { runner: async request => {
+    await fs.writeFile(join(f.repositoryPath, 'src/api.js'), 'export function handle() { return 3; }\n');
+    const sourceRevision = await f.commit();
+    newResult = await runDiagramJob({ ...f, event: { ...f.event, baseRevision: f.event.sourceRevision, sourceRevision } }, { runner: f.runner });
+    return f.runner(request);
+  } });
+  assert.equal(old.receipt.status, 'superseded');
+  assert.equal(newResult.receipt.status, 'completed');
+  assert.notEqual(old.receiptPath, newResult.receiptPath);
+  assert.equal((await readDiagramJob(newResult.receiptPath)).sha256, newResult.sha256);
+  const stale = await runDiagramJob({ ...f, config: { ...f.config, id: 'late-event' } }, { runner: () => assert.fail('Stale executed') });
+  assert.equal(stale.receipt.status, 'superseded');
+});
+
+test('clean runner restores baseline and completed receipts without absolute workspace identity', async t => {
+  const f = await fixture(t);
+  const completed = await runDiagramJob(f, { runner: f.runner });
+  const copy = join(f.root, 'restored-state');
+  const checkout = join(f.root, 'fresh-checkout');
+  await fs.cp(f.stateDir, copy, { recursive: true });
+  await exec('git', ['clone', '--no-hardlinks', f.repositoryPath, checkout]);
+  const reused = await runDiagramJob({ ...f, repositoryPath: checkout, stateDir: copy }, { runner: () => assert.fail('Restored result executed') });
+  assert.equal(reused.sha256, completed.sha256);
+  const next = await runDiagramJob({ ...f, repositoryPath: checkout, stateDir: copy, config: { ...f.config, id: 'new-job' } }, { runner: async request => {
+    assert.equal(await fs.readFile(join(dirname(request.baselineBundlePath), 'generated.excalidraw'), 'utf8'), f.original);
+    assert.equal(request.baselineHash, f.config.baseline.sha256);
+    return f.runner(request);
+  } });
+  assert.equal(next.receipt.status, 'completed');
+});
+
+test('unavailable and failing runtimes persist failed receipts and never successful artifacts', async t => {
+  const f = await fixture(t);
+  for (const [id, execution] of [
+    ['absent', { executable: join(f.root, 'missing-runtime') }],
+    ['denied', { args: ['-e', 'process.exit(3)'] }],
+    ['empty', { args: ['-e', 'process.stdout.write(JSON.stringify({status:"ready"}))'] }],
+  ]) {
+    const result = await runDiagramJob({ ...f, config: { ...f.config, id, execution: { ...f.config.execution, ...execution } } });
+    assert.equal(result.receipt.status, 'failed');
+    assert.equal(typeof result.receipt.error.code, 'string');
+    assert.deepEqual(result.receipt.artifacts, {});
+  }
+});
+
+test('execution timeout kills the actual process group and fails the durable job', async t => {
+  const f = await fixture(t);
+  const marker = join(f.root, 'must-not-write');
+  const script = join(f.root, 'slow.mjs');
+  await fs.writeFile(script, `import fs from 'node:fs'; setTimeout(() => fs.writeFileSync(${JSON.stringify(marker)}, 'late'), 500);`);
+  const result = await runDiagramJob({ ...f, config: { ...f.config, execution: { ...f.config.execution, args: [script], timeoutMs: 30 } } });
+  assert.equal(result.receipt.status, 'failed');
+  assert.equal(result.receipt.error.code, 'EXECUTION_TIMEOUT');
+  await delay(550);
+  await assert.rejects(fs.stat(marker), { code: 'ENOENT' });
+});
+
+test('a real executable consumes stdin and produces qualified output through the same contract', async t => {
+  const f = await fixture(t);
+  const script = join(f.root, 'existing-workflow.mjs');
+  await fs.writeFile(script, `
+    import fs from 'node:fs/promises'; import path from 'node:path';
+    let input = ''; for await (const chunk of process.stdin) input += chunk;
+    const request = JSON.parse(input);
+    const evidence = ${JSON.stringify(f.evidence(f.event.sourceRevision))};
+    const {runPreparedRefresh} = await import('${new URL('../src/ci-workflow.js', import.meta.url).href}');
+    const generatedPath = path.join(path.dirname(request.baselineBundlePath), 'generated.excalidraw');
+    const proposalPath = path.join(request.outputDir, 'proposal.json');
+    await fs.writeFile(proposalPath,JSON.stringify({command:'refresh-diagram',generatedPath,evidence}));
+    const result = await runPreparedRefresh(request, proposalPath);
+    process.stdout.write(JSON.stringify(result));
+  `);
+  const result = await runDiagramJob({ ...f, config: { ...f.config, execution: { ...f.config.execution, args: [script] } } });
+  assert.equal(result.receipt.status, 'completed');
+  assert.equal(result.receipt.result, 'ready');
+});
+
+test('one exact concurrent job runs once and unfinished dead-owner claims recover', async t => {
+  const f = await fixture(t);
+  let entered;
+  const ready = new Promise(resolve => { entered = resolve; });
+  let unblock;
+  const blocked = new Promise(resolve => { unblock = resolve; });
+  const running = runDiagramJob(f, { runner: async request => { entered(); await blocked; return f.runner(request); } });
+  await ready;
+  await assert.rejects(runDiagramJob(f, { runner: () => assert.fail('Second runner') }), { code: 'JOB_BUSY' });
+  unblock();
+  const result = await running;
+  const job = dirname(result.receiptPath);
+  await fs.unlink(result.receiptPath);
+  const ownerPath = join(job, 'claims/1.json');
+  const owner = JSON.parse(await fs.readFile(ownerPath));
+  // Simulate the retained claim after a dead runner; keep its attempted artifacts.
+  owner.pid = 2147483647;
+  owner.hostname = hostname();
+  await fs.writeFile(ownerPath, JSON.stringify(owner));
+  const recovered = await runDiagramJob(f, { runner: f.runner });
+  assert.equal(recovered.receipt.status, 'completed');
+  assert.notEqual(recovered.receipt.attempt, result.receipt.attempt);
+  assert.equal((await fs.readdir(join(job, 'attempts'))).length, 2);
+});
+
+test('wrong revisions, out-of-scope evidence, unresolved conflicts and symlink outputs fail qualification', async t => {
+  const f = await fixture(t);
+  const cases = {
+    'wrong-revision': async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.evidence);
+      const value = JSON.parse(await fs.readFile(path)); value.source.revision = f.event.baseRevision;
+      await fs.writeFile(path, JSON.stringify(value));
+    },
+    'wide-scope': async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.evidence);
+      const value = JSON.parse(await fs.readFile(path)); value.scope.paths = ['.'];
+      await fs.writeFile(path, JSON.stringify(value));
+    },
+    conflicts: async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.report);
+      const value = JSON.parse(await fs.readFile(path)); value.conflicts = ['Human label differs'];
+      await fs.writeFile(path, JSON.stringify(value));
+    },
+    symlink: async (request, result) => {
+      const path = join(request.outputDir, result.artifacts.native);
+      await fs.unlink(path); await fs.symlink(request.currentPath, path);
+    },
+  };
+  for (const [id, modify] of Object.entries(cases)) {
+    const result = await runDiagramJob({ ...f, config: { ...f.config, id } }, { runner: async request => {
+      const value = await f.runner(request); await modify(request, value); return value;
+    } });
+    assert.equal(result.receipt.status, 'failed', id);
+  }
+});
+
+test('untrusted events never execute and explicit argv has no shell interpretation or implicit secrets', async t => {
+  const f = await fixture(t);
+  const denied = await runDiagramJob({ ...f, event: { ...f.event, trusted: false } }, { runner: () => assert.fail('Untrusted runner') });
+  assert.equal(denied.receipt.error.code, 'UNTRUSTED_EXECUTION');
+  const marker = join(f.root, 'shell-marker');
+  const arg = `$(touch ${marker})`;
+  const controller = new AbortController();
+  const run = commandRunner({ executable: process.execPath, args: ['-e', 'process.stdout.write(JSON.stringify({arg:process.argv[1],token:process.env.GITHUB_TOKEN??null}))', arg] });
+  const value = await run({ repositoryPath: f.repositoryPath }, { signal: controller.signal });
+  assert.equal(value.arg, arg);
+  assert.equal(value.token, null);
+  await assert.rejects(fs.stat(marker), { code: 'ENOENT' });
+  await assert.rejects(runDiagramJob({ ...f, config: { ...f.config, execution: { ...f.config.execution, forwardEnv: ['GITHUB_TOKEN'] } } }), { code: 'INVALID_CONFIG' });
+});
+
+test('baseline tampering and path traversal cannot produce a success receipt', async t => {
+  const f = await fixture(t);
+  await fs.appendFile(join(f.stateDir, 'baseline/generated.excalidraw'), ' ');
+  const result = await runDiagramJob(f, { runner: () => assert.fail('Corrupt baseline executed') });
+  assert.equal(result.receipt.status, 'failed');
+  for (const path of ['../escape', '/tmp/escape', 'x/../escape', '.git/state']) {
+    await assert.rejects(runDiagramJob({ ...f, config: { ...f.config, output: path } }), { code: 'INVALID_CONFIG' });
+  }
+  assert.equal(sha256(await fs.readFile(f.inputPath)), sha256(f.original));
+});

--- a/test/workflow-commands.test.js
+++ b/test/workflow-commands.test.js
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import { workflowCommand } from '../src/workflow-commands.js';
+import { runPreparedRefresh } from '../src/ci-workflow.js';
 
 const exec = promisify(execFile);
 export async function workflowFixture(t) {
@@ -143,4 +144,34 @@ test('refresh requests preserve a human move, recover preview failure, and requi
   assert.equal(adopted.adopted, true);
   assert.equal(adopted.bundle.evidence.source.revision, revision);
   assert.equal(JSON.parse(await fs.readFile(join(f.root, 'human.excalidraw'))).elements[0].backgroundColor, undefined);
+});
+
+test('ci-diagram runs a prepared proposal through the refresh command and exposes runtime failure honestly', async t => {
+  const f = await workflowFixture(t);
+  await f.save({ ...f.request, generatedPath: 'input.excalidraw', outputDir: 'state/baseline' });
+  const baseline = await workflowCommand('accept-baseline', f.requestPath);
+  await fs.writeFile(join(f.repositoryPath, 'flow.excalidraw'), f.bytes);
+  await fs.writeFile(join(f.repositoryPath, 'api.js'), 'export function handle() { return 2; }\n');
+  await f.git('add', '.');
+  await f.git('-c', 'user.name=Workflow fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgSign=false', 'commit', '-m', 'test: commit workflow diagram change');
+  const revision = await f.git('rev-parse', 'HEAD');
+  const proposalPath = join(f.root, 'proposal.json');
+  await fs.writeFile(proposalPath, JSON.stringify({ command: 'refresh-diagram', generatedPath: 'input.excalidraw',
+    evidence: { ...f.evidence, source: { kind: 'git', revision } } }));
+  const request = { repositoryPath: 'source', stateDir: 'state',
+    event: { baseRevision: f.revision, sourceRevision: revision, headRef: 'refs/heads/main', trigger: 'manual', trusted: true },
+    config: { schemaVersion: 1, id: 'prepared-flow', sourcePaths: ['api.js'], diagramPath: 'flow.excalidraw', trigger: 'manual',
+      baseline: { bundlePath: 'baseline/evidence.json', sha256: baseline.sha256 }, output: 'jobs',
+      execution: { executable: process.execPath, args: ['unavailable-runtime.mjs'], version: 'v1', timeoutMs: 5000 } } };
+  await f.save(request);
+  const result = await workflowCommand('ci-diagram', f.requestPath, {}, { runner: job => runPreparedRefresh(job, proposalPath) });
+  assert.equal(result.receipt.status, 'completed');
+  assert.equal(result.receipt.sourceRevision, revision);
+  assert.match(result.receipt.artifacts.native.file, /refresh\/candidate.excalidraw$/);
+  await fs.unlink(join(f.root, 'state', 'jobs', 'prepared-flow', result.receipt.jobKey, result.receipt.artifacts.preview.file));
+  await assert.rejects(workflowCommand('ci-diagram', f.requestPath), { code: 'CORRUPT_JOB' });
+  await f.save({ ...request, config: { ...request.config, id: 'missing-runtime' } });
+  const failed = await workflowCommand('ci-diagram', f.requestPath);
+  assert.equal(failed.receipt.status, 'failed');
+  assert.equal(failed.receipt.error.code, 'RUNTIME_FAILED');
 });


### PR DESCRIPTION
Add a scoped CI job controller that invokes a configured executable through the existing evidence/refresh workflow. Exact revisions and configuration identify immutable jobs; irrelevant events skip, duplicates reuse retained output, and stale or superseded jobs cannot replace newer results. Baselines and receipts can be restored across runners.

A successful process exit is insufficient: the controller replays the three-way merge against its retained baseline/current scene, checks source evidence and the reported changes, then decodes the PNG and compares its pixels with a fresh native export. Failed qualification produces a failed receipt. Generation does not adopt a baseline or publish comments.

## Testing

- Real subprocess/Git fixtures cover preserved manual content, rewritten candidate hashes, missing proof, truncated or mismatched PNGs, restored state, duplicate/stale events, timeouts and unavailable runtimes.
- A prepared request-flow proposal completed the actual subprocess → native refresh → merge replay → decoded-pixel comparison path; its PNG was inspected and an exact retry reused the receipt.

The render-heavy test fixture allows 30 seconds on shared CI runners; the intentional 30 ms timeout case and production execution limits remain unchanged.

The fixture uses host-agent investigation supplied as a proposal. Automatic investigation of a new revision requires an explicitly configured existing agent workflow and model access.
