### PR TITLE
[Workspace]: edit diagrams and review agent proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,15 @@ node "$TOOLKIT_CLI" preview "/absolute/path/to/receipt.json"
 node "$TOOLKIT_CLI" preview "/absolute/path/to/diagram.excalidraw"
 ```
 
-Switch between Before and After with a short dissolve, inspect the recorded changes, download a PNG or
-native copy, and reopen the saved file. The review workspace is read-only; open
-the native copy in Excalidraw to continue drawing. Matching retries reuse a verified result;
-a new edit keeps the previous bundle intact. The original is never overwritten.
-The transition respects reduced-motion preferences and leaves the native scene unchanged.
+Draw directly in **Working** with Excalidraw’s native tools, text, images, and undo/redo.
+Inspect a preserved **Before**, then review an **Agent proposal** and accept or discard it.
+Independent manual edits survive acceptance; conflicts leave your work unchanged.
+Save the live diagram as `.excalidraw`, export PNG, and reopen it here. A local browser
+draft recovers changes after reload. [Workspace guide](docs/workspace.md).
+
+The agent handoff uses a captured file and instructions with your existing agent; an
+in-page model connection is not shipped. Matching CLI retries reuse a verified result,
+and the original input is never overwritten. Snapshot transitions respect reduced motion.
 
 ![Real browser recording: review Before and After, export PNG, download the native copy, and reopen it](examples/workflows/review-export-reopen.gif)
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,0 +1,57 @@
+# Draw and review in one workspace
+
+Run `excalidraw-toolkit preview diagram.excalidraw` to open an editable working
+copy. The native Excalidraw toolbar supports selection, shapes, arrows, text,
+freehand annotations, images, and keyboard undo/redo. The input file on disk is
+never overwritten.
+
+- **Working** is your editable document. Click an object or edit in the sidebar to
+  find it on the canvas. Native undo history stays available when you visit snapshots.
+- **Before** is a preserved snapshot. Preparing an agent edit captures a new Before
+  from the working document at that moment.
+- **Agent proposal** is the returned diagram, displayed read-only. Accept merges its
+  changes into your latest work. Discard leaves your working diagram unchanged.
+
+Opening a normal edit receipt shows its After file as an Agent proposal, with its
+Before file as the initial working document. Source-evidence and refresh receipts
+remain immutable reviews with their original labels and retained exports. Choose
+**Edit copy** to draw on a separate copy; those later changes are not source-verified.
+
+## Work with your existing agent
+
+1. Draw or open a diagram. Select the elements you want your agent to work on.
+2. Describe the edit in the sidebar and choose **Prepare agent edit**. This downloads
+   the complete current diagram and captures the exact proposal base.
+3. Attach that file and the displayed instructions to Claude Code, Codex, or your
+   preferred agent. You can continue drawing in Working while it runs.
+4. Choose **Load proposal** and open the returned `.excalidraw` file.
+5. Review Before, the proposal, and your current Working diagram. **Accept proposal**
+   preserves independent manual edits; one native Undo reverses the acceptance.
+
+The sidebar prepares a file handoff. It does not run a model or connect a ChatGPT or
+Claude subscription inside the website. An in-page agent conversation remains a
+future integration.
+
+Acceptance stops when changes conflict: for example, both versions move the same
+object, delete versus edit an object, modify related bindings, reuse an image ID
+with different bytes, or reorder the same objects differently. Nothing is partially
+applied. Discard the proposal, keep Working, and prepare a new input for the agent.
+Proposal changes that native undo cannot reliably represent (such as arbitrary
+file-level metadata) also require a new proposal. Unknown existing fields and
+unrelated manual drawings are retained.
+
+## Save, export, and recover
+
+**Save diagram** downloads the live Working canvas as a native `.excalidraw` file,
+including manual additions and image data. **Open file** reopens that file here;
+it also remains usable in Excalidraw. Saving or exporting a snapshot uses that
+snapshot, not the live working document. PNG export reads the current view and
+never includes the workspace UI or focus outline.
+
+A local browser draft is written after changes. **Saved in this browser** appears
+only after the storage transaction completes. Reloading the same preview URL
+restores the working document and any pending proposal. Native undo history is
+session-only and starts fresh after a reload. Storage failures are visible; use
+Save diagram to retain a portable copy. Drafts are specific to this browser and
+preview URL, so download before closing or restarting the local preview server.
+Opening another file offers to save a working diagram that has not been downloaded.

--- a/src/web/WorkingCanvas.jsx
+++ b/src/web/WorkingCanvas.jsx
@@ -1,0 +1,22 @@
+import React, { useRef } from 'react';
+import { Excalidraw, serializeAsJSON } from '@excalidraw/excalidraw';
+import { captureWorkingScene } from './workspace.js';
+
+// This instance lives for the document, not the selected review tab. Excalidraw
+// owns the drawing tools, selection, and undo history throughout the session.
+export function WorkingCanvas({ scene, onScene, onApi, onSelection }) {
+  const native = useRef(null);
+  const current = useRef(scene);
+  current.current = scene;
+  return <Excalidraw initialData={{ elements: structuredClone(scene.elements), files: structuredClone(scene.files || {}),
+    appState: { ...scene.appState, viewModeEnabled: false, zenModeEnabled: false } }}
+    excalidrawAPI={onApi} viewModeEnabled={false} zenModeEnabled={false} theme="light" handleKeyboardGlobally={false}
+    onChange={(elements, appState, files) => {
+      if (appState.isLoading) return;
+      const snapshot = { elements, files, appState: JSON.parse(serializeAsJSON([], appState, {}, 'local')).appState };
+      const next = captureWorkingScene(current.current, elements, snapshot.appState, files, native.current);
+      native.current = structuredClone(snapshot);
+      if (next !== current.current) { current.current = next; onScene(next); }
+      onSelection(Object.keys(appState.selectedElementIds || {}).filter(id => appState.selectedElementIds[id]));
+    }} />;
+}

--- a/src/web/drafts.js
+++ b/src/web/drafts.js
@@ -1,0 +1,26 @@
+// Drafts stay on this browser and this preview URL. Native downloads remain the
+// portable source of truth when the local preview server is restarted.
+export async function draftStore() {
+  const db = await new Promise((resolve, reject) => {
+    const request = indexedDB.open('excalidraw-toolkit', 1);
+    request.onupgradeneeded = () => request.result.createObjectStore('drafts');
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  const key = location.pathname;
+  return {
+    read: () => new Promise((resolve, reject) => {
+      const request = db.transaction('drafts').objectStore('drafts').get(key);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    }),
+    write: value => new Promise((resolve, reject) => {
+      const transaction = db.transaction('drafts', 'readwrite');
+      transaction.objectStore('drafts').put(value, key);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error || new Error('Draft storage was interrupted.'));
+    }),
+    close: () => db.close(),
+  };
+}

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -1,7 +1,7 @@
 :root { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #26251f; background: #faf9f5; font-synthesis: none; color-scheme: light; --paper: #faf9f5; --ink: #26251f; --muted: #77756c; --line: #e5e3da; --clay: #c67a59; }
 * { box-sizing: border-box; }
 body { margin: 0; }
-button, input { font: inherit; }
+button, input, textarea { font: inherit; }
 button { cursor: pointer; -webkit-tap-highlight-color: transparent; }
 button:disabled { cursor: default; opacity: .44; }
 button:focus-visible, a:focus-visible, .technical-changes summary:focus-visible, .technical-changes pre:focus-visible { outline: 2px solid #a25a3c; outline-offset: 4px; }
@@ -99,10 +99,10 @@ svg { flex-shrink: 0; }
 .fit-button.is-focused { color: #935e3f; }
 .fit-button.is-focused span { display: inline; }
 .view-snapshot { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 3; }
-.canvas-panel > .excalidraw { position: absolute; inset: 0; --color-primary: #9b654b; --color-primary-darker: #805039; --color-primary-light: #efe1d5; --color-primary-light-darker: #e8d4c4; }
-.canvas-panel .excalidraw .App-bottom-bar,
-.canvas-panel .excalidraw .layer-ui__wrapper,
-.canvas-panel .excalidraw .App-menu_top { display: none; }
+.native-layer > .excalidraw { position: absolute; inset: 0; --color-primary: #9b654b; --color-primary-darker: #805039; --color-primary-light: #efe1d5; --color-primary-light-darker: #e8d4c4; }
+.snapshot-layer .excalidraw .App-bottom-bar,
+.snapshot-layer .excalidraw .layer-ui__wrapper,
+.snapshot-layer .excalidraw .App-menu_top { display: none; }
 .canvas-state { min-height: 390px; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 15px; padding: 30px; text-align: center; color: #b7a78f; background: radial-gradient(circle at 50% 40%, #fffefa, #fff); }
 .canvas-state h2 { font-family: Georgia, serif; color: #746858; font-weight: 400; font-size: 23px; margin: 2px 0 0; }
 .canvas-state p { margin: 0; font-size: 12px; color: #817665; }
@@ -122,3 +122,42 @@ svg { flex-shrink: 0; }
 @media (max-width: 820px) { .review-app { height: auto; min-height: 100dvh; } .review-body { display: flex; flex-direction: column; } .diagram-workspace { min-height: 540px; flex: 1; } .sidebar-toggle { display: flex; align-items: center; gap: 8px; min-height: 43px; border: 0; border-bottom: 1px solid var(--line); padding: 10px 24px; text-align: left; color: #7c7261; background: transparent; font-size: 11px; } .sidebar-toggle > span:last-child { margin-left: auto; font-size: 17px; } .review-sidebar { display: none; } .review-sidebar[data-open="true"] { display: flex; flex: none; max-height: 50dvh; padding: 20px 26px; border-right: 0; border-bottom: 1px solid var(--line); } .review-sidebar .sidebar-footer { padding-top: 0; } .review-header { flex-wrap: wrap; gap: 14px; } .brand { font-size: 16px; } .header-actions { gap: 7px; } .button { padding: 8px 10px; } .action-divider { display: none; } .workspace-heading h1 { font-size: 31px; } .canvas-panel { min-height: 260px; } }
 @media (max-width: 560px) { .review-header { padding: 15px 18px; } .header-actions { width: 100%; margin-left: 0; justify-content: space-between; } .button { min-height: 40px; padding: 8px; font-size: 11px; } .button-quiet { padding-left: 0; } .diagram-workspace { padding: 26px 16px 18px; } .workspace-heading { margin-bottom: 22px; } .workspace-heading h1 { font-size: 29px; } .workspace-description { max-width: 275px; } .canvas-toolbar { gap: 10px; padding: 10px 12px; flex-wrap: wrap; } .canvas-caption { margin-right: auto; } .fit-button span { display: none; } .fit-button { margin-left: 0; } .view-tabs button { padding: 6px 11px; } .canvas-hint { display: none; } .canvas-footer { padding: 10px 12px; } .workspace-footer { gap: 14px; } .workspace-footer > span:last-child { max-width: 175px; text-align: right; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; transition: none !important; } }
+
+/* The working editor remains mounted and keeps native history while snapshots
+   are inspected. Visibility preserves its dimensions without exposing controls. */
+.native-layer { position: absolute; inset: 0; }
+.layer-hidden, .layer-hidden * { visibility: hidden !important; pointer-events: none !important; }
+.working-layer .excalidraw { --color-surface-primary-container: #efe1d5; --color-on-primary-container: #805039; --color-surface-low: #f5f2eb; --color-surface-mid: #eeebe4; --color-surface-high: #e5dfd3; }
+.agent-section > .sidebar-note { margin-bottom: 14px; }
+.agent-label { display: block; font-size: 11px; color: #686459; margin-bottom: 8px; }
+.agent-section textarea { width: 100%; min-height: 96px; resize: vertical; border: 1px solid #dcd7cb; border-radius: 8px; padding: 11px; background: #fffefa; color: var(--ink); font-size: 12px; line-height: 1.6; }
+.agent-section textarea:focus-visible { outline: 2px solid #a25a3c; outline-offset: 2px; }
+.agent-section .selection-note { font-size: 10px; line-height: 1.6; color: #8d7c68; margin: 9px 0 13px; }
+.agent-section .button { white-space: normal; }
+.agent-instructions { margin-bottom: 14px; font-size: 11px; }
+.agent-instructions summary { cursor: pointer; margin-bottom: 10px; }
+.agent-instructions textarea { margin-top: 9px; min-height: 150px; font-size: 10px; }
+.proposal-note { margin-top: 14px; }
+.proposal-bar { display: flex; align-items: center; flex-shrink: 0; gap: 12px; margin-top: 15px; border: 1px solid #e2d7c8; border-radius: 9px; background: #f4eee4; padding: 14px 17px; }
+.proposal-bar > div { flex: 1; min-width: 0; }
+.proposal-bar strong { font-weight: 550; font-size: 12px; color: #594936; }
+.proposal-bar p { margin: 5px 0 0; color: #87755e; font-size: 11px; line-height: 1.5; }
+.review-app:has(.working-layer) .diagram-workspace { padding-top: 24px; }
+.review-app:has(.working-layer) .workspace-heading { margin-bottom: 20px; }
+.review-app:has(.working-layer) .workspace-heading h1 { font-size: clamp(25px, 2.2vw, 33px); }
+@media (max-width: 820px) {
+  .review-app:has(.working-layer) { height: 100dvh; min-height: 680px; }
+  .review-app:has(.working-layer) .diagram-workspace { min-height: 0; }
+  .review-app:has(.working-layer) .workspace-heading { margin-bottom: 16px; }
+  .review-app:has(.working-layer) .workspace-description { display: none; }
+  .review-app:has(.working-layer) .canvas-panel { min-height: 300px; }
+  .proposal-bar { flex-wrap: wrap; padding: 11px; gap: 8px; }
+  .proposal-bar > div { flex-basis: 100%; }
+  .proposal-bar .button { flex: 1; }
+}
+
+.replace-dialog::backdrop { background: #26251f55; }
+.replace-dialog { width: min(480px, 100%); padding: 27px; border-radius: 13px; border: 1px solid #e0d9cc; background: var(--paper); box-shadow: 0 20px 70px #26251f33; }
+.replace-dialog h2 { font: 26px Georgia, serif; margin: 0 0 12px; }
+.replace-dialog p { color: var(--muted); font-size: 13px; line-height: 1.7; }
+.replace-dialog > div { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 8px; margin-top: 22px; }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -1,11 +1,14 @@
 import {measureLabel} from "./text.js";
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Excalidraw, exportToCanvas, exportToSvg, restoreElements, getCommonBounds, convertToExcalidrawElements, FONT_FAMILY } from '@excalidraw/excalidraw';
+import { Excalidraw, exportToCanvas, exportToSvg, restoreElements, getCommonBounds, convertToExcalidrawElements, newElementWith, CaptureUpdateAction, FONT_FAMILY } from '@excalidraw/excalidraw';
 import '@excalidraw/excalidraw/index.css';
 import './preview.css';
 import { elementLabel, summarizeEdits, formatTechnicalChanges, displayValue } from './edit-summary.js';
 import { ReceiptDetails } from './ReceiptDetails.jsx';
+import { WorkingCanvas } from './WorkingCanvas.jsx';
+import { mergeProposal, deriveChanges } from './workspace.js';
+import { draftStore } from './drafts.js';
 
 window.EXCALIDRAW_ASSET_PATH = new URL('./assets/', window.location.href).href;
 let activeScene;
@@ -180,7 +183,25 @@ function Review() {
   const [context, setContext] = useState({});
   const [view, setView] = useState('after');
   const [revision, setRevision] = useState(0);
-  const [api, setApi] = useState(null);
+  const [reviewApi, setReviewApi] = useState(null);
+  const [workingApi, setWorkingApi] = useState(null);
+  const [working, setWorking] = useState(null);
+  const workingRef = useRef(null);
+  const [baseline, setBaseline] = useState(null);
+  const [proposal, setProposal] = useState(null);
+  const [agentBase, setAgentBase] = useState(null);
+  const [agentPrompt, setAgentPrompt] = useState('');
+  const [agentInstructions, setAgentInstructions] = useState('');
+  const [selection, setSelection] = useState([]);
+  const [documentId, setDocumentId] = useState(0);
+  const [saveStatus, setSaveStatus] = useState('');
+  const [loaded, setLoaded] = useState(false);
+  const storage = useRef(null);
+  const draftSequence = useRef(0);
+  const proposalInput = useRef(null);
+  const lastDownload = useRef(null);
+  const [pendingFile, setPendingFile] = useState(null);
+  const api = view === 'working' ? workingApi : reviewApi;
   const [ready, setReady] = useState(false);
   const [error, setError] = useState('');
   const [exporting, setExporting] = useState(false);
@@ -194,15 +215,32 @@ function Review() {
   const tabs = useRef([]);
   const snapshot = useRef(null);
   const pendingView = useRef(null);
-  const displayed = view === 'before' ? context.beforeScene : view === 'proposal' ? context.proposalScene : scene;
-  const viewKeys = Object.keys(context.review?.viewLabels || { before: 'Before', after: 'After' });
-  const viewLabel = key => context.review?.viewLabels[key] || (key === 'before' ? 'Before' : 'After');
+  const isReceipt = Boolean(context.review);
+  const beforeScene = isReceipt ? context.beforeScene : proposal?.base || agentBase || baseline;
+  const displayed = view === 'working' ? working : view === 'before' ? beforeScene : view === 'proposal' ? context.proposalScene : proposal?.scene || scene;
+  const viewKeys = isReceipt ? Object.keys(context.review.viewLabels || { before: 'Before', after: 'After' }) : ['working', 'before', ...(proposal ? ['after'] : [])];
+  const viewLabel = key => isReceipt ? context.review.viewLabels?.[key] || (key === 'before' ? 'Before' : 'After') : ({ working: 'Working', before: 'Before', after: 'Agent proposal' })[key];
   activeScene = displayed;
   const elements = useMemo(() => displayed?.elements.filter(e => !e.isDeleted) || [], [displayed]);
-  const title = context.title?.trim() || (typeof scene?.appState?.name === 'string' && scene.appState.name) || 'Diagram review';
+  const title = context.title?.trim() || (typeof working?.appState?.name === 'string' && working.appState.name) || 'Untitled diagram';
   const filename = title.replace(/[<>:"/\\|?*\x00-\x1f]/g, '-').trim() || 'diagram';
-  const changes = Array.isArray(context.changes) ? context.changes : null;
-  const summary = useMemo(() => summarizeEdits(context.beforeScene, scene, changes), [context.beforeScene, scene, changes]);
+  const changes = useMemo(() => isReceipt ? context.changes : beforeScene && (proposal?.scene || working) ? deriveChanges(beforeScene, proposal?.scene || working) : null, [isReceipt, context.changes, beforeScene, proposal, working]);
+  const summary = useMemo(() => summarizeEdits(beforeScene, proposal?.scene || working || scene, changes), [beforeScene, proposal, working, scene, changes]);
+  function reconcile(base, current, proposed) {
+    const result = mergeProposal(base, current, proposed);
+    if (result.conflicts.length) return result;
+    try {
+      const restored = new Set(restoreElements(structuredClone(result.scene.elements), null).map(element => element.id));
+      const changed = new Set(deriveChanges(current, result.scene).map(change => change.id));
+      for (const element of result.scene.elements) {
+        if (changed.has(element.id) && !element.isDeleted && !restored.has(element.id)) throw new Error(`The native editor cannot display proposed element ${element.id}. Use a supported shape with a visible size.`);
+      }
+    } catch (error) { return { scene: null, conflicts: [{ field: 'elements', message: error.message }] }; }
+    return result;
+  }
+  const reconciliation = useMemo(() => proposal && working ? reconcile(proposal.base, working, proposal.scene) : null, [proposal, working]);
+  function updateWorking(value) { workingRef.current = value; setWorking(value); }
+  function updateSelection(ids) { setSelection(current => current.join('\0') === ids.join('\0') ? current : ids); }
   const objects = elements.filter(e => e.type !== 'text' && !['arrow', 'line'].includes(e.type));
   const categories = [['shape', 'Shapes', ['rectangle', 'ellipse', 'diamond']], ['arrow', 'Connections', ['arrow', 'line']], ['text', 'Labels', ['text']], ['frame', 'Frames', ['frame', 'magicframe']], ['image', 'Images', ['image']], ['pen', 'Freehand', ['freedraw']]].map(([icon, label, types]) => ({ icon, label, count: elements.filter(e => types.includes(e.type)).length })).filter(item => item.count);
   const otherCount = elements.length - categories.reduce((count, item) => count + item.count, 0);
@@ -214,7 +252,7 @@ function Review() {
     if (snapshot.current) snapshot.current.hidden = true;
   }
   function reportError(message) { cancelTransition(); setReady(false); window.previewReady = false; setError(message); window.previewError = message; }
-  function resetReadiness() { setApi(null); setReady(false); window.previewReady = false; window.previewError = undefined; }
+  function resetReadiness() { setReviewApi(null); setReady(false); window.previewReady = false; window.previewError = undefined; }
   function fitDiagram(animate = false) {
     if (!api) return;
     const all = api.getSceneElements();
@@ -227,7 +265,7 @@ function Review() {
     focusRef.current = null; setFocusedItem(null); setNotice('Showing the full diagram.'); fitDiagram(true);
   }
   function focusItem(item) {
-    const versions = [[view, displayed], ['after', scene], ['before', context.beforeScene]];
+    const versions = [[view, displayed], ['after', proposal?.scene || (isReceipt ? scene : null)], ['before', beforeScene], ['working', working]];
     const target = versions.find(([, value]) => value && focusElements(value.elements, item.elementId).length);
     if (!target) return;
     setFocusedItem({ ...item });
@@ -239,19 +277,71 @@ function Review() {
     }
   }
 
+  function initialize(value, metadata = {}) {
+    validate(value);
+    if (metadata.beforeScene) validate(metadata.beforeScene);
+    if (metadata.proposalScene) validate(metadata.proposalScene);
+    cancelTransition(); resetReadiness(); setWorkingApi(null); setFocusedItem(null); focusRef.current = null;
+    setScene(value); setContext(metadata); setAgentBase(null); setAgentInstructions(''); setAgentPrompt(''); setSelection([]);
+    const base = metadata.beforeScene || value;
+    lastDownload.current = JSON.stringify(base);
+    updateWorking(metadata.review ? null : structuredClone(base)); setBaseline(structuredClone(base));
+    setProposal(metadata.beforeScene && !metadata.review ? { base: structuredClone(base), scene: structuredClone(value) } : null);
+    setView(metadata.beforeScene || metadata.review ? 'after' : 'working');
+    setDocumentId(id => id + 1); setRevision(id => id + 1); setError(''); setNotice('');
+  }
   useEffect(() => {
-    Promise.all(['scene', 'context'].map(async resource => {
-      const response = await fetch(`./${resource}`);
-      if (!response.ok) throw new Error('The diagram could not be loaded. Reopen the preview and try again.');
-      return response.json();
-    })).then(([value, metadata]) => { validate(value); if (metadata.beforeScene) validate(metadata.beforeScene); if (metadata.proposalScene) validate(metadata.proposalScene); setScene(value); setContext(metadata); }).catch(error => reportError(error.message));
+    let cancelled = false;
+    (async () => {
+      const [value, metadata] = await Promise.all(['scene', 'context'].map(async resource => {
+        const response = await fetch(`./${resource}`);
+        if (!response.ok) throw new Error('The diagram could not be loaded. Reopen the preview and try again.');
+        return response.json();
+      }));
+      let draft;
+      try { storage.current = await draftStore(); draft = await storage.current.read(); }
+      catch { setSaveStatus('Browser storage unavailable. Download your diagram to keep changes.'); }
+      if (cancelled) return;
+      initialize(value, metadata);
+      if (draft) {
+        try {
+          validate(draft.working); validate(draft.baseline);
+          if (draft.proposal) { validate(draft.proposal.base); validate(draft.proposal.scene); }
+          if (draft.agentBase) validate(draft.agentBase);
+          updateWorking(draft.working); setBaseline(draft.baseline); setProposal(draft.proposal); setAgentBase(draft.agentBase);
+          setContext(draft.context); setAgentPrompt(draft.agentPrompt || ''); setAgentInstructions(draft.agentInstructions || '');
+          setView('working'); setNotice('Restored your working diagram from this browser.');
+        } catch { setSaveStatus('The saved draft could not be read. Your original diagram is open.'); }
+      }
+      setLoaded(true);
+    })().catch(error => reportError(error.message));
+    return () => { cancelled = true; storage.current?.close(); };
   }, []);
+  useEffect(() => {
+    if (!loaded || !working || !storage.current) return;
+    const sequence = ++draftSequence.current;
+    setSaveStatus('Saving in this browser…');
+    const timeout = setTimeout(() => {
+      storage.current.write({ working, baseline, proposal, agentBase, agentPrompt, agentInstructions, context }).then(() => {
+        if (draftSequence.current === sequence) setSaveStatus('Saved in this browser');
+      }).catch(() => {
+        if (draftSequence.current === sequence) setSaveStatus('Draft could not be saved. Download your diagram to keep changes.');
+      });
+    }, 250);
+    return () => clearTimeout(timeout);
+  }, [loaded, working, baseline, proposal, agentBase, agentPrompt, agentInstructions, context]);
+  useEffect(() => {
+    const warn = event => { if (working && saveStatus !== 'Saved in this browser') { event.preventDefault(); event.returnValue = ''; } };
+    window.addEventListener('beforeunload', warn);
+    return () => window.removeEventListener('beforeunload', warn);
+  }, [working, saveStatus]);
   useEffect(() => { document.title = `${title} · Excalidraw Toolkit`; }, [title]);
   useEffect(() => {
     if (!api || !ready || !focusedItem) return;
     if (!focusElements(api.getSceneElements(), focusedItem.elementId).length) {
       setFocusedItem(null); setNotice('This element is not present in this view.'); return;
     }
+    if (view === 'working') api.updateScene({ appState: { selectedElementIds: { [focusedItem.elementId]: true } }, captureUpdate: CaptureUpdateAction.NEVER });
     fitDiagram(true);
   }, [api, ready, focusedItem]);
   useEffect(() => {
@@ -261,7 +351,7 @@ function Review() {
     let frame;
     const resize = new ResizeObserver(() => {
       cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(() => { frame = requestAnimationFrame(() => { if (!cancelled) fitDiagram(); }); });
+      frame = requestAnimationFrame(() => { frame = requestAnimationFrame(() => { if (!cancelled) { if (view === 'working') api.refresh(); else fitDiagram(); } }); });
     });
     resize.observe(canvasPanel.current);
     (async () => {
@@ -281,22 +371,22 @@ function Review() {
       setReady(true); window.previewReady = true;
     })().catch(error => reportError(error.message));
     return () => { cancelled = true; resize.disconnect(); cancelAnimationFrame(frame); };
-  }, [api, displayed]);
+  }, [api, revision, view]);
 
   async function openFile(event) {
     const file = event.target.files?.[0]; if (!file) return;
     try {
       const value = validate(JSON.parse(await file.text()));
-      cancelTransition();
-      focusRef.current = null; setFocusedItem(null);
-      resetReadiness(); setError(''); setNotice(''); setView('after');
-      setScene(value); setContext({ title: file.name.replace(/\.(excalidraw|json)$/i, '') }); setRevision(value => value + 1);
+      const metadata = { title: file.name.replace(/\.(excalidraw|json)$/i, '') };
+      if (workingRef.current && JSON.stringify(workingRef.current) !== lastDownload.current && JSON.stringify(value) !== JSON.stringify(workingRef.current)) {
+        setPendingFile({ value, metadata });
+      } else { initialize(value, metadata); setLoaded(true); setNotice('Opened as a working diagram.'); }
     } catch (error) { setError(error instanceof SyntaxError ? 'This file contains invalid JSON. Choose a valid .excalidraw file.' : error.message); }
     event.target.value = '';
   }
   function selectView(next) {
     if ((pendingView.current?.view ?? view) === next) return;
-    const dissolve = typeof snapshot.current.animate === 'function' && !matchMedia('(prefers-reduced-motion: reduce)').matches && (ready || !snapshot.current.hidden);
+    const dissolve = snapshot.current && typeof snapshot.current.animate === 'function' && !matchMedia('(prefers-reduced-motion: reduce)').matches && (ready || !snapshot.current.hidden);
     // Snapshot the rendered layers (including a dissolve already in progress).
     // An unfinished next view keeps the previous snapshot instead of a blank frame.
     if (dissolve && (ready || pendingView.current?.animation)) {
@@ -307,7 +397,7 @@ function Review() {
       context.scale(devicePixelRatio, devicePixelRatio);
       context.fillStyle = '#ffffff'; context.fillRect(0, 0, bounds.width, bounds.height);
       for (const layer of canvasPanel.current.querySelectorAll('canvas')) {
-        if (layer.hidden || !layer.width || !layer.height) continue;
+        if (layer.hidden || layer.closest('.layer-hidden') || !layer.width || !layer.height) continue;
         const rect = layer.getBoundingClientRect();
         context.globalAlpha = Number(getComputedStyle(layer).opacity);
         context.drawImage(layer, rect.left - bounds.left, rect.top - bounds.top, rect.width, rect.height);
@@ -325,34 +415,85 @@ function Review() {
     setExporting(true); setError('');
     try {
       let url;
-      if (context.retainedPngViews?.includes(view)) {
+      if (isReceipt && context.retainedPngViews?.includes(view)) {
         const response = await fetch(`./exports/${view}.png`);
         if (!response.ok) throw new Error('The retained PNG is unavailable. Reopen the receipt and try again.');
         url = URL.createObjectURL(await response.blob());
         setTimeout(() => URL.revokeObjectURL(url), 1000);
       } else url = await png();
-      download(url, `${filename}${context.beforeScene ? `-${view}` : ''}.png`);
+      download(url, `${filename}${view !== 'working' ? `-${view}` : ''}.png`);
       setNotice('PNG download started.');
     }
     catch (error) { setError(`PNG export failed: ${error.message}`); }
     finally { setExporting(false); }
   }
   function saveNative() {
+    if (view === 'working') lastDownload.current = JSON.stringify(displayed);
     const url = URL.createObjectURL(new Blob([JSON.stringify(displayed, null, 2)], { type: 'application/json' }));
-    download(url, `${filename}${context.beforeScene ? `-${view}` : ''}.excalidraw`);
-    setTimeout(() => URL.revokeObjectURL(url), 1000); setNotice('Editable copy download started.');
+    download(url, `${filename}${view !== 'working' ? `-${view}` : ''}.excalidraw`);
+    setTimeout(() => URL.revokeObjectURL(url), 1000); setNotice(view === 'working' ? 'Working diagram download started.' : 'Snapshot download started.');
+  }
+
+  function downloadScene(value, name) {
+    const url = URL.createObjectURL(new Blob([JSON.stringify(value, null, 2)], { type: 'application/json' }));
+    download(url, name); setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+  function prepareAgentEdit() {
+    const base = structuredClone(workingRef.current);
+    setAgentBase(base); setProposal(null); setError('');
+    const inputName = `${filename}-agent-input.excalidraw`;
+    const scope = selection.length ? `Limit changes to selected element IDs and required bound labels/connectors: ${selection.join(', ')}.` : 'No elements were selected. Preserve unrelated content and existing native IDs.';
+    setAgentInstructions(`Edit the attached ${inputName} with Excalidraw Toolkit.\n\n${agentPrompt.trim()}\n\n${scope}\nReturn the full edited .excalidraw file as a proposal. Keep the input unchanged. I will review and accept the proposal in the workspace.`);
+    downloadScene(base, inputName);
+    setNotice('Agent input downloaded. Use it with the instructions below, then load the returned diagram. You can keep drawing.');
+  }
+  async function loadProposal(event) {
+    const file = event.target.files?.[0]; if (!file) return;
+    try {
+      const value = validate(JSON.parse(await file.text()));
+      if (!agentBase) throw new Error('Prepare an agent edit first so the proposal has an exact starting point.');
+      setProposal({ base: structuredClone(agentBase), scene: value }); setError(''); selectView('after');
+    } catch (error) { setError(`Proposal could not be loaded: ${error.message}`); }
+    event.target.value = '';
+  }
+  function acceptProposal() {
+    const result = reconcile(proposal.base, workingRef.current, proposal.scene);
+    if (result.conflicts.length) { setError('This proposal conflicts with your drawing. Keep your work and prepare a new edit from Working.'); return; }
+    const previous = workingApi.getSceneElementsIncludingDeleted();
+    const index = new Map(previous.map(element => [element.id, element]));
+    const changed = new Map(deriveChanges(workingRef.current, result.scene).map(change => [change.id, Object.keys(change.properties)]));
+    const restored = restoreElements(structuredClone(result.scene.elements), previous);
+    const next = restored.map(element => {
+      const old = index.get(element.id);
+      if (!old) return element;
+      if (!changed.has(element.id)) return old;
+      const updates = Object.fromEntries(changed.get(element.id).map(field => [field, element[field]]));
+      return newElementWith(old, updates);
+    });
+    // Native history records the entire proposal as one update. Image bytes
+    // remain available when undo removes their elements and redo restores them.
+    workingApi.addFiles(Object.values(result.scene.files || {}));
+    updateWorking(result.scene);
+    workingApi.updateScene({ elements: next, appState: { viewBackgroundColor: result.scene.appState?.viewBackgroundColor }, captureUpdate: CaptureUpdateAction.IMMEDIATELY });
+    setProposal(null); setAgentBase(null); setAgentInstructions(''); setError(''); selectView('working');
+    setNotice('Proposal accepted. Undo once to return to your previous working diagram.');
+  }
+  function discardProposal() {
+    setProposal(null); setAgentBase(null); setAgentInstructions(''); setError(''); selectView('working');
+    setNotice('Proposal discarded. Your working diagram is unchanged.');
   }
 
   return <div className="review-app" onKeyDown={event => { if (event.key === 'Escape' && focusedItem) { event.preventDefault(); backToOverview(); } }}>
+    {pendingFile && <dialog className="replace-dialog" ref={element => { if (element && !element.open) element.showModal(); }} onCancel={() => setPendingFile(null)} aria-labelledby="replace-title"><h2 id="replace-title">Keep your working diagram</h2><p>Opening another file replaces this browser draft. Save a native copy to keep your current drawing.</p><div><button className="button button-quiet" onClick={() => setPendingFile(null)}>Cancel</button><button className="button button-outline" onClick={() => { initialize(pendingFile.value, pendingFile.metadata); setPendingFile(null); }}>Open without saving</button><button autoFocus className="button button-primary" onClick={() => { downloadScene(workingRef.current, `${filename}.excalidraw`); initialize(pendingFile.value, pendingFile.metadata); setPendingFile(null); }}>Save &amp; open</button></div></dialog>}
     <a className="skip-link" href="#diagram-workspace">Skip to diagram</a>
     <header className="review-header">
       <div className="brand"><span className="brand-mark"><Icon name="layers" size={25} /></span><span>Excalidraw <strong>Toolkit</strong></span></div>
-      <span className="header-divider" /><span className="header-label">Diagram review</span>
+      <span className="header-divider" /><span className="header-label">Diagram workspace</span>
       <div className="header-actions">
         <input ref={fileInput} id="open" type="file" accept=".excalidraw,application/json" onChange={openFile} hidden />
         <button className="button button-quiet" onClick={() => fileInput.current.click()}><Icon name="open" /><span>Open file</span></button>
         <span className="action-divider" />
-        <button id="native" className="button button-outline" aria-label="Download editable .excalidraw copy" title="Download the current view as an editable .excalidraw copy" disabled={!ready} onClick={saveNative}><Icon name="file" /><span>Download copy</span></button>
+        <button id="native" className="button button-outline" aria-label="Download editable .excalidraw copy" title="Download the current view as an editable .excalidraw copy" disabled={!ready} onClick={saveNative}><Icon name="file" /><span>{view === 'working' ? 'Save diagram' : 'Download copy'}</span></button>
         <button id="png" className="button button-primary" disabled={!ready || exporting} onClick={exportPng}><Icon name="download" /><span>{exporting ? 'Exporting…' : 'Export PNG'}</span></button>
       </div>
     </header>
@@ -360,32 +501,50 @@ function Review() {
       <button className="sidebar-toggle" aria-expanded={detailsOpen} aria-controls="scene-details" onClick={() => setDetailsOpen(value => !value)}><Icon name="layers" size={16} /><span>Diagram details</span><span aria-hidden="true">{detailsOpen ? '−' : '+'}</span></button>
       <aside id="scene-details" className="review-sidebar" data-open={detailsOpen} aria-label="Diagram details">
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
-        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : context.beforeScene ? 'Before & after review' : 'Native diagram'}</p></div></div>
-        {context.review ? <ReceiptDetails review={context.review} view={view} /> : <>
+        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : proposal ? 'Proposal ready to review' : 'Editable working diagram'}</p></div></div>
+        {isReceipt ? <ReceiptDetails review={context.review} view={view} /> : <>
+        <section className="sidebar-section agent-section" aria-labelledby="agent-title">
+          <div className="section-heading"><h2 id="agent-title">Work with an agent</h2><Icon name="pen" size={15} /></div>
+          <p className="sidebar-note">Use your own agent with a saved copy. Keep drawing while it works.</p>
+          <label className="agent-label" htmlFor="agent-prompt">Describe the edit</label>
+          <textarea id="agent-prompt" aria-label="Describe the edit" placeholder="Connect this service to the queue…" value={agentPrompt} onChange={event => setAgentPrompt(event.target.value)} />
+          <p className="selection-note">{selection.length ? `${selection.length} selected ${selection.length === 1 ? 'element' : 'elements'}` : 'Select an area on Working to scope the edit.'}</p>
+          {!agentBase && !proposal && <button className="button button-outline" disabled={!ready || view !== 'working' || !agentPrompt.trim()} onClick={prepareAgentEdit}>Prepare agent edit</button>}
+          {agentBase && <><details className="agent-instructions" open={!proposal}><summary>Agent instructions</summary><p className="sidebar-note">Attach the downloaded input file to your agent.</p><textarea aria-label="Agent instructions" readOnly value={agentInstructions} /><button className="button button-quiet" onClick={async () => { try { await navigator.clipboard.writeText(agentInstructions); setNotice('Agent instructions copied.'); } catch { setError('Copy is unavailable. Select and copy the instructions above.'); } }}>Copy instructions</button></details>
+            <input ref={proposalInput} type="file" accept=".excalidraw,application/json" hidden onChange={loadProposal} />
+            <button className="button button-outline" onClick={() => proposalInput.current.click()}>Load proposal</button>
+            {!proposal && <button className="button button-quiet" onClick={discardProposal}>Cancel agent edit</button>}</>}
+          {proposal && <p className="sidebar-note proposal-note">Review the proposal beside your current work. Acceptance preserves independent manual edits.</p>}
+        </section>
         <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} disabled={!scene || !!error} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
         </section>
         {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><button className="object-link" disabled={!scene || !!error} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
         </>}
-        <div className="sidebar-footer"><Icon name="check" size={15} /><span>Review a copy. Keep your original.</span></div>
+        <div className="sidebar-footer"><Icon name="check" size={15} /><span>{isReceipt ? 'Review a copy. Keep your original.' : 'Native files. Your drawing stays yours.'}</span></div>
       </aside>
       <main id="diagram-workspace" className="diagram-workspace" tabIndex={-1}>
-        <div className="workspace-heading"><div><p className="eyebrow">{context.beforeScene ? 'Compare & review' : 'Your diagram'}</p><h1>{title}</h1><p className="workspace-description">{context.review?.kind === 'source-refresh' ? 'Compare the source proposal with your changes and the staged candidate.' : context.review ? 'Trace each relationship to its source, and see what changed.' : context.beforeScene ? 'A clear view of what changed, with the original close at hand.' : 'Explore the details. Take the editable file with you.'}</p></div><span className="review-badge"><span />Read-only preview</span></div>
+        <div className="workspace-heading"><div><p className="eyebrow">{isReceipt ? 'Compare & review' : 'Draw · refine · make it yours'}</p><h1>{title}</h1><p className="workspace-description">{isReceipt ? 'Inspect the preserved source review, or open an editable copy.' : 'Sketch freely. Review agent changes. Keep everything in one diagram.'}</p></div><span className="review-badge"><span />{view === 'working' ? 'Editable canvas' : 'Read-only snapshot'}</span>{isReceipt && <button className="button button-outline" onClick={() => initialize(structuredClone(displayed), { title })}>Edit copy</button>}</div>
         {error && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{error}</span>{scene && <button aria-label="Dismiss error" onClick={() => setError('')}>×</button>}</div>}
         <div className="canvas-card">
-          <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{context.review?.kind === 'source-refresh' ? viewLabel(view) : context.beforeScene ? (view === 'after' ? 'Updated diagram' : 'Original diagram') : 'Canvas'}</span></div>
-            {context.beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{viewKeys.map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? viewKeys.length - 1 : (index + (event.key === 'ArrowRight' ? 1 : viewKeys.length - 1)) % viewKeys.length; selectView(viewKeys[next]); tabs.current[next]?.focus(); } }}>{viewLabel(item)}</button>)}</div>}
+          <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{viewLabel(view)}</span></div>
+            {beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{viewKeys.map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? viewKeys.length - 1 : (index + (event.key === 'ArrowRight' ? 1 : viewKeys.length - 1)) % viewKeys.length; selectView(viewKeys[next]); tabs.current[next]?.focus(); } }}>{viewLabel(item)}</button>)}</div>}
             <button aria-label={focusedItem ? 'Back to overview' : 'Fit diagram'} className={`fit-button ${focusedItem ? 'is-focused' : ''}`} disabled={!ready || !elements.length} onClick={backToOverview}><Icon name="fit" size={15} /><span>{focusedItem ? 'Back to overview' : 'Fit diagram'}</span></button>
           </div>
-          <div ref={canvasPanel} id="canvas-panel" className="canvas-panel" role={context.beforeScene ? 'tabpanel' : 'region'} aria-labelledby={context.beforeScene ? `${view}-tab` : undefined} aria-label={context.beforeScene ? undefined : 'Diagram canvas'} aria-busy={!ready && !error}>
-            {displayed ? <CanvasBoundary key={`${revision}-${view}`} onError={reportError}><Excalidraw key={`${revision}-${view}`} initialData={{ elements: structuredClone(displayed.elements), files: structuredClone(displayed.files || {}), appState: { ...displayed.appState, viewModeEnabled: true } }} excalidrawAPI={setApi} viewModeEnabled={true} zenModeEnabled={true} theme="light" /></CanvasBoundary> : <div className="canvas-state"><span className={error ? '' : 'loading-symbol'}><Icon name={error ? 'info' : 'layers'} size={30} /></span><h2>{error ? 'Your diagram is waiting' : 'Opening your diagram'}</h2><p>{error ? 'Choose a file to start a new review.' : 'Preparing the native canvas…'}</p></div>}
-            {api && ready && focusedItem && <ElementFocus api={api} elementId={focusedItem.elementId} />}
+          <div ref={canvasPanel} id="canvas-panel" className="canvas-panel" role={beforeScene ? 'tabpanel' : 'region'} aria-labelledby={beforeScene ? `${view}-tab` : undefined} aria-label={beforeScene ? undefined : 'Diagram canvas'} aria-busy={!ready && !error}>
+            {working && <div className={`native-layer working-layer ${view !== 'working' ? 'layer-hidden' : ''}`} aria-hidden={view !== 'working'} {...(view !== 'working' ? { inert: '' } : {})}>
+              <CanvasBoundary key={documentId} onError={reportError}><WorkingCanvas key={documentId} scene={working} onScene={updateWorking} onApi={setWorkingApi} onSelection={updateSelection} /></CanvasBoundary>
+            </div>}
+            {view !== 'working' && displayed && <div className="native-layer snapshot-layer"><CanvasBoundary key={`${revision}-${view}`} onError={reportError}><Excalidraw key={`${revision}-${view}`} initialData={{ elements: structuredClone(displayed.elements), files: structuredClone(displayed.files || {}), appState: { ...displayed.appState, viewModeEnabled: true } }} excalidrawAPI={setReviewApi} viewModeEnabled={true} zenModeEnabled={true} theme="light" handleKeyboardGlobally={false} /></CanvasBoundary></div>}
+            {!displayed && <div className="canvas-state"><span className={error ? '' : 'loading-symbol'}><Icon name={error ? 'info' : 'layers'} size={30} /></span><h2>{error ? 'Your diagram is waiting' : 'Opening your diagram'}</h2><p>{error ? 'Choose a file to start a new workspace.' : 'Preparing the native canvas…'}</p></div>}
+            {view !== 'working' && api && ready && focusedItem && <ElementFocus api={api} elementId={focusedItem.elementId} />}
             <canvas ref={snapshot} className="view-snapshot" aria-hidden="true" hidden />
           </div>
-          <div className="canvas-footer"><span id="status" role="status"><span className={`status-dot ${ready ? 'is-ready' : ''}`} />{ready ? `${elements.length} ${elements.length === 1 ? 'element' : 'elements'} · Viewing a read-only copy` : error ? 'Preview unavailable' : 'Preparing canvas…'}</span><span className="canvas-hint">Scroll to pan · Pinch to zoom</span></div>
+          <div className="canvas-footer"><span id="status" role="status"><span className={`status-dot ${ready ? 'is-ready' : ''}`} />{ready ? `${elements.length} ${elements.length === 1 ? 'element' : 'elements'} · ${view === 'working' ? 'Draw and edit freely' : 'Viewing a read-only copy'}` : error ? 'Preview unavailable' : 'Preparing canvas…'}</span><span className="canvas-hint">{view === 'working' ? 'Space to pan · ⌘/Ctrl Z to undo' : 'Scroll to pan · Pinch to zoom'}</span></div>
         </div>
-        <div className="workspace-footer"><span>Made to stay editable.</span><span role="status" aria-live="polite">{notice || (context.beforeScene ? `Exports use the ${viewLabel(view).toLowerCase()} view.` : 'PNG for sharing. Excalidraw for what comes next.')}</span></div>
+        {proposal && <div className="proposal-bar"><div><strong>{reconciliation?.conflicts.length ? 'Your work needs a fresh proposal' : 'Ready when you are'}</strong><p>{reconciliation?.conflicts.length ? reconciliation.conflicts.map(conflict => conflict.message).join(' ') : 'Accept these changes into Working, or keep your drawing as it is.'}</p></div><button className="button button-quiet" onClick={discardProposal}>Discard proposal</button><button className="button button-primary" disabled={!ready || !workingApi || !!reconciliation?.conflicts.length} onClick={acceptProposal}>Accept proposal</button></div>}
+        <div className="workspace-footer"><span>{isReceipt ? 'Made to stay editable.' : saveStatus || 'Download your diagram to keep a portable copy.'}</span><span role="status" aria-live="polite">{notice || (beforeScene ? `Exports use the ${viewLabel(view).toLowerCase()} view.` : 'PNG for sharing. Excalidraw for what comes next.')}</span></div>
       </main>
     </div>
   </div>;

--- a/src/web/workspace.js
+++ b/src/web/workspace.js
@@ -1,0 +1,266 @@
+// Browser-only scene bookkeeping. Native restoration is a rendering operation;
+// only changes after its first onChange snapshot belong in the saved document.
+const bookkeeping = new Set(['version', 'versionNonce', 'updated', 'index']);
+const fileBookkeeping = new Set(['created', 'lastRetrieved']);
+// The acceptance surface is intentionally limited to native drawing properties.
+// Other imported fields are retained, but a proposal cannot rewrite metadata
+// which this workspace does not apply through the editor's undo history.
+const nativeFields = new Set([
+  'id', 'type', 'x', 'y', 'width', 'height', 'angle', 'isDeleted', 'groupIds', 'frameId', 'boundElements', 'link', 'locked', 'customData',
+  'backgroundColor', 'strokeColor', 'fillStyle', 'strokeWidth', 'strokeStyle', 'roughness', 'opacity', 'roundness',
+  'fontSize', 'fontFamily', 'text', 'textAlign', 'verticalAlign', 'containerId', 'originalText', 'autoResize', 'lineHeight',
+  'points', 'pressures', 'simulatePressure', 'startBinding', 'endBinding', 'startArrowhead', 'endArrowhead', 'elbowed',
+  'fixedSegments', 'startIsSpecial', 'endIsSpecial', 'fileId', 'status', 'scale', 'crop', 'name',
+]);
+const independentStyle = new Set(['backgroundColor', 'strokeColor', 'fillStyle', 'strokeWidth', 'strokeStyle', 'roughness', 'opacity', 'roundness']);
+const clone = structuredClone;
+const object = value => value !== null && typeof value === 'object' && !Array.isArray(value);
+const live = element => element && !element.isDeleted;
+// Native callbacks can include optional undefined keys; JSON downloads omit them.
+const at = (value, key) => value[key] !== undefined && Object.hasOwn(value, key) ? { value: value[key] } : {};
+function same(a, b) {
+  if (a === b) return true;
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object' || Array.isArray(a) !== Array.isArray(b)) return false;
+  const keys = Object.keys(a).filter(key => a[key] !== undefined);
+  return keys.length === Object.keys(b).filter(key => b[key] !== undefined).length && keys.every(key => Object.hasOwn(b, key) && same(a[key], b[key]));
+}
+function changed(a, b, ignored = bookkeeping) {
+  return [...new Set([...Object.keys(a), ...Object.keys(b)])].filter(key => !ignored.has(key) && !same(at(a, key), at(b, key)));
+}
+function setField(target, source, key) {
+  if (Object.hasOwn(source, key)) Object.defineProperty(target, key, { value: clone(source[key]), enumerable: true, writable: true, configurable: true });
+  else delete target[key];
+}
+
+// This follows scene.js validateScene's native identity, reciprocal binding,
+// frame, and image-asset rules without importing its Node-only receipt code.
+function validate(scene) {
+  if (!object(scene) || scene.type !== 'excalidraw' || !Array.isArray(scene.elements) ||
+    (scene.files !== undefined && !object(scene.files))) throw new Error('Invalid Excalidraw document.');
+  const index = new Map();
+  for (const element of scene.elements) {
+    if (!object(element) || typeof element.id !== 'string' || !element.id || typeof element.type !== 'string' || index.has(element.id)) throw new Error('Elements must have unique IDs and native types.');
+    index.set(element.id, element);
+  }
+  const reference = (id, owner) => {
+    if (!live(index.get(id))) throw new Error(`${owner}: missing live reference ${id}.`);
+    return index.get(id);
+  };
+  for (const element of scene.elements) {
+    if (!live(element)) continue;
+    if (element.boundElements != null) {
+      if (!Array.isArray(element.boundElements)) throw new Error(`${element.id}: invalid bound elements.`);
+      const seen = new Set();
+      for (const binding of element.boundElements) {
+        if (!object(binding) || typeof binding.id !== 'string' || seen.has(binding.id)) throw new Error(`${element.id}: invalid or duplicate binding.`);
+        seen.add(binding.id);
+        const target = reference(binding.id, element.id);
+        if (binding.type !== target.type || !['text', 'arrow'].includes(binding.type) ||
+          (target.type === 'text' && target.containerId !== element.id) ||
+          (target.type === 'arrow' && target.startBinding?.elementId !== element.id && target.endBinding?.elementId !== element.id)) throw new Error(`${element.id}: nonreciprocal binding.`);
+      }
+    }
+    if (element.containerId != null) {
+      const container = reference(element.containerId, element.id);
+      if (element.type !== 'text' || !container.boundElements?.some(binding => binding.id === element.id && binding.type === 'text')) throw new Error(`${element.id}: nonreciprocal text container.`);
+    }
+    for (const field of ['startBinding', 'endBinding']) {
+      const binding = element[field];
+      if (binding == null) continue;
+      if (!object(binding) || typeof binding.elementId !== 'string') throw new Error(`${element.id}: invalid ${field}.`);
+      const target = reference(binding.elementId, element.id);
+      if (element.type !== 'arrow' || !target.boundElements?.some(entry => entry.id === element.id && entry.type === 'arrow')) throw new Error(`${element.id}: nonreciprocal ${field}.`);
+    }
+    if (element.frameId != null && !['frame', 'magicframe'].includes(reference(element.frameId, element.id).type)) throw new Error(`${element.id}: invalid frame.`);
+    if (element.type === 'image' && element.fileId != null && !Object.hasOwn(scene.files ?? {}, element.fileId)) throw new Error(`${element.id}: missing image asset ${element.fileId}.`);
+  }
+  return index;
+}
+
+/** Changes have the receipt sidebar's shape, but also support manual reordering. */
+export function deriveChanges(before, after) {
+  const previous = new Map(before.elements.map(element => [element.id, element]));
+  const next = new Map(after.elements.map(element => [element.id, element]));
+  const changes = [];
+  for (const element of after.elements) {
+    const old = previous.get(element.id);
+    const fields = old ? changed(old, element) : Object.keys(element);
+    if (fields.length) changes.push({ id: element.id, ...(!old ? { created: true } : {}), properties: Object.fromEntries(fields.map(field => [field, {
+      before: old?.[field] ?? null, ...(Object.hasOwn(element, field) ? { after: clone(element[field]) } : {}),
+    }])) });
+  }
+  for (const element of before.elements) {
+    if (!next.has(element.id) && live(element)) changes.push({ id: element.id, properties: { isDeleted: { before: false, after: true } } });
+  }
+  return changes;
+}
+
+/** appState must contain native serializeAsJSON(..., 'local') persisted fields. */
+export function captureWorkingScene(original, elements, appState, files, previousNative) {
+  if (!previousNative) return original;
+  const previous = new Map(previousNative.elements.map(element => [element.id, element]));
+  const current = new Map(elements.map(element => [element.id, element]));
+  const stored = new Map(original.elements.map(element => [element.id, element]));
+  const candidate = clone(original);
+  let dirty = false;
+  const reordered = !same(previousNative.elements.map(element => element.id), elements.map(element => element.id));
+  const restacked = !same(previousNative.elements.filter(element => current.has(element.id)).map(element => element.id), elements.filter(element => previous.has(element.id)).map(element => element.id));
+  const captured = new Map();
+  for (const element of elements) {
+    const old = previous.get(element.id), existing = stored.get(element.id);
+    if (!existing) { captured.set(element.id, clone(element)); dirty = true; continue; }
+    const fields = old ? changed(old, element) : [];
+    const updated = clone(existing);
+    if (fields.length) {
+      for (const field of [...fields, ...bookkeeping]) setField(updated, element, field);
+      dirty = true;
+    } else if (restacked && !same(at(existing, 'index'), at(element, 'index'))) setField(updated, element, 'index');
+    captured.set(element.id, updated);
+  }
+  for (const existing of original.elements) {
+    if (current.has(existing.id)) continue;
+    const updated = clone(existing);
+    if (previous.has(existing.id) && !existing.isDeleted) { updated.isDeleted = true; dirty = true; }
+    captured.set(existing.id, updated);
+  }
+  // Keep imported objects that restoration did not expose, including tombstones.
+  candidate.elements = reordered ? [...captured.values()] : original.elements.map(element => captured.get(element.id));
+  dirty ||= reordered;
+  for (const field of changed(previousNative.appState ?? {}, appState ?? {}, new Set())) {
+    candidate.appState ??= {};
+    setField(candidate.appState, appState ?? {}, field);
+    dirty = true;
+  }
+  for (const id of changed(previousNative.files ?? {}, files ?? {}, new Set())) {
+    // Keep unused assets for native undo; loading or inserting an image may add
+    // native defaults to its file record, so copy only fields that actually changed.
+    if (!Object.hasOwn(files ?? {}, id)) continue;
+    candidate.files ??= {};
+    const existing = candidate.files[id];
+    const fields = changed(previousNative.files?.[id] ?? {}, files[id], existing ? fileBookkeeping : new Set());
+    if (!fields.length) continue;
+    const asset = clone(existing ?? {});
+    for (const field of fields) setField(asset, files[id], field);
+    setField(candidate.files, { [id]: asset }, id);
+    dirty = true;
+  }
+  return dirty ? candidate : original;
+}
+
+function orderElements(base, current, proposed, merged, conflicts) {
+  const common = new Set(base.elements.filter(element => current.some(item => item.id === element.id) && proposed.some(item => item.id === element.id)).map(element => element.id));
+  const order = elements => elements.filter(element => common.has(element.id)).map(element => element.id);
+  const initial = order(base.elements), human = order(current), agent = order(proposed);
+  if (!same(human, initial) && !same(agent, initial) && !same(human, agent)) {
+    conflicts.push({ field: 'elements', message: 'Both versions changed the stacking order differently.' });
+    return [];
+  }
+  const result = same(agent, initial) ? human : agent;
+  for (const elements of [current, proposed]) {
+    for (let start = 0; start < elements.length;) {
+      if (common.has(elements[start].id)) { start++; continue; }
+      let end = start;
+      while (end < elements.length && !common.has(elements[end].id)) end++;
+      const before = start ? elements[start - 1].id : null;
+      const after = end < elements.length ? elements[end].id : null;
+      if (before && after && result.indexOf(before) > result.indexOf(after)) {
+        conflicts.push({ field: 'elements', message: 'A new element overlaps a concurrent stacking-order change.' });
+        return [];
+      }
+      const additions = elements.slice(start, end).map(element => element.id).filter(id => !result.includes(id));
+      result.splice(after ? result.indexOf(after) : result.length, 0, ...additions);
+      start = end;
+    }
+  }
+  for (const id of merged.keys()) if (!result.includes(id)) result.push(id);
+  return result.map(id => merged.get(id));
+}
+
+/** Apply a proposal atomically; conflict means the working scene stays untouched. */
+export function mergeProposal(base, current, proposed) {
+  const conflicts = [];
+  let before, human, agent;
+  try { before = validate(base); human = validate(current); agent = validate(proposed); }
+  catch (error) { return { scene: null, conflicts: [{ field: 'document', message: error.message }] }; }
+  const candidate = clone(current);
+  const merged = new Map(candidate.elements.map(element => [element.id, element]));
+  for (const [id, element] of before) if (!merged.has(id)) merged.set(id, { ...clone(element), isDeleted: true });
+  const conflict = (id, field, message) => conflicts.push({ ...(id ? { id } : {}), field, message });
+  const structural = [new Set(), new Set()];
+  for (const [id, incoming] of agent) {
+    const old = before.get(id);
+    if (!old) continue; // Undo removes a newly added element as a whole.
+    for (const field of changed(old, incoming)) {
+      if (field === 'type' || !Object.hasOwn(incoming, field)) conflict(id, field, 'A proposal cannot change an existing native type or remove drawing fields. Use an explicit native value instead.');
+      if (!nativeFields.has(field) && !(field === 'lastCommittedPoint' && incoming[field] == null)) conflict(id, field, `The proposal changes unsupported metadata (${field}). Keep it unchanged so acceptance stays undoable.`);
+    }
+  }
+  for (const [id, incoming] of agent) {
+    if (before.has(id)) continue;
+    if (human.has(id)) { conflict(id, 'id', 'The proposal and working diagram added the same element ID.'); continue; }
+    merged.set(id, clone(incoming));
+    structural[1].add(id);
+  }
+  for (const [id, existing] of human) if (!before.has(id)) structural[0].add(id);
+  for (const [id, old] of before) {
+    const existing = human.get(id), incoming = agent.get(id);
+    const humanFields = existing ? changed(old, existing) : ['isDeleted'];
+    const agentFields = incoming ? changed(old, incoming) : ['isDeleted'];
+    if (!existing || !incoming || changed(existing, incoming).length) {
+      if (humanFields.some(field => !independentStyle.has(field))) structural[0].add(id);
+      if (agentFields.some(field => !independentStyle.has(field))) structural[1].add(id);
+    }
+    if (!agentFields.length) continue;
+    if (!live(existing) || !live(incoming)) {
+      if (Boolean(live(existing)) !== Boolean(live(incoming)) && humanFields.length && agentFields.length) {
+        conflict(id, 'isDeleted', 'This element was deleted in one version and edited in the other.'); continue;
+      }
+      if (!incoming) merged.set(id, { ...clone(existing ?? old), isDeleted: true });
+      else if (!humanFields.length) for (const field of agentFields) setField(merged.get(id), incoming, field);
+      continue;
+    }
+    if (humanFields.some(field => !independentStyle.has(field)) && agentFields.some(field => !independentStyle.has(field)) && !same(humanFields.map(field => [field, at(existing, field)]), agentFields.map(field => [field, at(incoming, field)]))) {
+      conflict(id, 'element', 'Both versions changed this element’s geometry, text, or relationships.'); continue;
+    }
+    for (const field of agentFields) {
+      if (humanFields.includes(field) && !same(at(existing, field), at(incoming, field))) conflict(id, field, `Both versions changed ${field}.`);
+      else setField(merged.get(id), incoming, field);
+    }
+  }
+  // Bound labels and connected endpoints share geometry even across element IDs.
+  for (const elements of [base.elements, current.elements, proposed.elements]) {
+    for (const element of elements) {
+      const references = [...(element.boundElements?.map(binding => binding.id) ?? []), element.containerId, element.startBinding?.elementId, element.endBinding?.elementId, element.frameId].filter(Boolean);
+      if (structural[0].has(element.id) && references.some(id => id !== element.id && structural[1].has(id))) conflict(element.id, 'bindings', 'Related elements changed in both versions; review their positions and bindings together.');
+    }
+  }
+  const mergeFields = (initial, existing, incoming, target, prefix) => {
+    for (const field of changed(initial, incoming, new Set())) {
+      if (!same(at(initial, field), at(existing, field)) && !same(at(existing, field), at(incoming, field))) conflict(null, `${prefix}${field}`, `Both versions changed ${prefix}${field}.`);
+      else setField(target, incoming, field);
+    }
+  };
+  const document = value => Object.fromEntries(Object.entries(value).filter(([key]) => !['elements', 'files', 'appState'].includes(key)));
+  for (const field of changed(document(base), document(proposed), new Set())) conflict(null, field, `The proposal changes document metadata (${field}). Keep it unchanged so acceptance stays undoable.`);
+  const appFields = changed(base.appState ?? {}, proposed.appState ?? {}, new Set());
+  for (const field of appFields) {
+    if (field !== 'viewBackgroundColor' || typeof proposed.appState[field] !== 'string') conflict(null, `appState.${field}`, `The proposal changes a setting (${field}) outside the workspace's undoable drawing state.`);
+  }
+  if (appFields.length) {
+    candidate.appState ??= {};
+    mergeFields(base.appState ?? {}, current.appState ?? {}, proposed.appState ?? {}, candidate.appState, 'appState.');
+  }
+  for (const [id, asset] of Object.entries(proposed.files ?? {})) {
+    if (Object.hasOwn(current.files ?? {}, id)) {
+      if (!same(base.files?.[id], asset) && !same(current.files[id], asset)) conflict(null, `files.${id}`, 'An existing image asset cannot be replaced; use a new file ID.');
+    } else if (!Object.hasOwn(base.files ?? {}, id)) {
+      candidate.files ??= {};
+      setField(candidate.files, { [id]: asset }, id);
+    }
+  }
+  candidate.elements = orderElements(base, current.elements, proposed.elements, merged, conflicts);
+  if (!conflicts.length) {
+    try { validate(candidate); } catch (error) { conflict(null, 'bindings', error.message); }
+  }
+  return { scene: conflicts.length ? null : candidate, conflicts };
+}

