### PR TITLE
[Docs]: document the npm 0.2.0 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ unrelated layout stay intact.
 
 **[Explore the toolkit →](https://edwingao.com/excalidraw-toolkit)** · [Watch the real workflow](https://edwingao.com/excalidraw-toolkit#see-the-workflow) · [Get started](#get-started)
 
-![A real agent edit with the original notes and diagram layout preserved](examples/workflows/agent-edit.png)
+![A real agent edit with the original notes and diagram layout preserved](https://raw.githubusercontent.com/edwingao28/excalidraw-toolkit/993507ce81977f221535ecadf962511c75a923c9/examples/workflows/agent-edit.png)
 
 > Extend this architecture diagram with the MCP interface in `src/scoped-mcp.js`.
 > Show where agent requests enter and how verified images come back. Preserve
@@ -22,11 +22,11 @@ an edited `.excalidraw` copy with before/after PNGs and a change receipt.
 This real Codex/MCP edit extends a nine-stage diagram of this repository into an
 eleven-stage overview. The blue additions show the existing MCP interface;
 the original pipeline and annotations stay in place.
-Try the [original diagram](examples/workflows/toolkit-pipeline-before.excalidraw),
-open the [edited result](examples/workflows/toolkit-pipeline-after.excalidraw), or
-read the [task and source references](examples/workflows/).
+Try the [original diagram](https://github.com/edwingao28/excalidraw-toolkit/blob/main/examples/workflows/toolkit-pipeline-before.excalidraw),
+open the [edited result](https://github.com/edwingao28/excalidraw-toolkit/blob/main/examples/workflows/toolkit-pipeline-after.excalidraw), or
+read the [task and source references](https://github.com/edwingao28/excalidraw-toolkit/tree/main/examples/workflows/).
 
-**Implemented on `main`.** The npm `latest` release is still `0.1.0`; it does not include these workflows. Version `0.2.0` is not published yet. Use the source setup below.
+**Available in [npm 0.2.0](https://www.npmjs.com/package/excalidraw-toolkit/v/0.2.0).** Install the release below to use these workflows.
 
 ## What you can do
 
@@ -45,25 +45,25 @@ extra model service.
 
 ## Get started
 
-Use Node.js **24.15+ in the 24.x line** (or Node 26+), Git, and a POSIX shell with `tar`. The build uses npm 12.0.2:
+Use Node.js **20+** and npm. The commands below use a POSIX shell:
 
 ```sh
-git clone https://github.com/edwingao28/excalidraw-toolkit.git
-cd excalidraw-toolkit
-npx --yes npm@12.0.2 ci
-npx --yes npm@12.0.2 run build
+npm install --global excalidraw-toolkit@0.2.0
 
-TOOLKIT_CLI="$PWD/bin/cli.js"
+TOOLKIT_NODE="$(node -p 'process.execPath')"
+TOOLKIT_CLI="$(npm root --global)/excalidraw-toolkit/bin/cli.js"
 TOOLKIT_PROJECT="/absolute/path/to/your-project"
-node "$TOOLKIT_CLI" setup-preview
-node "$TOOLKIT_CLI" init --target all --project "$TOOLKIT_PROJECT"
-node "$TOOLKIT_CLI" doctor --target all --project "$TOOLKIT_PROJECT"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" setup-preview
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" init --target all --project "$TOOLKIT_PROJECT"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" doctor --target all --project "$TOOLKIT_PROJECT"
 ```
 
-Set `TOOLKIT_PROJECT` to the project containing your diagram. Use `--target claude`
-or `--target codex` for one client. Keep this checkout available: the installed
-skill records its absolute CLI path. [Installation guide](docs/install.md)
-covers the packed archive, updates, runtime requirements, and uninstalling.
+Set `TOOLKIT_PROJECT` to an existing project containing your diagram. Use
+`--target claude` or `--target codex` for one client. The package includes its built
+browser assets; `setup-preview` installs Chromium. Keep the Node and toolkit
+installation available: the installed skill records their absolute paths.
+[Installation guide](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/install.md) covers updates, a local installation,
+source builds, Linux dependencies, and uninstalling.
 
 ### Claude Code
 
@@ -89,7 +89,7 @@ If the name is unused, add the connection:
 
 ```sh
 codex mcp add excalidraw_toolkit -- \
-  node "$TOOLKIT_CLI" mcp --project "$TOOLKIT_PROJECT"
+  "$TOOLKIT_NODE" "$TOOLKIT_CLI" mcp --project "$TOOLKIT_PROJECT"
 ```
 
 This is a persistent Codex user registration; choose an unused name for another
@@ -99,15 +99,15 @@ installation. Start a new session in the project and verify `inspect_scene`,
 The trusted MCP process runs the renderer while Codex's default macOS shell
 sandbox stays unchanged. Tool paths are project-relative; edited copies live
 under `.excalidraw-toolkit/edits/` in that project. Changing projects requires a
-connection rooted there. [Connection and removal details](docs/install.md).
+connection rooted there. [Connection and removal details](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/install.md).
 
 ## Review, export, and keep editing
 
 Open an edit receipt or native file with the installed CLI:
 
 ```sh
-node "$TOOLKIT_CLI" preview "/absolute/path/to/receipt.json"
-node "$TOOLKIT_CLI" preview "/absolute/path/to/diagram.excalidraw"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" preview "/absolute/path/to/receipt.json"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" preview "/absolute/path/to/diagram.excalidraw"
 ```
 
 Switch between Before and After with a short dissolve, inspect the recorded changes, download a PNG or
@@ -116,15 +116,15 @@ the native copy in Excalidraw to continue drawing. Matching retries reuse a veri
 a new edit keeps the previous bundle intact. The original is never overwritten.
 The transition respects reduced-motion preferences and leaves the native scene unchanged.
 
-![Real browser recording: review Before and After, export PNG, download the native copy, and reopen it](examples/workflows/review-export-reopen.gif)
+![Real browser recording: review Before and After, export PNG, download the native copy, and reopen it](https://raw.githubusercontent.com/edwingao28/excalidraw-toolkit/993507ce81977f221535ecadf962511c75a923c9/examples/workflows/review-export-reopen.gif)
 
 *Recorded from the working review UI using the Codex-produced file above. The agent edit finished before this clip; the recording shows the subsequent browser workflow.*
-[Download the WebM](examples/workflows/review-export-reopen.webm?raw=true) · [View the reopened result](examples/workflows/reopened.png)
+[Download the WebM](https://github.com/edwingao28/excalidraw-toolkit/blob/main/examples/workflows/review-export-reopen.webm?raw=true) · [View the reopened result](https://github.com/edwingao28/excalidraw-toolkit/blob/main/examples/workflows/reopened.png)
 
 Native files preserve IDs, ordering, embedded assets, deleted-element history,
 document settings, and fields outside the permitted change. Unsupported geometry,
 text that cannot fit, and ambiguous removal policies fail explicitly.
-See [supported operations and examples](docs/scoped-edit.md).
+See [supported operations and examples](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/scoped-edit.md).
 
 ## Explain source changes and preserve manual work
 
@@ -139,8 +139,8 @@ survive. Competing changes appear as conflicts. Review the candidate, then call
 `adopt-refresh` explicitly to accept the new baseline.
 
 These commands take request files prepared by the agent. Read the
-[request guide](docs/workflow-commands.md), [evidence contract](docs/evidence.md),
-[comparison targets](docs/explain.md), and [refresh rules](docs/refresh.md).
+[request guide](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/workflow-commands.md), [evidence contract](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/evidence.md),
+[comparison targets](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/explain.md), and [refresh rules](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/refresh.md).
 
 ## Configured CI and optional PR updates
 
@@ -151,8 +151,8 @@ configured agent and model access, or an already prepared proposal.
 
 Publication is off by default. A trusted publisher can reconcile one managed PR
 comment after its destination, credentials, uploaded artifacts, and visibility
-are configured. Fork publication is unsupported. See [CI setup](docs/ci.md),
-[examples](examples/ci/), and [publication](docs/publication.md).
+are configured. Fork publication is unsupported. See [CI setup](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/ci.md),
+[examples](https://github.com/edwingao28/excalidraw-toolkit/tree/main/examples/ci/), and [publication](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/publication.md).
 
 ## Scope and validation
 
@@ -169,14 +169,14 @@ prepared source proposal, and publisher tests used local HTTP fixtures. Producti
 model access, uploaded links, and repository policy remain deployment setup.
 
 For new diagrams, a separate Claude Code live-canvas integration remains available;
-see [live-canvas workflows](docs/live-canvas.md).
+see [live-canvas workflows](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/live-canvas.md).
 
 **Future directions, not included:** revision-checked edits to an unsaved live
 canvas, Obsidian round trips, additional backends, and additional diagram views.
 These are conditional follow-ups, not promised release dates.
 
-For development and Linux browser dependencies, see [installation](docs/install.md).
-The installed package supports Node 20+; the source-build requirements above are higher.
+For development and Linux browser dependencies, see [installation](https://github.com/edwingao28/excalidraw-toolkit/blob/main/docs/install.md).
+The installed package supports Node 20+; source builds require a newer Node version and npm 12.0.2.
 
 ## License
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,31 +1,48 @@
 # Install and connect your agent
 
-## Source checkout or packed archive
+## Install from npm
 
-
-The current workflows are implemented on `main`; npm 0.2.0 has not been published. The [README quickstart](../README.md#get-started) runs directly from a built checkout. To install a separate archive, clone the repository first and use Node 24.15+ in the 24.x line (or Node 26+), Git, `tar`, and npm 12.0.2. Set these paths to your checkout and dedicated output/install directories:
+Use Node.js 20+ and npm. These commands use a POSIX shell and install the released package with its built browser assets:
 
 ```sh
-TOOLKIT_SOURCE="/absolute/path/to/excalidraw-toolkit"
-TOOLKIT_ARCHIVES="/absolute/path/to/toolkit-archives"
-TOOLKIT_INSTALL="/absolute/path/to/toolkit-install"
+npm install --global excalidraw-toolkit@0.2.0
 
-cd "$TOOLKIT_SOURCE"
-npx --yes npm@12.0.2 ci
-mkdir -p "$TOOLKIT_ARCHIVES"
-npx --yes npm@12.0.2 pack --pack-destination "$TOOLKIT_ARCHIVES"
-npx --yes npm@12.0.2 install --prefix "$TOOLKIT_INSTALL" --omit=dev --ignore-scripts \
-  "$TOOLKIT_ARCHIVES/excalidraw-toolkit-0.2.0.tgz"
-
-TOOLKIT_CLI="$TOOLKIT_INSTALL/node_modules/excalidraw-toolkit/bin/cli.js"
-node "$TOOLKIT_CLI" init --target all --project "/absolute/path/to/project"
-node "$TOOLKIT_CLI" setup-preview
-node "$TOOLKIT_CLI" doctor --target all --project "/absolute/path/to/project"
+TOOLKIT_NODE="$(node -p 'process.execPath')"
+TOOLKIT_CLI="$(npm root --global)/excalidraw-toolkit/bin/cli.js"
+TOOLKIT_PROJECT="/absolute/path/to/your-project"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" setup-preview
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" init --target all --project "$TOOLKIT_PROJECT"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" doctor --target all --project "$TOOLKIT_PROJECT"
 ```
 
-`pack` builds the distributable before creating the archive. The archive installation uses those built assets; it does not run a consumer build. Commands below use the same `TOOLKIT_CLI` path.
+Set `TOOLKIT_PROJECT` to an existing project. Use `--target claude` or `--target codex` for one client. Project discovery uses `.claude/skills/scoped-edit` and `.agents/skills/scoped-edit`. Start a new client session in that project and ask to edit your saved diagram. `--scope user` explicitly selects personal skill installation instead of a project.
 
-Use `--target claude` or `--target codex` for one client. Project discovery uses `.claude/skills/scoped-edit` and `.agents/skills/scoped-edit`. Start a new client session in that project and ask to edit your saved diagram. The installed skill records the absolute CLI path; keep that installation directory available. `--scope user` explicitly selects personal installation instead of a project. Ownership hashes protect modified or unrelated skills during update and uninstall. Separate installed Claude Code skill/CLI and Codex scoped-MCP sessions have completed native editing and preview review. A successful `doctor` checks the installed skill, not whether a model has loaded or followed it.
+The installed skill records the absolute Node and CLI paths. Keep both installations available; rerun `init` and update any MCP registration if either path changes, such as when switching Node versions. Ownership hashes protect modified or unrelated skills during update and uninstall. A successful `doctor` checks the installed skill and Chromium executable, not whether a model has loaded or followed the skill.
+
+### Install without a global prefix
+
+To keep the toolkit in a dedicated writable directory, use this alternative, then run `setup-preview`, `init`, and `doctor` as above:
+
+```sh
+TOOLKIT_INSTALL="/absolute/path/to/toolkit-install"
+npm install --prefix "$TOOLKIT_INSTALL" --omit=dev excalidraw-toolkit@0.2.0
+TOOLKIT_NODE="$(node -p 'process.execPath')"
+TOOLKIT_CLI="$TOOLKIT_INSTALL/node_modules/excalidraw-toolkit/bin/cli.js"
+```
+
+Use a stable directory. A temporary `npx` cache is unsuitable for the absolute paths recorded by the installed skill and persistent MCP connection.
+
+### Update an existing installation
+
+Install `excalidraw-toolkit@0.2.0` again using the same global or local-prefix command, then refresh each project's owned skill and renderer:
+
+```sh
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" setup-preview
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" update --target all --project "$TOOLKIT_PROJECT"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" doctor --target all --project "$TOOLKIT_PROJECT"
+```
+
+For a move from 0.1.0, `init --target … --project …` adds the saved-file workflow. For the separate live-canvas installation, see [live-canvas setup](live-canvas.md). These skill commands do not upgrade the npm package itself.
 
 ### Codex connection for scoped edits
 
@@ -41,7 +58,7 @@ Codex's own configuration command:
 TOOLKIT_PROJECT="/absolute/path/to/project"
 # Inspect an existing same-name entry before registering; preserve conflicts.
 codex mcp get excalidraw_toolkit
-codex mcp add excalidraw_toolkit -- node "$TOOLKIT_CLI" mcp --project "$TOOLKIT_PROJECT"
+codex mcp add excalidraw_toolkit -- "$TOOLKIT_NODE" "$TOOLKIT_CLI" mcp --project "$TOOLKIT_PROJECT"
 ```
 
 `codex mcp add` is a persistent user registration. Use an unused name if an existing
@@ -70,16 +87,46 @@ Project skill uninstall removes only its owned skill files. It does not delete a
 separately registered MCP connection. See [Codex MCP configuration](https://learn.chatgpt.com/docs/extend/mcp).
 
 ```sh
-node "$TOOLKIT_CLI" uninstall --target all --project "/absolute/path/to/project"
+"$TOOLKIT_NODE" "$TOOLKIT_CLI" uninstall --target all --project "$TOOLKIT_PROJECT"
 ```
 
+After removing the owned skills and any MCP registration, a global npm installation can be removed with `npm uninstall --global excalidraw-toolkit`.
+
+## Source checkout or packed archive
+
+For development, use Node 24.15+ in the 24.x line (or Node 26+), Git, `tar`, and npm 12.0.2:
+
+```sh
+git clone https://github.com/edwingao28/excalidraw-toolkit.git
+cd excalidraw-toolkit
+npx --yes npm@12.0.2 ci
+npx --yes npm@12.0.2 run build
+TOOLKIT_NODE="$(node -p 'process.execPath')"
+TOOLKIT_CLI="$PWD/bin/cli.js"
+```
+
+Run `setup-preview`, `init`, and `doctor` from the npm instructions with these paths. Keep the checkout available because the installed skill references it. A checkout follows its Git revision; it is independent of the npm release version. Use `git rev-parse HEAD` to record the source revision being built.
+
+To build and install a separate archive, set dedicated output/install directories from the checkout:
+
+```sh
+TOOLKIT_ARCHIVES="/absolute/path/to/toolkit-archives"
+TOOLKIT_INSTALL="/absolute/path/to/toolkit-install"
+mkdir -p "$TOOLKIT_ARCHIVES"
+npx --yes npm@12.0.2 pack --pack-destination "$TOOLKIT_ARCHIVES"
+npx --yes npm@12.0.2 install --prefix "$TOOLKIT_INSTALL" --omit=dev --ignore-scripts \
+  "$TOOLKIT_ARCHIVES/excalidraw-toolkit-0.2.0.tgz"
+TOOLKIT_CLI="$TOOLKIT_INSTALL/node_modules/excalidraw-toolkit/bin/cli.js"
+```
+
+`pack` builds the distributable before creating the archive. Installation uses those built assets and does not run a consumer build. Run `setup-preview`, `init`, and `doctor` with the new CLI path, and update any MCP registration to use it.
 
 ## Linux browser dependencies
 
-`setup-preview` downloads Chromium. On a minimal Linux host, install the required system libraries with Playwright before rendering. From the source checkout:
+`setup-preview` downloads Chromium. On a minimal Linux host, install the required system libraries with Playwright before rendering. Use the Playwright version pinned by this release:
 
 ```sh
-npx playwright install --with-deps chromium
+npx --yes playwright@1.63.0 install --with-deps chromium
 ```
 
 The system-package step may need administrator privileges. The [CI example](../examples/ci/diagram-artifacts.yml) installs the same build and browser prerequisites on Ubuntu.


### PR DESCRIPTION
Prepare the README and installation guide for the npm 0.2.0 release. Users install the built package directly, connect Claude Code or Codex with stable paths, and upgrade existing installations. Source builds remain documented; screenshots and guide links also work from the npm package page.

Runtime code is unchanged from the qualified release. Documentation shell blocks and links pass validation. The exact archive passed a clean global-prefix installation, project setup and doctor, ownership-safe uninstall, native MCP discovery and editing, scene and binding preservation, identical and conflicting retries, and failure recovery. Browser checks passed for animated Before/After review, PNG export, and native download/reopen.

This PR remains a draft until npm publication and registry installation are verified. The release wording describes the intended post-publication state.
