### PR TITLE
[Workspace]: expand sidebar objects and toggle overview

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -6,7 +6,9 @@ freehand annotations, images, and keyboard undo/redo. The input file on disk is
 never overwritten.
 
 - **Working** is your editable document. Click an object or edit in the sidebar to
-  find it on the canvas. Native undo history stays available when you visit snapshots.
+  find it on the canvas. Click it again to clear the selection and fit the entire
+  diagram; switching versions keeps that overview. Expand **more objects** to reach
+  the rest of the list. Native undo history stays available when you visit snapshots.
 - **Before** is a preserved snapshot. Preparing an agent edit captures a new Before
   from the working document at that moment.
 - **Agent proposal** is the returned diagram, displayed read-only. Accept merges its

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -52,7 +52,8 @@ svg { flex-shrink: 0; }
 .object-link:hover:not(:disabled), .object-link[aria-pressed="true"] { color: #805039; background: #eee8dd; }
 .object-dot { width: 5px; height: 5px; background: #c4bdae; border-radius: 50%; flex-shrink: 0; margin-left: 5px; margin-right: 6px; }
 .sidebar-note { font-size: 11px; line-height: 1.65; color: #81796b; margin: 0; }
-.more-objects { margin-top: 12px; padding-left: 26px; }
+.more-objects { display: block; width: 100%; min-height: 32px; margin-top: 10px; padding: 6px 6px 6px 26px; border: 0; border-radius: 5px; background: transparent; text-align: left; }
+.more-objects:hover { color: #805039; background: #eee8dd; }
 .change-count { background: #eee3d8; border: 1px solid #e6d5c4; color: #9b6548 !important; border-radius: 5px; min-width: 20px; text-align: center; padding: 2px 5px; }
 .change-hint { margin: -3px 0 14px; font-size: 10px; }
 .change-list { display: grid; gap: 4px; }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -207,6 +207,7 @@ function Review() {
   const [exporting, setExporting] = useState(false);
   const [notice, setNotice] = useState('');
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [objectsExpanded, setObjectsExpanded] = useState(false);
   const [focusedItem, setFocusedItem] = useState(null);
   const focusRef = useRef(null);
   focusRef.current = focusedItem;
@@ -262,13 +263,16 @@ function Review() {
       animate: animate && !matchMedia('(prefers-reduced-motion: reduce)').matches, duration: 280 });
   }
   function backToOverview() {
-    focusRef.current = null; setFocusedItem(null); setNotice('Showing the full diagram.'); fitDiagram(true);
+    focusRef.current = null; setFocusedItem(null);
+    workingApi?.updateScene({ appState: { selectedElementIds: {}, selectedGroupIds: {} }, captureUpdate: CaptureUpdateAction.NEVER });
+    setNotice('Showing the full diagram.'); fitDiagram(true);
   }
   function focusItem(item) {
+    if (focusRef.current?.elementId === item.elementId) { backToOverview(); return; }
     const versions = [[view, displayed], ['after', proposal?.scene || (isReceipt ? scene : null)], ['before', beforeScene], ['working', working]];
     const target = versions.find(([, value]) => value && focusElements(value.elements, item.elementId).length);
     if (!target) return;
-    setFocusedItem({ ...item });
+    focusRef.current = item; setFocusedItem({ ...item });
     selectView(target[0]);
     setNotice(`${item.text}. Highlighted in the ${viewLabel(target[0]).toLowerCase()} view.`);
     if (matchMedia('(max-width: 820px)').matches) {
@@ -282,7 +286,7 @@ function Review() {
     if (metadata.beforeScene) validate(metadata.beforeScene);
     if (metadata.proposalScene) validate(metadata.proposalScene);
     cancelTransition(); resetReadiness(); setWorkingApi(null); setFocusedItem(null); focusRef.current = null;
-    setScene(value); setContext(metadata); setAgentBase(null); setAgentInstructions(''); setAgentPrompt(''); setSelection([]);
+    setScene(value); setContext(metadata); setAgentBase(null); setAgentInstructions(''); setAgentPrompt(''); setSelection([]); setObjectsExpanded(false);
     const base = metadata.beforeScene || value;
     lastDownload.current = JSON.stringify(base);
     updateWorking(metadata.review ? null : structuredClone(base)); setBaseline(structuredClone(base));
@@ -520,7 +524,7 @@ function Review() {
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
         </section>
-        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul className="object-list">{objects.slice(0, 6).map(element => <li key={element.id}><button className="object-link" disabled={!scene || !!error} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <p className="sidebar-note more-objects">+{objects.length - 6} more objects</p>}</section>}
+        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul id="object-list" className="object-list">{(objectsExpanded ? objects : objects.slice(0, 6)).map(element => <li key={element.id}><button className="object-link" disabled={!scene || !!error} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <button className="sidebar-note more-objects" aria-expanded={objectsExpanded} aria-controls="object-list" onClick={() => setObjectsExpanded(expanded => !expanded)}>{objectsExpanded ? 'Show fewer objects' : `+${objects.length - 6} more ${objects.length === 7 ? 'object' : 'objects'}`}</button>}</section>}
         </>}
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>{isReceipt ? 'Review a copy. Keep your original.' : 'Native files. Your drawing stays yours.'}</span></div>
       </aside>

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -156,12 +156,10 @@ test('edit summary buttons focus native elements across versions without changin
     return frame.bottom < canvas.top || frame.top > canvas.bottom;
   });
   await added.click();
-  await page.waitForFunction(() => {
-    const frame = document.querySelector('.element-focus').getBoundingClientRect();
-    const canvas = document.querySelector('#canvas-panel').getBoundingClientRect();
-    return frame.left >= canvas.left && frame.top >= canvas.top && frame.right <= canvas.right && frame.bottom <= canvas.bottom;
-  });
-  assert.equal(await added.getAttribute('aria-pressed'), 'true');
+  assert.equal(await added.getAttribute('aria-pressed'), 'false', 'repeat activation returns to overview even after panning away');
+  await focus.waitFor({ state: 'detached' });
+  await added.click();
+  await waitForFocus('queue:primary');
   await page.keyboard.press('Escape');
   await focus.waitFor({ state: 'detached' });
   assert.equal(await added.getAttribute('aria-pressed'), 'false');
@@ -176,6 +174,102 @@ test('edit summary buttons focus native elements across versions without changin
   assert.equal(await page.getByRole('tab', { name: 'Agent proposal', exact: true }).getAttribute('aria-selected'), 'true');
   assert.deepEqual({ before, after }, original);
   assert.deepEqual(errors, []);
+});
+
+test('expanded objects toggle native detail and fitted overview across Working and snapshots', async t => {
+  const template = JSON.parse(readFileSync(fixture));
+  const before = { ...template, files: {}, elements: [] };
+  for (let index = 0; index < 14; index++) {
+    const id = `component-${index}`;
+    const x = (index % 7) * 480;
+    const y = Math.floor(index / 7) * 500;
+    before.elements.push(
+      { ...template.elements[0], id, x, y, groupIds: [], roughness: 0, backgroundColor: index === 0 ? '#d6336c' : index === 13 ? '#0b7285' : '#fff3bf', boundElements: [{ id: `${id}-label`, type: 'text' }] },
+      { ...template.elements[1], id: `${id}-label`, x: x + 50, y: y + 36, groupIds: [], containerId: id, text: `Component ${index + 1}`, originalText: `Component ${index + 1}` },
+    );
+  }
+  const after = structuredClone(before);
+  for (const element of after.elements.filter(element => element.id.startsWith('component-13'))) element.x += 2400;
+  const preview = await servePreview(after, { beforeScene: before, changes: deriveSceneChanges(before, after) });
+  t.after(() => preview.close());
+  const browser = await chromium.launch();
+  t.after(() => browser.close());
+  const page = await browser.newPage({ viewport: { width: 1200, height: 900 }, reducedMotion: 'reduce' });
+  await page.goto(preview.url);
+  await page.waitForFunction(() => window.previewReady);
+
+  // Read rendered pixels, not just zoom numbers: both distant corner objects
+  // must be present, uncut, and comfortably inside the visible native canvas.
+  const overviewVisible = async () => {
+    await page.waitForFunction(() => {
+      const canvas = [...document.querySelectorAll('.native-layer:not(.layer-hidden) canvas')].find(canvas => canvas.classList.contains('static'));
+      if (!canvas) return false;
+      const { data, width, height } = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
+      return [[214, 51, 108], [11, 114, 133]].every(color => {
+        let left = width, top = height, right = -1, bottom = -1;
+        for (let offset = 0; offset < data.length; offset += 4) {
+          if (color.every((channel, index) => data[offset + index] === channel) && data[offset + 3] === 255) {
+            const pixel = offset / 4;
+            const x = pixel % width;
+            const y = Math.floor(pixel / width);
+            left = Math.min(left, x); right = Math.max(right, x); top = Math.min(top, y); bottom = Math.max(bottom, y);
+          }
+        }
+        return right > left && bottom > top && left > 5 && top > 5 && right < width - 5 && bottom < height - 5;
+      });
+    });
+  };
+  const objectList = page.locator('.object-list');
+  assert.equal(await objectList.getByRole('button').count(), 6);
+  const expand = page.getByRole('button', { name: '+8 more objects', exact: true });
+  assert.equal(await expand.count(), 1, 'the remaining-object count is an accessible button');
+  assert.equal(await expand.getAttribute('aria-expanded'), 'false');
+  await expand.click();
+  assert.equal(await objectList.getByRole('button').count(), 14);
+  const collapse = page.getByRole('button', { name: 'Show fewer objects', exact: true });
+  assert.equal(await collapse.getAttribute('aria-expanded'), 'true');
+  assert.equal(await collapse.getAttribute('aria-controls'), await objectList.getAttribute('id'));
+  await collapse.click();
+  assert.equal(await objectList.getByRole('button').count(), 6);
+  await expand.click();
+  for (let index = 0; index < 14; index++) {
+    const object = objectList.getByRole('button', { name: `Show Component ${index + 1}`, exact: true });
+    await object.click();
+    await page.waitForFunction(id => document.querySelector('.element-focus')?.dataset.elementId === id, `component-${index}`);
+    assert.equal(await object.getAttribute('aria-pressed'), 'true');
+    await object.click();
+    await page.locator('.element-focus').waitFor({ state: 'detached' });
+    assert.equal(await object.getAttribute('aria-pressed'), 'false');
+  }
+  await overviewVisible();
+  for (const name of ['Before', 'Agent proposal', 'Before', 'Agent proposal', 'Working']) {
+    await page.getByRole('tab', { name, exact: true }).click();
+    await page.waitForFunction(() => window.previewReady);
+    await overviewVisible();
+  }
+  const lastObject = objectList.getByRole('button', { name: 'Show Component 14', exact: true });
+  await lastObject.click();
+  await page.locator('.selection-note').filter({ hasText: '1 selected element' }).waitFor();
+  assert.equal(await lastObject.getAttribute('aria-pressed'), 'true');
+  await lastObject.click();
+  await page.locator('.selection-note').filter({ hasText: 'Select an area on Working' }).waitFor();
+  assert.equal(await lastObject.getAttribute('aria-pressed'), 'false');
+  await overviewVisible();
+  for (const name of ['Before', 'Agent proposal', 'Working']) {
+    await page.getByRole('tab', { name, exact: true }).click();
+    await page.waitForFunction(() => window.previewReady);
+    await overviewVisible();
+  }
+  await lastObject.click();
+  await page.locator('.selection-note').filter({ hasText: '1 selected element' }).waitFor();
+  await page.getByRole('tab', { name: 'Before', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady);
+  await lastObject.click();
+  await page.getByRole('tab', { name: 'Working', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady);
+  await page.locator('.selection-note').filter({ hasText: 'Select an area on Working' }).waitFor();
+  await overviewVisible();
+  assert.deepEqual(await page.evaluate(() => window.sceneForPreview()), before, 'sidebar navigation preserves the working document');
 });
 
 test('review transitions wait for a fitted view, survive rapid keyboard changes, and retain exact exports', async t => {


### PR DESCRIPTION
The sidebar stopped at six objects, and repeated clicks kept the same object focused. Returning to overview also left the editable canvas's native selection active.

Make the remaining-object count an accessible expand/collapse button and give every object the existing navigation action. Repeated activation in either the object list or edit summary now clears focus and native selection, then fits the diagram. Version switches retain the overview and expanded list.

Validation: preview build and packed-preview check passed; all 12 native-preview and editable-workspace browser tests passed. The regression checks every expanded object, selection clearing, scene preservation, and rendered content at both ends of differently sized Before/After diagrams. Computer use verified expansion, repeated-click overview, and version switching on the real 61-element multimodal architecture.