--- a/test/editable-workspace.test.js
+++ b/test/editable-workspace.test.js
@@ -1,0 +1,297 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { chromium } from 'playwright';
+import { servePreview } from '../src/render.js';
+
+const fixture = new URL('./fixtures/annotated.excalidraw', import.meta.url);
+const readScene = page => page.evaluate(() => JSON.parse(JSON.stringify(window.sceneForPreview())));
+const live = scene => scene.elements.filter(element => !element.isDeleted);
+const tool = (page, name) => page.locator('.working-layer label').filter({ has: page.getByRole('radio', { name, exact: true }) });
+
+async function openWorkspace(t, init) {
+  const original = JSON.parse(readFileSync(fixture));
+  const preview = await servePreview(original);
+  t.after(() => preview.close());
+  const browser = await chromium.launch();
+  t.after(() => browser.close());
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, reducedMotion: 'reduce' });
+  // Headless Chromium cannot operate the OS file picker. Exercise Excalidraw's
+  // native file-input fallback, also used by browsers without that picker API.
+  await page.addInitScript(() => { delete window.showOpenFilePicker; });
+  if (init) await page.addInitScript(init);
+  page.setDefaultTimeout(10000);
+  const errors = [];
+  page.on('pageerror', error => errors.push(error.message));
+  t.after(() => assert.deepEqual(errors, []));
+  await page.goto(preview.url);
+  await page.waitForFunction(() => window.previewReady);
+  assert.equal(await page.getByRole('tab', { name: 'Working', exact: true }).getAttribute('aria-selected'), 'true');
+  return { page, original };
+}
+
+async function version(page, name) {
+  await page.getByRole('tab', { name, exact: true }).click();
+  await page.waitForFunction(id => window.previewReady && document.getElementById(id)?.getAttribute('aria-selected') === 'true', { Working: 'working-tab', Before: 'before-tab', 'Agent proposal': 'after-tab' }[name]);
+}
+
+async function downloadScene(page, trigger) {
+  const downloading = page.waitForEvent('download');
+  await trigger.click();
+  const download = await downloading;
+  return { scene: JSON.parse(readFileSync(await download.path())), name: download.suggestedFilename() };
+}
+
+async function chooseScene(page, name, scene) {
+  const choosing = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name, exact: true }).click();
+  await (await choosing).setFiles({ name: 'working.excalidraw', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(scene)) });
+}
+
+async function loadScene(page, name, scene) {
+  await chooseScene(page, name, scene);
+  await page.waitForFunction(id => window.previewReady && document.getElementById(id)?.getAttribute('aria-selected') === 'true', name === 'Load proposal' ? 'after-tab' : 'working-tab');
+  if (name === 'Open file') await page.waitForFunction(() => document.title.startsWith('working ·'));
+}
+
+async function draw(page, type, { x = 0.67, y = 0.76 } = {}) {
+  const previous = new Set(live(await readScene(page)).map(element => element.id));
+  const canvas = await page.locator('#canvas-panel').boundingBox();
+  const point = { x: canvas.x + canvas.width * x, y: canvas.y + canvas.height * y };
+  await tool(page, type === 'freedraw' ? 'Draw' : 'Rectangle').click();
+  await page.mouse.move(point.x, point.y);
+  await page.mouse.down();
+  if (type === 'freedraw') {
+    await page.mouse.move(point.x + 25, point.y - 15, { steps: 3 });
+    await page.mouse.move(point.x + 55, point.y + 20, { steps: 4 });
+    await page.mouse.move(point.x + 90, point.y - 5, { steps: 4 });
+  } else await page.mouse.move(point.x + 105, point.y + 60, { steps: 5 });
+  await page.mouse.up();
+  await page.waitForFunction(ids => window.sceneForPreview().elements.some(element => !element.isDeleted && !ids.includes(element.id)), [...previous]);
+  const added = live(await readScene(page)).filter(element => !previous.has(element.id));
+  assert.equal(added.length, 1);
+  assert.equal(added[0].type, type);
+  return { element: added[0], point };
+}
+
+async function writeText(page, text) {
+  const canvas = await page.locator('#canvas-panel').boundingBox();
+  await tool(page, 'Text').click();
+  await page.mouse.click(canvas.x + canvas.width * 0.56, canvas.y + canvas.height * 0.88);
+  await page.locator('textarea.excalidraw-wysiwyg').fill(text);
+  await page.keyboard.press('Escape');
+  await page.waitForFunction(text => window.sceneForPreview().elements.some(element => !element.isDeleted && element.text === text), text);
+  return live(await readScene(page)).find(element => element.text === text);
+}
+
+async function insertImage(page, dataURL) {
+  const ids = live(await readScene(page)).map(element => element.id);
+  const choosing = page.waitForEvent('filechooser');
+  await tool(page, 'Insert image').click();
+  await (await choosing).setFiles({ name: 'manual-reference.png', mimeType: 'image/png', buffer: Buffer.from(dataURL.split(',')[1], 'base64') });
+  await page.waitForFunction(ids => {
+    const scene = window.sceneForPreview();
+    return scene.elements.some(element => !element.isDeleted && element.type === 'image' && !ids.includes(element.id) && scene.files[element.fileId]);
+  }, ids);
+  const canvas = await page.locator('#canvas-panel').boundingBox();
+  await page.mouse.move(canvas.x + canvas.width * 0.49, canvas.y + canvas.height * 0.72);
+  await page.mouse.down();
+  await page.mouse.move(canvas.x + canvas.width * 0.49 + 50, canvas.y + canvas.height * 0.72 + 50, { steps: 5 });
+  await page.mouse.up();
+  await page.waitForFunction(ids => window.sceneForPreview().elements.some(element => !element.isDeleted && element.type === 'image' && !ids.includes(element.id) && element.width > 0 && element.height > 0), ids);
+  return live(await readScene(page)).find(element => element.type === 'image' && !ids.includes(element.id));
+}
+
+async function prepare(page, prompt) {
+  await page.getByRole('textbox', { name: 'Describe the edit', exact: true }).fill(prompt);
+  const captured = await downloadScene(page, page.getByRole('button', { name: 'Prepare agent edit', exact: true }));
+  assert.match(captured.name, /-agent-input\.excalidraw$/);
+  return captured.scene;
+}
+
+test('native drawing, text, and freehand survive review, browser recovery, and exact save/reopen', async t => {
+  const { page, original } = await openWorkspace(t);
+  assert.deepEqual(await readScene(page), original);
+  const rectangle = (await draw(page, 'rectangle')).element;
+  const freehand = (await draw(page, 'freedraw', { x: 0.79, y: 0.64 })).element;
+  assert.ok(freehand.points.length > 2);
+  const image = await insertImage(page, original.files.asset.dataURL);
+  const note = await writeText(page, 'Manual retry boundary');
+  const working = await readScene(page);
+  assert.equal(live(working).length, live(original).length + 4);
+  for (const element of original.elements) assert.deepEqual(working.elements.find(value => value.id === element.id), element, `untouched ${element.id} is preserved`);
+  assert.deepEqual(working.files.asset, original.files.asset);
+  const pixels = await page.evaluate(urls => Promise.all(urls.map(async url => {
+    const image = new Image(); image.src = url; await image.decode();
+    const canvas = document.createElement('canvas'); canvas.width = image.width; canvas.height = image.height;
+    const context = canvas.getContext('2d'); context.drawImage(image, 0, 0);
+    return { width: image.width, height: image.height, pixels: [...context.getImageData(0, 0, image.width, image.height).data] };
+  })), [working.files[image.fileId].dataURL, original.files.asset.dataURL]);
+  assert.deepEqual(pixels[0], pixels[1], 'native image import preserves the inserted pixels');
+  assert.deepEqual(working.customMetadata, original.customMetadata);
+  assert.deepEqual(working.appState.customSetting, original.appState.customSetting);
+
+  await version(page, 'Before');
+  assert.deepEqual(await readScene(page), original);
+  assert.equal(await page.locator('.working-layer').getByRole('button', { name: 'Undo', exact: true, includeHidden: true }).isVisible(), false, 'hidden native controls do not leak into snapshots');
+  assert.equal(await page.locator('.working-layer').isVisible(), false);
+  await version(page, 'Working');
+  assert.deepEqual(await readScene(page), working);
+  await page.getByRole('button', { name: 'Undo', exact: true }).click();
+  await page.waitForFunction(id => !window.sceneForPreview().elements.some(element => element.id === id && !element.isDeleted), note.id);
+  assert.ok(live(await readScene(page)).some(element => element.id === rectangle.id));
+  assert.ok(live(await readScene(page)).some(element => element.id === freehand.id));
+  await page.getByRole('button', { name: 'Redo', exact: true }).click();
+  await page.waitForFunction(id => window.sceneForPreview().elements.some(element => element.id === id && !element.isDeleted), note.id);
+
+  const saved = (await downloadScene(page, page.locator('#native'))).scene;
+  assert.deepEqual(saved, await readScene(page));
+  const pngDownload = page.waitForEvent('download');
+  await page.locator('#png').click();
+  const png = readFileSync(await (await pngDownload).path());
+  assert.equal(png.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');
+  assert.ok(png.readUInt32BE(16) > 600);
+  await page.getByText('Saved in this browser', { exact: true }).waitFor();
+  await page.reload();
+  await page.waitForFunction(() => window.previewReady);
+  assert.deepEqual(await readScene(page), saved, 'a completed local draft survives reload');
+  await version(page, 'Before');
+  assert.deepEqual(await readScene(page), original, 'draft recovery keeps the preserved comparison snapshot');
+  await version(page, 'Working');
+  await loadScene(page, 'Open file', saved);
+  assert.deepEqual(await readScene(page), saved, 'a native download reopens without dropping drawings, bindings, files, or metadata');
+});
+
+test('agent proposal merges over later manual work and acceptance is one native undo action', async t => {
+  const { page, original } = await openWorkspace(t);
+  const rectangle = (await draw(page, 'rectangle')).element;
+  await page.keyboard.press('Escape');
+  const base = await prepare(page, 'Give the API service and worker blue fills, keeping all annotations.');
+  assert.ok(base.elements.some(element => element.id === rectangle.id), 'the agent receives the live canvas');
+  const note = await writeText(page, 'Keep this later manual decision');
+  const beforeAcceptance = await readScene(page);
+  const proposal = structuredClone(base);
+  proposal.elements.find(element => element.id === 'service').backgroundColor = '#a5d8ff';
+  proposal.elements.find(element => element.id === 'worker').backgroundColor = '#d0ebff';
+  proposal.elements.push(
+    { ...structuredClone(original.elements.find(element => element.id === 'service')), id: 'agent-component', x: 850, y: 100, groupIds: [], boundElements: null },
+    { ...structuredClone(original.elements.find(element => element.id === 'image')), id: 'agent-image', x: 850, y: 300, fileId: 'agent-asset' },
+  );
+  proposal.files['agent-asset'] = { ...structuredClone(original.files.asset), id: 'agent-asset' };
+  await loadScene(page, 'Load proposal', proposal);
+  assert.equal(await page.getByRole('tab', { name: 'Agent proposal', exact: true }).getAttribute('aria-selected'), 'true');
+  assert.equal(live(await readScene(page)).some(element => element.id === note.id), false, 'the imported proposal remains an inspectable snapshot');
+  await version(page, 'Before');
+  assert.ok(live(await readScene(page)).some(element => element.id === rectangle.id));
+  assert.equal(live(await readScene(page)).some(element => element.id === note.id), false, 'Before is the captured agent base');
+  await version(page, 'Agent proposal');
+  assert.equal(await page.getByRole('button', { name: 'Accept proposal', exact: true }).isEnabled(), true, await page.locator('.proposal-bar').innerText());
+  await page.getByRole('button', { name: 'Accept proposal', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady && document.querySelector('#working-tab')?.getAttribute('aria-selected') === 'true');
+  const accepted = await readScene(page);
+  assert.equal(accepted.elements.find(element => element.id === 'service').backgroundColor, '#a5d8ff');
+  assert.equal(accepted.elements.find(element => element.id === 'worker').backgroundColor, '#d0ebff');
+  assert.ok(live(accepted).some(element => element.id === 'agent-component'));
+  assert.ok(live(accepted).some(element => element.id === 'agent-image'));
+  assert.deepEqual(accepted.elements.find(element => element.id === note.id), beforeAcceptance.elements.find(element => element.id === note.id));
+  assert.deepEqual(accepted.elements.find(element => element.id === 'request'), original.elements.find(element => element.id === 'request'));
+  assert.deepEqual(accepted.files.asset, original.files.asset);
+  assert.deepEqual(accepted.files['agent-asset'], proposal.files['agent-asset']);
+
+  await page.getByRole('button', { name: 'Undo', exact: true }).click();
+  await page.waitForFunction(() => window.sceneForPreview().elements.find(element => element.id === 'service').backgroundColor === 'transparent');
+  assert.equal((await readScene(page)).elements.find(element => element.id === 'worker').backgroundColor, 'transparent', 'one undo reverses every changed proposal element');
+  assert.equal(live(await readScene(page)).some(element => element.id === 'agent-component' || element.id === 'agent-image'), false, 'the same undo removes all proposal-created elements');
+  assert.ok(live(await readScene(page)).some(element => element.id === note.id), 'one undo reverses only proposal acceptance');
+  await page.getByRole('button', { name: 'Undo', exact: true }).click();
+  await page.waitForFunction(id => !window.sceneForPreview().elements.some(element => element.id === id && !element.isDeleted), note.id);
+  assert.ok(live(await readScene(page)).some(element => element.id === rectangle.id), 'native manual history survives snapshot visits and proposal acceptance');
+  await page.getByRole('button', { name: 'Redo', exact: true }).click();
+  await page.waitForFunction(id => window.sceneForPreview().elements.some(element => element.id === id && !element.isDeleted), note.id);
+  await page.getByRole('button', { name: 'Redo', exact: true }).click();
+  await page.waitForFunction(() => window.sceneForPreview().elements.find(element => element.id === 'service').backgroundColor === '#a5d8ff');
+  assert.equal((await readScene(page)).elements.find(element => element.id === 'worker').backgroundColor, '#d0ebff');
+  assert.ok(live(await readScene(page)).some(element => element.id === note.id));
+  assert.ok(live(await readScene(page)).some(element => element.id === 'agent-component'));
+  assert.ok(live(await readScene(page)).some(element => element.id === 'agent-image'));
+  assert.deepEqual((await readScene(page)).files['agent-asset'], proposal.files['agent-asset'], 'redo keeps the added image bytes available');
+});
+
+test('a conflicting agent proposal cannot overwrite a manual edit and can be discarded', async t => {
+  const { page } = await openWorkspace(t);
+  const { element, point } = await draw(page, 'rectangle');
+  const base = await prepare(page, 'Move the selected component to the right.');
+  assert.ok((await page.getByRole('textbox', { name: 'Agent instructions', exact: true }).inputValue()).includes(element.id), 'agent instructions retain the native selection IDs');
+  await tool(page, 'Selection').click();
+  await page.mouse.click(point.x + 3, point.y + 30);
+  await page.keyboard.press('ArrowRight');
+  await page.waitForFunction(({ id, x }) => window.sceneForPreview().elements.find(element => element.id === id)?.x !== x, { id: element.id, x: element.x });
+  const manual = await readScene(page);
+  const proposal = structuredClone(base);
+  proposal.elements.find(value => value.id === element.id).x += 100;
+  await loadScene(page, 'Load proposal', proposal);
+  assert.equal(await page.getByRole('button', { name: 'Accept proposal', exact: true }).isEnabled(), false);
+  assert.match(await page.locator('body').innerText(), /Both versions changed/);
+  await version(page, 'Working');
+  assert.deepEqual(await readScene(page), manual);
+  await version(page, 'Agent proposal');
+  await page.getByRole('button', { name: 'Discard proposal', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady && document.querySelector('#working-tab')?.getAttribute('aria-selected') === 'true');
+  assert.deepEqual(await readScene(page), manual);
+});
+
+test('opening another file can be cancelled or save the exact working diagram first', async t => {
+  const { page, original } = await openWorkspace(t);
+  await draw(page, 'rectangle');
+  const manual = await readScene(page);
+  const replacement = structuredClone(original);
+  replacement.elements.find(element => element.id === 'service').backgroundColor = '#ffd8a8';
+  await chooseScene(page, 'Open file', replacement);
+  const dialog = page.getByRole('dialog', { name: 'Keep your working diagram', exact: true });
+  await dialog.waitFor();
+  await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+  await dialog.waitFor({ state: 'detached' });
+  assert.deepEqual(await readScene(page), manual);
+
+  await chooseScene(page, 'Open file', replacement);
+  await dialog.waitFor();
+  const backup = await downloadScene(page, dialog.getByRole('button', { name: 'Save & open', exact: true }));
+  assert.deepEqual(backup.scene, manual);
+  await dialog.waitFor({ state: 'detached' });
+  await page.waitForFunction(() => window.previewReady && document.title.startsWith('working ·'));
+  assert.deepEqual(await readScene(page), replacement);
+  await version(page, 'Before');
+  assert.deepEqual(await readScene(page), replacement, 'replacement opens a new document with its own preserved snapshot');
+});
+
+test('unrenderable proposals fail before acceptance and leave Working recoverable', async t => {
+  const { page, original } = await openWorkspace(t);
+  const base = await prepare(page, 'Add another component beside the worker.');
+  for (const [id, fields] of [['zero-size', { type: 'rectangle', width: 0, height: 0 }], ['unsupported', { type: 'not-a-native-shape' }]]) {
+    const proposal = structuredClone(base);
+    proposal.elements.push({ ...structuredClone(original.elements.find(element => element.id === 'service')), id, x: 850, y: 100, groupIds: [], boundElements: null, ...fields });
+    await loadScene(page, 'Load proposal', proposal);
+    assert.equal(await page.getByRole('button', { name: 'Accept proposal', exact: true }).isEnabled(), false);
+    assert.match(await page.locator('.proposal-bar').innerText(), /cannot display|supported|native type/i);
+    await version(page, 'Working');
+    assert.deepEqual(await readScene(page), original);
+  }
+  await page.getByRole('button', { name: 'Discard proposal', exact: true }).click();
+  assert.deepEqual((await downloadScene(page, page.locator('#native'))).scene, original);
+});
+
+test('browser draft storage failure is visible while native saving remains available', async t => {
+  const { page } = await openWorkspace(t, () => {
+    const put = IDBObjectStore.prototype.put;
+    IDBObjectStore.prototype.put = function (...args) {
+      if (this.name === 'drafts') throw new DOMException('Controlled full browser storage', 'QuotaExceededError');
+      return put.apply(this, args);
+    };
+  });
+  await draw(page, 'rectangle');
+  await page.getByText('Draft could not be saved. Download your diagram to keep changes.', { exact: true }).waitFor();
+  assert.equal(await page.getByText('Saved in this browser', { exact: true }).count(), 0);
+  const working = await readScene(page);
+  assert.deepEqual((await downloadScene(page, page.locator('#native'))).scene, working);
+  assert.equal(await page.getByRole('tab', { name: 'Working', exact: true }).getAttribute('aria-selected'), 'true');
+});

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -60,7 +60,7 @@ test('failed initial loading remains visible and Open file recovers without a fa
   assert.deepEqual(await page.evaluate(() => window.sceneForPreview()), scene);
   assert.equal(await page.getByRole('alert').count(), 0);
   assert.equal(await page.getByRole('button', { name: 'Export PNG', exact: true }).isEnabled(), true);
-  assert.match(await page.locator('#status').innerText(), /Viewing a read-only copy/);
+  assert.match(await page.locator('#status').innerText(), /Draw and edit freely/);
 });
 
 test('edit summary buttons focus native elements across versions without changing exports', async t => {
@@ -125,7 +125,7 @@ test('edit summary buttons focus native elements across versions without changin
   await page.keyboard.press('Space');
   await waitForFocus('queue:primary');
   assert.equal(await added.evaluate(element => element === document.activeElement), true, 'keyboard activation retains focus after automatic version fallback');
-  assert.equal(await page.getByRole('tab', { name: 'After', exact: true }).getAttribute('aria-selected'), 'true');
+  assert.equal(await page.getByRole('tab', { name: 'Agent proposal', exact: true }).getAttribute('aria-selected'), 'true');
   assert.equal(await added.getAttribute('aria-pressed'), 'true');
   assert.equal(await renamed.getAttribute('aria-pressed'), 'false');
   await page.getByRole('tab', { name: 'Before', exact: true }).click();
@@ -133,7 +133,7 @@ test('edit summary buttons focus native elements across versions without changin
   assert.equal(await focus.count(), 0);
   assert.equal(await added.getAttribute('aria-pressed'), 'false');
 
-  await page.getByRole('tab', { name: 'After', exact: true }).click();
+  await page.getByRole('tab', { name: 'Agent proposal', exact: true }).click();
   await page.waitForFunction(() => window.previewReady);
   await removed.click();
   await waitForFocus('request');
@@ -173,7 +173,7 @@ test('edit summary buttons focus native elements across versions without changin
     buttons.find(button => button.getAttribute('aria-label') === 'Show Added Queue').click();
   });
   await waitForFocus('queue:primary');
-  assert.equal(await page.getByRole('tab', { name: 'After', exact: true }).getAttribute('aria-selected'), 'true');
+  assert.equal(await page.getByRole('tab', { name: 'Agent proposal', exact: true }).getAttribute('aria-selected'), 'true');
   assert.deepEqual({ before, after }, original);
   assert.deepEqual(errors, []);
 });

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -1,0 +1,265 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeProposal, captureWorkingScene, deriveChanges } from '../src/web/workspace.js';
+import { validateScene } from '../src/scene.js';
+
+const clone = structuredClone;
+const box = (id, extra = {}) => ({ id, type: 'rectangle', x: 0, y: 0, width: 100, height: 80, backgroundColor: '#fff', version: 1, versionNonce: 42, ...extra });
+const doc = (elements = [box('a'), box('b')], extra = {}) => ({ type: 'excalidraw', version: 2, elements, appState: { viewBackgroundColor: '#fff' }, files: {}, ...extra });
+const modify = (scene, id, extra) => Object.assign(scene.elements.find(element => element.id === id), extra);
+const bound = () => doc([
+  box('a', { boundElements: [{ id: 'label', type: 'text' }, { id: 'arrow', type: 'arrow' }] }),
+  { id: 'label', type: 'text', containerId: 'a', text: 'API', x: 10, y: 10, width: 70, height: 20 },
+  { id: 'arrow', type: 'arrow', x: 100, y: 40, points: [[0, 0], [100, 0]], startBinding: { elementId: 'a', focus: 0, gap: 1 }, endBinding: null },
+]);
+function conflict(base, current, proposed, field) {
+  const inputs = clone([base, current, proposed]);
+  const result = mergeProposal(base, current, proposed);
+  assert.equal(result.scene, null);
+  assert.ok(result.conflicts.some(item => item.field === field), JSON.stringify(result.conflicts));
+  assert.deepEqual([base, current, proposed], inputs, 'a rejected proposal never changes its inputs');
+}
+
+test('merges agent styling with manual geometry, drawings, assets, and unknown fields', () => {
+  const base = doc(undefined, { futureDocument: { owner: 'human' } });
+  modify(base, 'a', { futureElement: { tags: ['original'] } });
+  const current = clone(base), proposed = clone(base);
+  modify(current, 'a', { x: 140, width: 180, version: 3, versionNonce: 99, futureElement: { tags: ['annotated'] } });
+  current.elements.push({ id: 'pen', type: 'freedraw', points: [[0, 0], [8, 9]], pressure: [0.5, 0.7] }, { id: 'photo', type: 'image', fileId: 'upload' });
+  current.files.upload = { id: 'upload', dataURL: 'data:image/png;base64,AA==', futureAsset: 'keep' };
+  current.futureDocument = { owner: 'human', note: 'private' };
+  modify(proposed, 'a', { backgroundColor: '#ff0', version: 2, versionNonce: 88 });
+  proposed.elements.push(box('agent-node'));
+  const inputs = clone([base, current, proposed]);
+  const result = mergeProposal(base, current, proposed);
+  assert.deepEqual(result.conflicts, []);
+  validateScene(result.scene);
+  assert.deepEqual(result.scene.elements[0], { ...current.elements[0], backgroundColor: '#ff0' });
+  assert.deepEqual(result.scene.elements.map(element => element.id), ['a', 'b', 'pen', 'photo', 'agent-node']);
+  assert.deepEqual(result.scene.files, current.files);
+  assert.deepEqual(result.scene.futureDocument, current.futureDocument);
+  assert.deepEqual([base, current, proposed], inputs);
+});
+
+test('preserves manual metadata and merges only undoable canvas settings', () => {
+  const base = doc(undefined, { future: { enabled: true } });
+  const current = clone(base), proposed = clone(base);
+  current.appState.gridSize = 20;
+  current.future.note = 'manual';
+  proposed.appState.viewBackgroundColor = '#eeeeee';
+  const { scene, conflicts } = mergeProposal(base, current, proposed);
+  assert.deepEqual(conflicts, []);
+  assert.deepEqual(scene.appState, { gridSize: 20, viewBackgroundColor: '#eeeeee' });
+  assert.deepEqual(scene.future, current.future);
+  proposed.future = { enabled: false };
+  conflict(base, current, proposed, 'future');
+  proposed.future = clone(base.future);
+  proposed.appState.gridSize = 10;
+  conflict(base, current, proposed, 'appState.gridSize');
+  proposed.appState = clone(base.appState);
+  proposed.source = 'another exporter';
+  conflict(base, current, proposed, 'source');
+  delete proposed.source;
+  modify(proposed, 'a', { customMetadata: 'cannot be applied through this workspace' });
+  conflict(base, current, proposed, 'customMetadata');
+});
+
+test('rejects same-field styling and coupled geometry changes, ignoring only bookkeeping', () => {
+  const base = doc(), current = clone(base), proposed = clone(base);
+  modify(current, 'a', { backgroundColor: '#00f', version: 8 });
+  modify(proposed, 'a', { backgroundColor: '#f00', version: 2 });
+  conflict(base, current, proposed, 'backgroundColor');
+  modify(current, 'a', { backgroundColor: '#fff', x: 120 });
+  modify(proposed, 'a', { backgroundColor: '#fff', y: 220 });
+  conflict(base, current, proposed, 'element');
+  modify(proposed, 'a', { y: 0, x: 120 });
+  assert.deepEqual(mergeProposal(base, current, proposed).conflicts, []);
+  modify(current, 'a', { x: 0, seed: 7 });
+  modify(proposed, 'a', { x: 0, seed: 8 });
+  conflict(base, current, proposed, 'element');
+});
+
+test('deletion conflicts with edits but accepts unchanged and bookkeeping-only objects', () => {
+  const base = doc(), current = clone(base), proposed = clone(base);
+  modify(current, 'a', { version: 30, versionNonce: 200, updated: 123 });
+  modify(proposed, 'a', { isDeleted: true });
+  assert.equal(mergeProposal(base, current, proposed).scene.elements[0].isDeleted, true);
+  modify(current, 'a', { futureNote: 'do not delete' });
+  conflict(base, current, proposed, 'isDeleted');
+  const manualDelete = clone(base), proposalEdit = clone(base);
+  manualDelete.elements.splice(0, 1);
+  modify(proposalEdit, 'a', { backgroundColor: '#ff0' });
+  conflict(base, manualDelete, proposalEdit, 'isDeleted');
+  modify(proposalEdit, 'a', { backgroundColor: '#fff' });
+  modify(proposalEdit, 'b', { backgroundColor: '#ff0' });
+  const result = mergeProposal(base, manualDelete, proposalEdit);
+  assert.deepEqual(result.conflicts, []);
+  assert.equal(result.scene.elements.find(element => element.id === 'a').isDeleted, true);
+  assert.equal(result.scene.elements.find(element => element.id === 'b').backgroundColor, '#ff0');
+});
+
+test('rejects added ID collisions and never partially applies unrelated proposal changes', () => {
+  const base = doc(), current = clone(base), proposed = clone(base);
+  current.elements.push(box('collision', { text: 'manual' }));
+  proposed.elements.push(box('collision', { text: 'agent' }));
+  modify(proposed, 'a', { backgroundColor: '#ff0' });
+  conflict(base, current, proposed, 'id');
+});
+
+test('keeps manual stacking order and detects concurrent incompatible order changes', () => {
+  const base = doc([box('a'), box('b'), box('c')]);
+  const current = clone(base), proposed = clone(base);
+  current.elements.reverse();
+  modify(proposed, 'a', { backgroundColor: '#ff0' });
+  assert.deepEqual(mergeProposal(base, current, proposed).scene.elements.map(element => element.id), ['c', 'b', 'a']);
+  proposed.elements = [proposed.elements[1], proposed.elements[0], proposed.elements[2]];
+  conflict(base, current, proposed, 'elements');
+  const inserted = clone(base);
+  inserted.elements.splice(1, 0, box('new'));
+  conflict(base, current, inserted, 'elements');
+});
+
+test('merges ordered additions from either side without moving existing objects', () => {
+  const base = doc(), current = clone(base), proposed = clone(base);
+  current.elements.splice(1, 0, box('manual'));
+  proposed.elements.splice(1, 0, box('agent-1'), box('agent-2'));
+  const { scene, conflicts } = mergeProposal(base, current, proposed);
+  assert.deepEqual(conflicts, []);
+  assert.deepEqual(scene.elements.map(element => element.id), ['a', 'manual', 'agent-1', 'agent-2', 'b']);
+});
+
+test('validates reciprocal text and arrow bindings and related geometry together', () => {
+  const base = bound(), current = clone(base), proposed = clone(base);
+  modify(current, 'a', { x: 200 });
+  modify(proposed, 'label', { text: 'New API', width: 95 });
+  conflict(base, current, proposed, 'bindings');
+  const safe = clone(base);
+  modify(safe, 'a', { strokeColor: '#00f' });
+  assert.deepEqual(mergeProposal(base, current, safe).conflicts, []);
+  const dangling = clone(base);
+  modify(dangling, 'a', { boundElements: [] });
+  conflict(base, base, dangling, 'document');
+  const identical = clone(base);
+  modify(identical, 'a', { x: 100 });
+  modify(identical, 'label', { x: 110 });
+  assert.deepEqual(mergeProposal(base, identical, identical).conflicts, []);
+});
+
+test('preserves image assets and rejects missing assets or replacement under an existing ID', () => {
+  const base = doc([{ id: 'image', type: 'image', fileId: 'asset' }], { files: { asset: { id: 'asset', dataURL: 'data:image/png;base64,AA==', unknown: 'keep' } } });
+  const proposed = clone(base);
+  proposed.files.asset.dataURL = 'data:image/png;base64,BB==';
+  conflict(base, base, proposed, 'files.asset');
+  proposed.files.asset = clone(base.files.asset);
+  proposed.files.new = { id: 'new', dataURL: 'data:image/png;base64,BB==' };
+  proposed.elements.push({ id: 'new-image', type: 'image', fileId: 'new' });
+  const result = mergeProposal(base, base, proposed);
+  assert.deepEqual(result.conflicts, []);
+  assert.deepEqual(result.scene.files, proposed.files);
+  delete proposed.files.new;
+  conflict(base, base, proposed, 'document');
+});
+
+test('capture ignores first-load normalization and bookkeeping-only callbacks', () => {
+  const original = doc([box('a', { future: 'retained' })], { futureDocument: { value: 1 } });
+  const restored = clone(original);
+  delete restored.elements[0].future;
+  modify(restored, 'a', { strokeWidth: 1, version: 2, versionNonce: 99, index: 'a0' });
+  assert.equal(captureWorkingScene(original, restored.elements, restored.appState, restored.files), original);
+  const callback = clone(restored);
+  modify(callback, 'a', { version: 9, versionNonce: 120, updated: 100, index: 'a9' });
+  assert.equal(captureWorkingScene(original, callback.elements, callback.appState, callback.files, restored), original);
+  assert.equal(original.elements[0].future, 'retained');
+  original.files.asset = { id: 'asset', dataURL: 'data:image/png;base64,AA==', created: 1 };
+  restored.files = clone(original.files);
+  const loadedFiles = { asset: { ...restored.files.asset, lastRetrieved: 1234 } };
+  assert.equal(captureWorkingScene(original, restored.elements, restored.appState, loadedFiles, restored), original);
+});
+
+test('captures real native edits and images while retaining normalized-away unknown fields', () => {
+  const original = doc([box('a', { future: { value: 1 }, unknownEmpty: null })], { futureDocument: 'keep' });
+  const previous = clone(original);
+  delete previous.elements[0].future;
+  delete previous.elements[0].unknownEmpty;
+  previous.elements[0].strokeWidth = 1;
+  const native = clone(previous);
+  modify(native, 'a', { x: 200, version: 3, versionNonce: 70 });
+  native.elements.push({ id: 'image', type: 'image', fileId: 'uploaded' });
+  native.files.uploaded = { id: 'uploaded', dataURL: 'data:image/png;base64,AA==', mimeType: 'image/png' };
+  native.appState.viewBackgroundColor = '#fafafa';
+  const saved = captureWorkingScene(original, native.elements, native.appState, native.files, previous);
+  assert.deepEqual(saved.elements[0], { ...original.elements[0], x: 200, version: 3, versionNonce: 70 });
+  assert.deepEqual(saved.files, native.files);
+  assert.equal(saved.futureDocument, 'keep');
+  assert.equal(saved.appState.viewBackgroundColor, '#fafafa');
+  assert.deepEqual(original.elements[0].future, { value: 1 });
+  validateScene(saved);
+  const next = clone(native);
+  modify(next, 'a', { x: 0, version: 4, versionNonce: 90 });
+  const undone = captureWorkingScene(saved, next.elements, next.appState, next.files, native);
+  assert.equal(undone.elements[0].x, 0);
+  assert.deepEqual(undone.elements[0].future, { value: 1 });
+});
+
+test('capture retains deleted history, unused assets, and imported unrendered elements', () => {
+  const original = doc([box('a'), box('history', { isDeleted: true, future: 'keep' })], { files: { unused: { id: 'unused', dataURL: 'data:image/png;base64,AA==' } } });
+  const previous = { elements: [clone(original.elements[0])], appState: clone(original.appState), files: clone(original.files) };
+  const saved = captureWorkingScene(original, [], original.appState, {}, previous);
+  assert.deepEqual(saved.elements, [{ ...original.elements[0], isDeleted: true }, original.elements[1]]);
+  assert.deepEqual(saved.files, original.files);
+});
+
+test('deriveChanges supports native additions, deletions, and field removals without bookkeeping noise', () => {
+  const before = doc([box('a', { link: 'https://example.com' }), box('b')]);
+  const after = clone(before);
+  after.elements.reverse();
+  modify(after, 'a', { version: 7, versionNonce: 9 });
+  delete after.elements[1].link;
+  after.elements[0].isDeleted = true;
+  after.elements.push({ id: 'note', type: 'text', text: 'Manual note' });
+  const changes = deriveChanges(before, after);
+  assert.deepEqual(changes[0], { id: 'b', properties: { isDeleted: { before: null, after: true } } });
+  assert.deepEqual(changes[1], { id: 'a', properties: { link: { before: 'https://example.com' } } });
+  assert.equal(changes[2].id, 'note');
+  assert.equal(changes[2].created, true);
+});
+
+
+test('adding native elements does not stamp normalized indices onto untouched imported objects', () => {
+  const original = doc([box('a', { future: 'keep' })]);
+  const previous = clone(original);
+  previous.elements[0].index = 'a0';
+  const native = clone(previous);
+  native.elements.push(box('new', { index: 'a1' }));
+  const saved = captureWorkingScene(original, native.elements, native.appState, native.files, previous);
+  assert.deepEqual(saved.elements[0], original.elements[0]);
+  assert.equal(saved.elements[1].id, 'new');
+  const reverse = clone(native);
+  reverse.elements.reverse();
+  reverse.elements[0].index = 'a0';
+  reverse.elements[1].index = 'a1';
+  const reordered = captureWorkingScene(saved, reverse.elements, reverse.appState, reverse.files, native);
+  assert.deepEqual(reordered.elements.map(element => element.id), ['new', 'a']);
+  assert.equal(reordered.elements[1].index, 'a1');
+});
+
+
+test('rejects existing seeds, type mutations, and removals that native updates cannot undo', () => {
+  const base = doc([box('a', { seed: 7, customData: { note: 'retain' } })]);
+  for (const [field, value] of [['seed', 8], ['type', 'ellipse']]) {
+    const proposed = clone(base); proposed.elements[0][field] = value;
+    conflict(base, base, proposed, field);
+  }
+  const proposed = clone(base); delete proposed.elements[0].customData;
+  conflict(base, base, proposed, 'customData');
+  const added = clone(base); added.elements.push(box('new', { seed: 9 }));
+  assert.deepEqual(mergeProposal(base, base, added).conflicts, []);
+});
+
+
+test('native undefined fields and their absence in JSON describe the same proposal base', () => {
+  const base = doc([box('a', { customData: undefined })]);
+  const proposed = JSON.parse(JSON.stringify(base));
+  proposed.elements[0].backgroundColor = '#ff0';
+  assert.deepEqual(mergeProposal(base, base, proposed).conflicts, []);
+});


### PR DESCRIPTION
Native files now open in an editable Working canvas with Excalidraw's drawing tools, images, and undo/redo. Before and agent proposals stay read-only; the working editor stays mounted while users review them.

- Capture a live file and selected-element instructions for an existing agent, then import its returned proposal. Acceptance merges independent manual changes and records one native undo action; conflicts and unsupported changes leave Working untouched.
- Save/export the live document, recover a browser draft after reload, and offer a backup before replacing an edited file. Existing verified receipts retain their original review and export behavior.
- Keep clickable edit/object navigation, snapshot motion, keyboard access, and responsive layout. Match native controls to the workspace palette.

Validation: 218 tests passed, then all 27 affected tests after final view-isolation fixes. Browser tests cover manual drawing/text/image insertion, exact save/reopen, atomic proposal undo/redo, bindings/assets, conflicts, invalid proposals, draft failure, and replacement recovery. Computer use verified drawing, native download/reopen across Chrome and the in-app browser, a real CLI-generated proposal, preservation of later manual annotations, and one-step undo/redo. Native image insertion was automated through Excalidraw's file-input fallback; computer-use interception could not operate its OS picker.

The agent UI is an explicit file handoff. Direct model execution and subscription login inside the website remain future work. npm publication is separate.
