### PR TITLE
[Preview]: navigate from edit summaries to diagram elements

### DIFF
--- a/docs/scoped-edit.md
+++ b/docs/scoped-edit.md
@@ -32,6 +32,12 @@ before/after PNG previews. It preserves the input bytes, image assets, unknown
 metadata, deleted elements, IDs, order, and every field outside the requested
 style properties. Native rendering consumes a separate copy of each scene.
 
+Select an item in **Edit summary** to center and highlight its element on the
+canvas. Before/After keeps the element in focus when it exists in both versions;
+selecting a removed or added item opens the version that contains it. Choose
+**Back to overview** or press Escape to return to the full diagram. Navigation and
+highlighting do not change the diagram or its exports.
+
 `setStyle` changes fill or stroke colors on rectangles, ellipses, and diamonds.
 Use hex RGB/RGBA colors or `transparent`.
 

--- a/src/web/edit-summary.js
+++ b/src/web/edit-summary.js
@@ -25,7 +25,7 @@ export function summarizeEdits(beforeScene, afterScene, changes) {
   const before = new Map(beforeScene.elements.map(element => [element.id, element]));
   const after = new Map(afterScene.elements.map(element => [element.id, element]));
   const summaries = [];
-  const push = (id, kind, text, details = []) => summaries.push({ id: `${id}:${kind}`, kind, text, details });
+  const push = (id, kind, text, details = []) => summaries.push({ id: `${id}:${kind}`, elementId: id, kind, text, details });
   for (const change of changes) {
     const old = before.get(change.id), next = after.get(change.id);
     if (!live(old) && !live(next)) continue;

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -47,18 +47,24 @@ svg { flex-shrink: 0; }
 .object-list, .change-list { list-style: none; padding: 0; margin: 0; }
 .object-list { display: grid; gap: 12px; }
 .object-list li { display: flex; align-items: center; gap: 10px; font-size: 12px; color: #787367; min-width: 0; }
-.object-list li > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.object-link { display: flex; align-items: center; gap: 10px; width: 100%; min-height: 30px; padding: 4px 6px; margin: -4px -6px; border: 0; border-radius: 5px; background: transparent; color: inherit; text-align: left; }
+.object-link > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.object-link:hover:not(:disabled), .object-link[aria-pressed="true"] { color: #805039; background: #eee8dd; }
 .object-dot { width: 5px; height: 5px; background: #c4bdae; border-radius: 50%; flex-shrink: 0; margin-left: 5px; margin-right: 6px; }
 .sidebar-note { font-size: 11px; line-height: 1.65; color: #81796b; margin: 0; }
 .more-objects { margin-top: 12px; padding-left: 26px; }
 .change-count { background: #eee3d8; border: 1px solid #e6d5c4; color: #9b6548 !important; border-radius: 5px; min-width: 20px; text-align: center; padding: 2px 5px; }
-.change-list { display: grid; gap: 14px; }
-.change-list > li { display: flex; align-items: flex-start; gap: 9px; }
+.change-hint { margin: -3px 0 14px; font-size: 10px; }
+.change-list { display: grid; gap: 4px; }
+.change-link { display: flex; align-items: flex-start; gap: 9px; width: calc(100% + 16px); padding: 9px 8px; margin: 0 -8px; border: 1px solid transparent; border-radius: 7px; background: transparent; text-align: left; transition: background .15s ease, border-color .15s ease; }
+.change-link:hover:not(:disabled) { background: #f0ece4; }
+.change-link[aria-pressed="true"] { background: #eee3d8; border-color: #e3cdbb; }
+.change-link[aria-pressed="true"] .change-mark { background: #a46b4c; color: #fffdf7; }
 .change-mark { margin-top: 1px; flex-shrink: 0; width: 18px; height: 18px; border-radius: 50%; display: grid; place-items: center; font-size: 12px; line-height: 1; color: #8c7459; background: #eee9df; }
 .change-mark--added { color: #52684e; background: #e5eadf; }
 .change-mark--removed { color: #996148; background: #f0e2d9; }
 .change-description { min-width: 0; flex: 1; }
-.change-description > p { font-size: 12px; font-weight: 500; line-height: 1.55; margin: 0; color: #514b41; overflow-wrap: anywhere; }
+.change-title { display: block; font-size: 12px; font-weight: 500; line-height: 1.55; margin: 0; color: #514b41; overflow-wrap: anywhere; }
 .property-change { font-size: 10px; line-height: 1.5; color: #7d7364; display: flex; flex-wrap: wrap; gap: 3px 7px; margin-top: 6px; overflow-wrap: anywhere; }
 .property-change > span:first-child { color: #645c50; }
 .change-values, .color-value { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 5px; }
@@ -88,7 +94,10 @@ svg { flex-shrink: 0; }
 .view-tabs button[aria-selected="true"] { color: #5c4a35; background: #fffefa; box-shadow: 0 1px 3px #3a2c1512; }
 .fit-button { margin-left: auto; padding: 6px 0 6px 8px; border: 0; background: transparent; display: flex; align-items: center; gap: 7px; font-size: 10px; color: #7e7363; }
 .fit-button:hover:not(:disabled) { color: var(--ink); }
-.canvas-panel { position: relative; flex: 1; min-height: 0; }
+.canvas-panel { position: relative; flex: 1; min-height: 0; overflow: hidden; }
+.element-focus { position: absolute; z-index: 2; pointer-events: none; border: 2px solid #b47852; border-radius: 8px; box-shadow: 0 0 0 5px #c67a591a; }
+.fit-button.is-focused { color: #935e3f; }
+.fit-button.is-focused span { display: inline; }
 .view-snapshot { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 3; }
 .canvas-panel > .excalidraw { position: absolute; inset: 0; --color-primary: #9b654b; --color-primary-darker: #805039; --color-primary-light: #efe1d5; --color-primary-light-darker: #e8d4c4; }
 .canvas-panel .excalidraw .App-bottom-bar,

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -231,7 +231,7 @@ function Review() {
     const target = versions.find(([, value]) => value && focusElements(value.elements, item.elementId).length);
     if (!target) return;
     setFocusedItem({ ...item });
-    if (target[0] !== view) selectView(target[0]);
+    selectView(target[0]);
     setNotice(`${item.text}. Highlighted in the ${viewLabel(target[0]).toLowerCase()} view.`);
     if (matchMedia('(max-width: 820px)').matches) {
       setDetailsOpen(false);

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -362,11 +362,11 @@ function Review() {
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
         <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
         {context.review ? <ReceiptDetails review={context.review} view={view} /> : <>
-        <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} ready={ready} />
+        <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} disabled={!scene || !!error} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
         </section>
-        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><button className="object-link" disabled={!ready} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
+        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><button className="object-link" disabled={!scene || !!error} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
         </>}
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>Review a copy. Keep your original.</span></div>
       </aside>
@@ -390,11 +390,11 @@ function Review() {
     </div>
   </div>;
 }
-function EditSummary({ changes, summary, focusedId, onFocus, ready }) {
+function EditSummary({ changes, summary, focusedId, onFocus, disabled }) {
   const fieldCount = changes?.reduce((count, change) => count + Object.keys(change.properties || {}).length, 0) || 0;
   return <section className="sidebar-section changes-section" aria-labelledby="changes-title">
     <div className="section-heading"><h2 id="changes-title">Edit summary</h2>{summary && <span className="change-count" aria-label={`${summary.length} summarized edits`}>{summary.length}</span>}</div>
-    {summary?.length ? <><p className="sidebar-note change-hint">Select an edit to find it on the canvas.</p><ul className="change-list">{summary.map(item => <li key={item.id}><button className="change-link" disabled={!ready} aria-label={`Show ${item.text}`} aria-describedby={item.details.length ? item.details.map((_, index) => `change-${encodeURIComponent(item.id)}-${index}`).join(' ') : undefined} aria-pressed={focusedId === item.id} onClick={() => onFocus(item)}>
+    {summary?.length ? <><p className="sidebar-note change-hint">Select an edit to find it on the canvas.</p><ul className="change-list">{summary.map(item => <li key={item.id}><button className="change-link" disabled={disabled} aria-label={`Show ${item.text}`} aria-describedby={item.details.length ? item.details.map((_, index) => `change-${encodeURIComponent(item.id)}-${index}`).join(' ') : undefined} aria-pressed={focusedId === item.id} onClick={() => onFocus(item)}>
       <span className={`change-mark change-mark--${item.kind}`} aria-hidden="true">{item.kind === 'added' ? '+' : item.kind === 'removed' ? '−' : '↗'}</span>
       <span className="change-description"><span className="change-title">{item.text}</span>{item.details.map((detail, index) => <span className="property-change" id={`change-${encodeURIComponent(item.id)}-${index}`} key={index}>
         <span>{detail.label}</span>{'value' in detail ? <span>{detail.value}</span> : <span className="change-values"><StyleValue value={detail.before} label={detail.label} /><span aria-label="to">→</span><StyleValue value={detail.after} label={detail.label} /></span>}

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -150,6 +150,31 @@ class CanvasBoundary extends React.Component {
   render() { return this.state.failed ? <div className="canvas-state"><Icon name="info" size={28} /><h2>Unable to display this diagram</h2><p>Open another file to continue.</p></div> : this.props.children; }
 }
 
+function focusElements(elements, id) {
+  const target = elements.find(element => element.id === id && !element.isDeleted);
+  if (!target) return [];
+  return elements.filter(element => !element.isDeleted && (element.id === id || element.id === target.containerId || element.containerId === id));
+}
+
+// A view-only outline follows the native viewport without changing the scene
+// or adding selection decorations to exported files.
+function ElementFocus({ api, elementId }) {
+  const [style, setStyle] = useState(null);
+  useEffect(() => {
+    const update = () => {
+      const targets = focusElements(api.getSceneElements(), elementId);
+      if (!targets.length) { setStyle(null); return; }
+      const [x, y, right, bottom] = getCommonBounds(targets);
+      const { scrollX, scrollY, zoom } = api.getAppState();
+      setStyle({ left: (x + scrollX) * zoom.value - 8, top: (y + scrollY) * zoom.value - 8,
+        width: (right - x) * zoom.value + 16, height: (bottom - y) * zoom.value + 16 });
+    };
+    update();
+    return api.onScrollChange(update);
+  }, [api, elementId]);
+  return style && <div className="element-focus" data-element-id={elementId} style={style} aria-hidden="true" />;
+}
+
 function Review() {
   const [scene, setScene] = useState(null);
   const [context, setContext] = useState({});
@@ -161,6 +186,9 @@ function Review() {
   const [exporting, setExporting] = useState(false);
   const [notice, setNotice] = useState('');
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [focusedItem, setFocusedItem] = useState(null);
+  const focusRef = useRef(null);
+  focusRef.current = focusedItem;
   const fileInput = useRef(null);
   const canvasPanel = useRef(null);
   const tabs = useRef([]);
@@ -187,8 +215,28 @@ function Review() {
   }
   function reportError(message) { cancelTransition(); setReady(false); window.previewReady = false; setError(message); window.previewError = message; }
   function resetReadiness() { setApi(null); setReady(false); window.previewReady = false; window.previewError = undefined; }
-  function fitDiagram() {
-    if (api) api.scrollToContent(api.getSceneElements(), { fitToViewport: true, viewportZoomFactor: 0.82, maxZoom: 1, animate: false });
+  function fitDiagram(animate = false) {
+    if (!api) return;
+    const all = api.getSceneElements();
+    const targets = focusElements(all, focusRef.current?.elementId);
+    if (all.length) api.scrollToContent(targets.length ? targets : all, { fitToViewport: true,
+      viewportZoomFactor: targets.length ? 0.65 : 0.82, maxZoom: 1,
+      animate: animate && !matchMedia('(prefers-reduced-motion: reduce)').matches, duration: 280 });
+  }
+  function backToOverview() {
+    focusRef.current = null; setFocusedItem(null); setNotice('Showing the full diagram.'); fitDiagram(true);
+  }
+  function focusItem(item) {
+    const versions = [[view, displayed], ['after', scene], ['before', context.beforeScene]];
+    const target = versions.find(([, value]) => value && focusElements(value.elements, item.elementId).length);
+    if (!target) return;
+    setFocusedItem({ ...item });
+    if (target[0] !== view) selectView(target[0]);
+    setNotice(`${item.text}. Highlighted in the ${viewLabel(target[0]).toLowerCase()} view.`);
+    if (matchMedia('(max-width: 820px)').matches) {
+      setDetailsOpen(false);
+      document.getElementById('diagram-workspace').focus({ preventScroll: true });
+    }
   }
 
   useEffect(() => {
@@ -199,6 +247,13 @@ function Review() {
     })).then(([value, metadata]) => { validate(value); if (metadata.beforeScene) validate(metadata.beforeScene); if (metadata.proposalScene) validate(metadata.proposalScene); setScene(value); setContext(metadata); }).catch(error => reportError(error.message));
   }, []);
   useEffect(() => { document.title = `${title} · Excalidraw Toolkit`; }, [title]);
+  useEffect(() => {
+    if (!api || !ready || !focusedItem) return;
+    if (!focusElements(api.getSceneElements(), focusedItem.elementId).length) {
+      setFocusedItem(null); setNotice('This element is not present in this view.'); return;
+    }
+    fitDiagram(true);
+  }, [api, ready, focusedItem]);
   useEffect(() => {
     if (!api || !displayed) return;
     let cancelled = false;
@@ -233,6 +288,7 @@ function Review() {
     try {
       const value = validate(JSON.parse(await file.text()));
       cancelTransition();
+      focusRef.current = null; setFocusedItem(null);
       resetReadiness(); setError(''); setNotice(''); setView('after');
       setScene(value); setContext({ title: file.name.replace(/\.(excalidraw|json)$/i, '') }); setRevision(value => value + 1);
     } catch (error) { setError(error instanceof SyntaxError ? 'This file contains invalid JSON. Choose a valid .excalidraw file.' : error.message); }
@@ -287,7 +343,7 @@ function Review() {
     setTimeout(() => URL.revokeObjectURL(url), 1000); setNotice('Editable copy download started.');
   }
 
-  return <div className="review-app">
+  return <div className="review-app" onKeyDown={event => { if (event.key === 'Escape' && focusedItem) { event.preventDefault(); backToOverview(); } }}>
     <a className="skip-link" href="#diagram-workspace">Skip to diagram</a>
     <header className="review-header">
       <div className="brand"><span className="brand-mark"><Icon name="layers" size={25} /></span><span>Excalidraw <strong>Toolkit</strong></span></div>
@@ -306,11 +362,11 @@ function Review() {
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
         <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
         {context.review ? <ReceiptDetails review={context.review} view={view} /> : <>
-        <EditSummary changes={changes} summary={summary} key={revision} />
+        <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} ready={ready} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
         </section>
-        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
+        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><button className="object-link" disabled={!ready} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
         </>}
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>Review a copy. Keep your original.</span></div>
       </aside>
@@ -320,10 +376,11 @@ function Review() {
         <div className="canvas-card">
           <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{context.review?.kind === 'source-refresh' ? viewLabel(view) : context.beforeScene ? (view === 'after' ? 'Updated diagram' : 'Original diagram') : 'Canvas'}</span></div>
             {context.beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{viewKeys.map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? viewKeys.length - 1 : (index + (event.key === 'ArrowRight' ? 1 : viewKeys.length - 1)) % viewKeys.length; selectView(viewKeys[next]); tabs.current[next]?.focus(); } }}>{viewLabel(item)}</button>)}</div>}
-            <button aria-label="Fit diagram" className="fit-button" disabled={!ready || !elements.length} onClick={fitDiagram}><Icon name="fit" size={15} /><span>Fit diagram</span></button>
+            <button aria-label={focusedItem ? 'Back to overview' : 'Fit diagram'} className={`fit-button ${focusedItem ? 'is-focused' : ''}`} disabled={!ready || !elements.length} onClick={backToOverview}><Icon name="fit" size={15} /><span>{focusedItem ? 'Back to overview' : 'Fit diagram'}</span></button>
           </div>
           <div ref={canvasPanel} id="canvas-panel" className="canvas-panel" role={context.beforeScene ? 'tabpanel' : 'region'} aria-labelledby={context.beforeScene ? `${view}-tab` : undefined} aria-label={context.beforeScene ? undefined : 'Diagram canvas'} aria-busy={!ready && !error}>
             {displayed ? <CanvasBoundary key={`${revision}-${view}`} onError={reportError}><Excalidraw key={`${revision}-${view}`} initialData={{ elements: structuredClone(displayed.elements), files: structuredClone(displayed.files || {}), appState: { ...displayed.appState, viewModeEnabled: true } }} excalidrawAPI={setApi} viewModeEnabled={true} zenModeEnabled={true} theme="light" /></CanvasBoundary> : <div className="canvas-state"><span className={error ? '' : 'loading-symbol'}><Icon name={error ? 'info' : 'layers'} size={30} /></span><h2>{error ? 'Your diagram is waiting' : 'Opening your diagram'}</h2><p>{error ? 'Choose a file to start a new review.' : 'Preparing the native canvas…'}</p></div>}
+            {api && ready && focusedItem && <ElementFocus api={api} elementId={focusedItem.elementId} />}
             <canvas ref={snapshot} className="view-snapshot" aria-hidden="true" hidden />
           </div>
           <div className="canvas-footer"><span id="status" role="status"><span className={`status-dot ${ready ? 'is-ready' : ''}`} />{ready ? `${elements.length} ${elements.length === 1 ? 'element' : 'elements'} · Viewing a read-only copy` : error ? 'Preview unavailable' : 'Preparing canvas…'}</span><span className="canvas-hint">Scroll to pan · Pinch to zoom</span></div>
@@ -333,16 +390,16 @@ function Review() {
     </div>
   </div>;
 }
-function EditSummary({ changes, summary }) {
+function EditSummary({ changes, summary, focusedId, onFocus, ready }) {
   const fieldCount = changes?.reduce((count, change) => count + Object.keys(change.properties || {}).length, 0) || 0;
   return <section className="sidebar-section changes-section" aria-labelledby="changes-title">
     <div className="section-heading"><h2 id="changes-title">Edit summary</h2>{summary && <span className="change-count" aria-label={`${summary.length} summarized edits`}>{summary.length}</span>}</div>
-    {summary?.length ? <ul className="change-list">{summary.map(item => <li key={item.id}>
+    {summary?.length ? <><p className="sidebar-note change-hint">Select an edit to find it on the canvas.</p><ul className="change-list">{summary.map(item => <li key={item.id}><button className="change-link" disabled={!ready} aria-label={`Show ${item.text}`} aria-describedby={item.details.length ? item.details.map((_, index) => `change-${encodeURIComponent(item.id)}-${index}`).join(' ') : undefined} aria-pressed={focusedId === item.id} onClick={() => onFocus(item)}>
       <span className={`change-mark change-mark--${item.kind}`} aria-hidden="true">{item.kind === 'added' ? '+' : item.kind === 'removed' ? '−' : '↗'}</span>
-      <div className="change-description"><p>{item.text}</p>{item.details.map((detail, index) => <div className="property-change" key={index}>
+      <span className="change-description"><span className="change-title">{item.text}</span>{item.details.map((detail, index) => <span className="property-change" id={`change-${encodeURIComponent(item.id)}-${index}`} key={index}>
         <span>{detail.label}</span>{'value' in detail ? <span>{detail.value}</span> : <span className="change-values"><StyleValue value={detail.before} label={detail.label} /><span aria-label="to">→</span><StyleValue value={detail.after} label={detail.label} /></span>}
-      </div>)}</div>
-    </li>)}</ul> : <p className="sidebar-note">{changes ? (changes.length ? 'Element metadata updated. See the technical changes below.' : 'No changes recorded in this review.') : 'No edit receipt is attached to this diagram.'}</p>}
+      </span>)}</span>
+    </button></li>)}</ul></> : <p className="sidebar-note">{changes ? (changes.length ? 'Element metadata updated. See the technical changes below.' : 'No changes recorded in this review.') : 'No edit receipt is attached to this diagram.'}</p>}
     {!!changes?.length && <details className="technical-changes">
       <summary>Technical changes<span>{fieldCount} fields · {changes.length} elements</span></summary>
       <p className="sidebar-note">Display values are rounded to two decimals. The editable copy keeps the original values.</p>

--- a/test/edit-summary.test.js
+++ b/test/edit-summary.test.js
@@ -57,6 +57,22 @@ test('style edits use human labels and retain their actual before/after values',
   assert.deepEqual(change.details, [{ label: 'Fill', before: '#ffffff', after: '#a5d8ff' }, { label: 'Stroke width', before: undefined, after: 2.1234567 }]);
 });
 
+test('summary targets preserve complete element IDs without changing either scene or receipt', () => {
+  const before = scene([...node('api:primary', 'API'), ...node('old:queue', 'Old queue')]);
+  const after = structuredClone(before);
+  Object.assign(after.elements[1], { text: 'Public API', originalText: 'Public API' });
+  after.elements[2].isDeleted = after.elements[3].isDeleted = true;
+  after.elements.push(...node('new:queue', 'Queue'));
+  const changes = deriveSceneChanges(before, after);
+  const original = structuredClone({ before, after, changes });
+  assert.deepEqual(summarizeEdits(before, after, changes).map(({ elementId, kind }) => ({ elementId, kind })), [
+    { elementId: 'api:primary-label', kind: 'renamed' },
+    { elementId: 'old:queue', kind: 'removed' },
+    { elementId: 'new:queue', kind: 'added' },
+  ]);
+  assert.deepEqual({ before, after, changes }, original);
+});
+
 test('reconnections use endpoint identities while retaining the prior route', () => {
   const before = scene([...node('api', 'API'), ...node('worker', 'Worker'), ...node('queue', 'Queue'), arrow('direct', 'api', 'worker')]);
   const after = structuredClone(before);

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -167,6 +167,13 @@ test('edit summary buttons focus native elements across versions without changin
   assert.equal(await added.getAttribute('aria-pressed'), 'false');
   assert.equal(await page.evaluate(() => window.summaryAnimations), 0);
   await exportNative(after);
+  await page.evaluate(() => {
+    const buttons = [...document.querySelectorAll('.change-link')];
+    buttons.find(button => button.getAttribute('aria-label') === 'Show Removed API service → Worker').click();
+    buttons.find(button => button.getAttribute('aria-label') === 'Show Added Queue').click();
+  });
+  await waitForFocus('queue:primary');
+  assert.equal(await page.getByRole('tab', { name: 'After', exact: true }).getAttribute('aria-selected'), 'true');
   assert.deepEqual({ before, after }, original);
   assert.deepEqual(errors, []);
 });

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -6,6 +6,7 @@ import {join} from 'node:path';
 import {execFile} from 'node:child_process';
 import {promisify} from 'node:util';
 import {renderScene, servePreview} from '../src/render.js';
+import {deriveSceneChanges} from '../src/scene.js';
 import {chromium} from 'playwright';
 const exec = promisify(execFile);
 const fixture = new URL('./fixtures/annotated.excalidraw', import.meta.url);
@@ -60,6 +61,113 @@ test('failed initial loading remains visible and Open file recovers without a fa
   assert.equal(await page.getByRole('alert').count(), 0);
   assert.equal(await page.getByRole('button', { name: 'Export PNG', exact: true }).isEnabled(), true);
   assert.match(await page.locator('#status').innerText(), /Viewing a read-only copy/);
+});
+
+test('edit summary buttons focus native elements across versions without changing exports', async t => {
+  const before = JSON.parse(readFileSync(fixture));
+  const labelId = 'service:label:manual';
+  before.elements.find(element => element.id === 'service-label').id = labelId;
+  before.elements.find(element => element.id === 'service').boundElements.find(binding => binding.type === 'text').id = labelId;
+  const after = structuredClone(before);
+  Object.assign(after.elements.find(element => element.id === labelId), { text: 'Public API', originalText: 'Public API' });
+  after.elements.find(element => element.id === 'request').isDeleted = true;
+  for (const element of after.elements) if (element.boundElements) element.boundElements = element.boundElements.filter(binding => binding.id !== 'request');
+  after.elements.push(
+    { ...structuredClone(before.elements[0]), id: 'queue:primary', x: 410, y: 310, groupIds: [], boundElements: [{ id: 'queue:label', type: 'text' }] },
+    { ...structuredClone(before.elements[1]), id: 'queue:label', x: 460, y: 346, groupIds: [], containerId: 'queue:primary', text: 'Queue', originalText: 'Queue' },
+  );
+  const original = structuredClone({ before, after });
+  const preview = await servePreview(after, { beforeScene: before, changes: deriveSceneChanges(before, after) });
+  t.after(() => preview.close());
+  const browser = await chromium.launch();
+  t.after(() => browser.close());
+  const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+  const errors = [];
+  page.on('pageerror', error => errors.push(error.message));
+  await page.goto(preview.url);
+  await page.waitForFunction(() => window.previewReady);
+  const renamed = page.getByRole('button', { name: 'Show Renamed API service → Public API', exact: true });
+  const removed = page.getByRole('button', { name: 'Show Removed API service → Worker', exact: true });
+  const added = page.getByRole('button', { name: 'Show Added Queue', exact: true });
+  const focus = page.locator('.element-focus');
+  const waitForFocus = async id => {
+    await page.waitForFunction(id => window.previewReady && document.querySelector('.element-focus')?.dataset.elementId === id, id);
+    await focus.waitFor({ state: 'visible' });
+  };
+  const exportNative = async expected => {
+    const download = page.waitForEvent('download');
+    await page.locator('#native').click();
+    assert.deepEqual(JSON.parse(readFileSync(await (await download).path())), expected);
+    assert.deepEqual(await page.evaluate(() => window.sceneForPreview()), expected);
+  };
+
+  assert.equal(await renamed.getAttribute('aria-pressed'), 'false');
+  await renamed.click();
+  await waitForFocus(labelId);
+  assert.equal(await renamed.getAttribute('aria-pressed'), 'true');
+  const frame = await focus.boundingBox();
+  const canvas = await page.locator('#canvas-panel').boundingBox();
+  assert.ok(frame.width / frame.height < 3, 'bound text frames its parent, not only the narrow label');
+  assert.ok(frame.x >= canvas.x && frame.y >= canvas.y && frame.x + frame.width <= canvas.x + canvas.width && frame.y + frame.height <= canvas.y + canvas.height, 'target is visible inside the canvas');
+  await exportNative(after);
+
+  await page.getByRole('tab', { name: 'Before', exact: true }).click();
+  await waitForFocus(labelId);
+  assert.equal(await renamed.getAttribute('aria-pressed'), 'true');
+  await page.getByRole('button', { name: 'Back to overview', exact: true }).click();
+  await focus.waitFor({ state: 'detached' });
+  assert.equal(await renamed.getAttribute('aria-pressed'), 'false');
+
+  await renamed.focus();
+  await page.keyboard.press('Enter');
+  await waitForFocus(labelId);
+  await added.focus();
+  await page.keyboard.press('Space');
+  await waitForFocus('queue:primary');
+  assert.equal(await page.getByRole('tab', { name: 'After', exact: true }).getAttribute('aria-selected'), 'true');
+  assert.equal(await added.getAttribute('aria-pressed'), 'true');
+  assert.equal(await renamed.getAttribute('aria-pressed'), 'false');
+  await page.getByRole('tab', { name: 'Before', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady);
+  assert.equal(await focus.count(), 0);
+  assert.equal(await added.getAttribute('aria-pressed'), 'false');
+
+  await page.getByRole('tab', { name: 'After', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady);
+  await removed.click();
+  await waitForFocus('request');
+  assert.equal(await page.getByRole('tab', { name: 'Before', exact: true }).getAttribute('aria-selected'), 'true');
+  await exportNative(before);
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.evaluate(() => {
+    const animate = Element.prototype.animate;
+    window.summaryAnimations = 0;
+    Element.prototype.animate = function (...args) { window.summaryAnimations++; return animate.apply(this, args); };
+  });
+  await added.click();
+  await waitForFocus('queue:primary');
+  await page.mouse.move(canvas.x + canvas.width / 2, canvas.y + canvas.height / 2);
+  await page.mouse.wheel(0, canvas.height * 2);
+  await page.waitForFunction(() => {
+    const frame = document.querySelector('.element-focus').getBoundingClientRect();
+    const canvas = document.querySelector('#canvas-panel').getBoundingClientRect();
+    return frame.bottom < canvas.top || frame.top > canvas.bottom;
+  });
+  await added.click();
+  await page.waitForFunction(() => {
+    const frame = document.querySelector('.element-focus').getBoundingClientRect();
+    const canvas = document.querySelector('#canvas-panel').getBoundingClientRect();
+    return frame.left >= canvas.left && frame.top >= canvas.top && frame.right <= canvas.right && frame.bottom <= canvas.bottom;
+  });
+  assert.equal(await added.getAttribute('aria-pressed'), 'true');
+  await page.keyboard.press('Escape');
+  await focus.waitFor({ state: 'detached' });
+  assert.equal(await added.getAttribute('aria-pressed'), 'false');
+  assert.equal(await page.evaluate(() => window.summaryAnimations), 0);
+  await exportNative(after);
+  assert.deepEqual({ before, after }, original);
+  assert.deepEqual(errors, []);
 });
 
 test('review transitions wait for a fitted view, survive rapid keyboard changes, and retain exact exports', async t => {

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -124,6 +124,7 @@ test('edit summary buttons focus native elements across versions without changin
   await added.focus();
   await page.keyboard.press('Space');
   await waitForFocus('queue:primary');
+  assert.equal(await added.evaluate(element => element === document.activeElement), true, 'keyboard activation retains focus after automatic version fallback');
   assert.equal(await page.getByRole('tab', { name: 'After', exact: true }).getAttribute('aria-selected'), 'true');
   assert.equal(await added.getAttribute('aria-pressed'), 'true');
   assert.equal(await renamed.getAttribute('aria-pressed'), 'false');


### PR DESCRIPTION
Edit-summary entries now center and highlight their exact canvas element. Before/After retains focus where the element exists; added and removed entries open the matching version. Back to overview and Escape reset the view. Object-list entries are clickable too.

Highlights stay outside the native scene and exports. Keyboard activation, accessible change descriptions, and reduced motion are supported; the compact layout closes the details panel after selection.

Validation: 196 tests passed, followed by all 12 affected tests after the final recentering and accessibility fixes. Computer-use checks passed on a 61-element diagram at desktop and mobile widths.
