### PR TITLE
[Workspace]: remove disconnected agent UI and status noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ Independent manual edits survive acceptance; conflicts leave your work unchanged
 Save the live diagram as `.excalidraw`, export PNG, and reopen it here. A local browser
 draft recovers changes after reload. [Workspace guide](docs/workspace.md).
 
-The agent handoff uses a captured file and instructions with your existing agent; an
-in-page model connection is not shipped. Matching CLI retries reuse a verified result,
-and the original input is never overwritten. Snapshot transitions respect reduced motion.
+Run editing requests in your existing coding agent, then open its receipt here for
+review. An in-page agent conversation is not shipped. Matching CLI retries reuse a
+verified result, and the original input is never overwritten. Snapshot transitions
+respect reduced motion.
 
 ![Real browser recording: review Before and After, export PNG, download the native copy, and reopen it](examples/workflows/review-export-reopen.gif)
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -15,8 +15,7 @@ so drawing and undo history survive both modes. Historical snapshots remain read
   find it on the canvas. Click it again to clear the selection and fit the entire
   diagram; switching versions keeps that overview. Expand **more objects** to reach
   the rest of the list. Native undo history stays available when you visit snapshots.
-- **Before** is a preserved snapshot. Preparing an agent edit captures a new Before
-  from the working document at that moment.
+- **Before** is the preserved input file or the original input from an edit receipt.
 - **Agent proposal** is the returned diagram, displayed read-only. Accept merges its
   changes into your latest work. Discard leaves your working diagram unchanged.
 
@@ -27,23 +26,21 @@ remain immutable reviews with their original labels and retained exports. Choose
 
 ## Work with your existing agent
 
-1. Draw or open a diagram. Select the elements you want your agent to work on.
-2. Describe the edit in the sidebar and choose **Prepare agent edit**. This downloads
-   the complete current diagram and captures the exact proposal base.
-3. Attach that file and the displayed instructions to Claude Code, Codex, or your
-   preferred agent. You can continue drawing in Working while it runs.
-4. Choose **Load proposal** and open the returned `.excalidraw` file.
-5. Review Before, the proposal, and your current Working diagram. **Accept proposal**
-   preserves independent manual edits; one native Undo reverses the acceptance.
+1. Draw or open a diagram, then choose **Save diagram** to download the current file.
+2. Give that file and your editing request to Claude Code or Codex with the toolkit
+   installed. Ask it to preserve unrelated content and return an edit receipt.
+3. Open the returned receipt with `excalidraw-toolkit preview /path/to/receipt.json`.
+4. Review Before and Agent proposal. You can draw in Working during review;
+   **Accept proposal** preserves independent manual edits, and one native Undo
+   reverses the acceptance. **Discard proposal** keeps your working diagram.
 
-The sidebar prepares a file handoff. It does not run a model or connect a ChatGPT or
-Claude subscription inside the website. An in-page agent conversation remains a
-future integration.
+Agent requests run in your coding agent. The website provides drawing and review;
+an in-page agent conversation is not shipped.
 
 Acceptance stops when changes conflict: for example, both versions move the same
 object, delete versus edit an object, modify related bindings, reuse an image ID
 with different bytes, or reorder the same objects differently. Nothing is partially
-applied. Discard the proposal, keep Working, and prepare a new input for the agent.
+applied. Discard the proposal, keep Working, and save a new input for the agent.
 Proposal changes that native undo cannot reliably represent (such as arbitrary
 file-level metadata) also require a new proposal. Unknown existing fields and
 unrelated manual drawings are retained.
@@ -56,9 +53,8 @@ it also remains usable in Excalidraw. Saving or exporting a snapshot uses that
 snapshot, not the live working document. PNG export reads the current view and
 never includes the workspace UI or focus outline.
 
-A local browser draft is written after changes. **Saved in this browser** appears
-only after the storage transaction completes. Reloading the same preview URL
-restores the working document and any pending proposal. Native undo history is
+A local browser draft is written quietly after changes. Reloading the same preview
+URL restores the working document and any pending proposal. Native undo history is
 session-only and starts fresh after a reload. Storage failures are visible; use
 Save diagram to retain a portable copy. Drafts are specific to this browser and
 preview URL, so download before closing or restarting the local preview server.

--- a/src/web/WorkingCanvas.jsx
+++ b/src/web/WorkingCanvas.jsx
@@ -4,7 +4,7 @@ import { captureWorkingScene } from './workspace.js';
 
 // This instance lives for the document, not the selected review tab. Excalidraw
 // owns the drawing tools, selection, and undo history throughout the session.
-export function WorkingCanvas({ scene, onScene, onApi, onSelection }) {
+export function WorkingCanvas({ scene, onScene, onApi }) {
   const native = useRef(null);
   const current = useRef(scene);
   current.current = scene;
@@ -17,6 +17,5 @@ export function WorkingCanvas({ scene, onScene, onApi, onSelection }) {
       const next = captureWorkingScene(current.current, elements, snapshot.appState, files, native.current);
       native.current = structuredClone(snapshot);
       if (next !== current.current) { current.current = next; onScene(next); }
-      onSelection(Object.keys(appState.selectedElementIds || {}).filter(id => appState.selectedElementIds[id]));
     }} />;
 }

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -84,8 +84,6 @@ svg { flex-shrink: 0; }
 .workspace-heading .eyebrow { color: #a67f65; margin-bottom: 10px; }
 .workspace-heading h1 { font-family: Georgia, "Times New Roman", serif; font-size: clamp(26px, 2.45vw, 37px); letter-spacing: -.8px; font-weight: 400; line-height: 1.2; margin: 0; overflow-wrap: anywhere; }
 .workspace-description { margin: 12px 0 0; color: #81796d; font-size: 12px; line-height: 1.6; }
-.review-badge { flex-shrink: 0; display: flex; align-items: center; gap: 7px; border: 1px solid #e5e0d4; border-radius: 20px; padding: 7px 10px; font-size: 10px; color: #807565; }
-.review-badge > span { width: 5px; height: 5px; background: #b59a75; border-radius: 50%; }
 .canvas-card { min-height: 200px; flex: 1; display: flex; flex-direction: column; background: #fff; border: 1px solid #e1ded4; border-radius: 11px; overflow: hidden; box-shadow: 0 3px 7px #33270e03, 0 16px 40px #33270e03; }
 .canvas-toolbar { min-height: 52px; flex-shrink: 0; padding: 10px 17px; display: flex; align-items: center; gap: 20px; border-bottom: 1px solid #eeece5; background: #fffefa; }
 .canvas-caption { display: flex; align-items: center; gap: 8px; color: #82796c; font-size: 11px; }
@@ -114,16 +112,14 @@ svg { flex-shrink: 0; }
 #status { display: inline-flex; align-items: center; gap: 7px; }
 .status-dot { width: 5px; height: 5px; border-radius: 50%; background: #c4b7a2; }
 .status-dot.is-ready { background: #95a181; }
-.workspace-footer { display: flex; flex-shrink: 0; justify-content: space-between; gap: 20px; padding-top: 17px; font-size: 10px; line-height: 1.5; color: #8c8272; }
-.workspace-footer > span:first-child { font-family: Georgia, serif; font-style: italic; font-size: 12px; }
 .feedback { padding: 12px 14px; display: flex; align-items: center; gap: 10px; font-size: 12px; line-height: 1.5; border: 1px solid #dfbba6; background: #fbefe7; color: #8b503b; border-radius: 7px; margin-bottom: 16px; }
 .feedback > span { overflow-wrap: anywhere; }
 .feedback button { border: 0; background: transparent; color: inherit; margin-left: auto; font-size: 22px; }
 @keyframes breathe { 50% { opacity: .4; transform: translateY(-2px); } }
 @media (min-width: 1600px) { .diagram-workspace { padding-left: 64px; padding-right: 64px; } }
-@media (max-width: 1100px) { .review-header { padding: 16px 22px; gap: 18px; } .header-label, .header-divider { display: none; } .diagram-workspace { padding: 30px 26px 20px; } .review-body { grid-template-columns: 236px minmax(0, 1fr); } .review-sidebar { padding-left: 18px; padding-right: 18px; } .workspace-heading { align-items: flex-start; } .review-badge { display: none; } }
+@media (max-width: 1100px) { .review-header { padding: 16px 22px; gap: 18px; } .header-label, .header-divider { display: none; } .diagram-workspace { padding: 30px 26px 20px; } .review-body { grid-template-columns: 236px minmax(0, 1fr); } .review-sidebar { padding-left: 18px; padding-right: 18px; } .workspace-heading { align-items: flex-start; } }
 @media (max-width: 820px) { .review-app { height: auto; min-height: 100dvh; } .review-body { display: flex; flex-direction: column; } .diagram-workspace { min-height: 540px; flex: 1; } .sidebar-toggle { display: flex; align-items: center; gap: 8px; min-height: 43px; border: 0; border-bottom: 1px solid var(--line); padding: 10px 24px; text-align: left; color: #7c7261; background: transparent; font-size: 11px; } .sidebar-toggle > span:last-child { margin-left: auto; font-size: 17px; } .review-sidebar { display: none; } .review-sidebar[data-open="true"] { display: flex; flex: none; max-height: 50dvh; padding: 20px 26px; border-right: 0; border-bottom: 1px solid var(--line); } .review-sidebar .sidebar-footer { padding-top: 0; } .review-header { flex-wrap: wrap; gap: 14px; } .brand { font-size: 16px; } .header-actions { gap: 7px; } .button { padding: 8px 10px; } .action-divider { display: none; } .workspace-heading h1 { font-size: 31px; } .canvas-panel { min-height: 260px; } }
-@media (max-width: 560px) { .review-header { padding: 15px 18px; } .header-actions { width: 100%; margin-left: 0; justify-content: space-between; } .button { min-height: 40px; padding: 8px; font-size: 11px; } .button-quiet { padding-left: 0; } .diagram-workspace { padding: 26px 16px 18px; } .workspace-heading { margin-bottom: 22px; } .workspace-heading h1 { font-size: 29px; } .workspace-description { max-width: 275px; } .canvas-toolbar { gap: 10px; padding: 10px 12px; flex-wrap: wrap; } .canvas-caption { margin-right: auto; } .fit-button span { display: none; } .fit-button { margin-left: 0; } .view-tabs button { padding: 6px 11px; } .canvas-hint { display: none; } .canvas-footer { padding: 10px 12px; } .workspace-footer { gap: 14px; } .workspace-footer > span:last-child { max-width: 175px; text-align: right; } }
+@media (max-width: 560px) { .review-header { padding: 15px 18px; } .header-actions { width: 100%; margin-left: 0; justify-content: space-between; } .button { min-height: 40px; padding: 8px; font-size: 11px; } .button-quiet { padding-left: 0; } .diagram-workspace { padding: 26px 16px 18px; } .workspace-heading { margin-bottom: 22px; } .workspace-heading h1 { font-size: 29px; } .workspace-description { max-width: 275px; } .canvas-toolbar { gap: 10px; padding: 10px 12px; flex-wrap: wrap; } .canvas-caption { margin-right: auto; } .fit-button span { display: none; } .fit-button { margin-left: 0; } .view-tabs button { padding: 6px 11px; } .canvas-hint { display: none; } .canvas-footer { padding: 10px 12px; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; transition: none !important; } }
 
 /* The working editor remains mounted and keeps native history while snapshots
@@ -131,16 +127,6 @@ svg { flex-shrink: 0; }
 .native-layer { position: absolute; inset: 0; }
 .layer-hidden, .layer-hidden * { visibility: hidden !important; pointer-events: none !important; }
 .working-layer .excalidraw { --color-surface-primary-container: #efe1d5; --color-on-primary-container: #805039; --color-surface-low: #f5f2eb; --color-surface-mid: #eeebe4; --color-surface-high: #e5dfd3; }
-.agent-section > .sidebar-note { margin-bottom: 14px; }
-.agent-label { display: block; font-size: 11px; color: #686459; margin-bottom: 8px; }
-.agent-section textarea { width: 100%; min-height: 96px; resize: vertical; border: 1px solid #dcd7cb; border-radius: 8px; padding: 11px; background: #fffefa; color: var(--ink); font-size: 12px; line-height: 1.6; }
-.agent-section textarea:focus-visible { outline: 2px solid #a25a3c; outline-offset: 2px; }
-.agent-section .selection-note { font-size: 10px; line-height: 1.6; color: #8d7c68; margin: 9px 0 13px; }
-.agent-section .button { white-space: normal; }
-.agent-instructions { margin-bottom: 14px; font-size: 11px; }
-.agent-instructions summary { cursor: pointer; margin-bottom: 10px; }
-.agent-instructions textarea { margin-top: 9px; min-height: 150px; font-size: 10px; }
-.proposal-note { margin-top: 14px; }
 .proposal-bar { display: flex; align-items: center; flex-shrink: 0; gap: 12px; margin-top: 15px; border: 1px solid #e2d7c8; border-radius: 9px; background: #f4eee4; padding: 14px 17px; }
 .proposal-bar > div { flex: 1; min-width: 0; }
 .proposal-bar strong { font-weight: 550; font-size: 12px; color: #594936; }
@@ -167,7 +153,7 @@ svg { flex-shrink: 0; }
 
 .review-app.is-fullscreen { height: 100dvh; min-height: 0; }
 .review-app.is-fullscreen .review-header, .review-app.is-fullscreen .sidebar-toggle, .review-app.is-fullscreen .review-sidebar,
-.review-app.is-fullscreen .workspace-heading, .review-app.is-fullscreen .proposal-bar, .review-app.is-fullscreen .workspace-footer { display: none; }
+.review-app.is-fullscreen .workspace-heading, .review-app.is-fullscreen .proposal-bar { display: none; }
 .review-app.is-fullscreen .review-body { display: flex; }
 .review-app.is-fullscreen .diagram-workspace { flex: 1; min-height: 0; padding: 0; }
 .review-app.is-fullscreen .canvas-card { min-height: 0; border: 0; border-radius: 0; box-shadow: none; }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -191,23 +191,18 @@ function Review() {
   const workingRef = useRef(null);
   const [baseline, setBaseline] = useState(null);
   const [proposal, setProposal] = useState(null);
-  const [agentBase, setAgentBase] = useState(null);
-  const [agentPrompt, setAgentPrompt] = useState('');
-  const [agentInstructions, setAgentInstructions] = useState('');
-  const [selection, setSelection] = useState([]);
   const [documentId, setDocumentId] = useState(0);
-  const [saveStatus, setSaveStatus] = useState('');
+  const [draftSaved, setDraftSaved] = useState(false);
+  const [saveError, setSaveError] = useState('');
   const [loaded, setLoaded] = useState(false);
   const storage = useRef(null);
   const draftSequence = useRef(0);
-  const proposalInput = useRef(null);
   const lastDownload = useRef(null);
   const [pendingFile, setPendingFile] = useState(null);
   const api = view === 'working' ? workingApi : reviewApi;
   const [ready, setReady] = useState(false);
   const [error, setError] = useState('');
   const [exporting, setExporting] = useState(false);
-  const [notice, setNotice] = useState('');
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
   const [objectsExpanded, setObjectsExpanded] = useState(false);
@@ -220,7 +215,7 @@ function Review() {
   const snapshot = useRef(null);
   const pendingView = useRef(null);
   const isReceipt = Boolean(context.review);
-  const beforeScene = isReceipt ? context.beforeScene : proposal?.base || agentBase || baseline;
+  const beforeScene = isReceipt ? context.beforeScene : proposal?.base || baseline;
   const displayed = view === 'working' ? working : view === 'before' ? beforeScene : view === 'proposal' ? context.proposalScene : proposal?.scene || scene;
   const viewKeys = isReceipt ? Object.keys(context.review.viewLabels || { before: 'Before', after: 'After' }) : ['working', 'before', ...(proposal ? ['after'] : [])];
   const viewLabel = key => isReceipt ? context.review.viewLabels?.[key] || (key === 'before' ? 'Before' : 'After') : ({ working: 'Working', before: 'Before', after: 'Agent proposal' })[key];
@@ -244,7 +239,6 @@ function Review() {
   }
   const reconciliation = useMemo(() => proposal && working ? reconcile(proposal.base, working, proposal.scene) : null, [proposal, working]);
   function updateWorking(value) { workingRef.current = value; setWorking(value); }
-  function updateSelection(ids) { setSelection(current => current.join('\0') === ids.join('\0') ? current : ids); }
   const objects = elements.filter(e => e.type !== 'text' && !['arrow', 'line'].includes(e.type));
   const categories = [['shape', 'Shapes', ['rectangle', 'ellipse', 'diamond']], ['arrow', 'Connections', ['arrow', 'line']], ['text', 'Labels', ['text']], ['frame', 'Frames', ['frame', 'magicframe']], ['image', 'Images', ['image']], ['pen', 'Freehand', ['freedraw']]].map(([icon, label, types]) => ({ icon, label, count: elements.filter(e => types.includes(e.type)).length })).filter(item => item.count);
   const otherCount = elements.length - categories.reduce((count, item) => count + item.count, 0);
@@ -268,7 +262,7 @@ function Review() {
   function backToOverview() {
     focusRef.current = null; setFocusedItem(null);
     workingApi?.updateScene({ appState: { selectedElementIds: {}, selectedGroupIds: {} }, captureUpdate: CaptureUpdateAction.NEVER });
-    setNotice('Showing the full diagram.'); fitDiagram(true);
+    fitDiagram(true);
   }
   function focusItem(item) {
     if (focusRef.current?.elementId === item.elementId) { backToOverview(); return; }
@@ -277,7 +271,6 @@ function Review() {
     if (!target) return;
     focusRef.current = item; setFocusedItem({ ...item });
     selectView(target[0]);
-    setNotice(`${item.text}. Highlighted in the ${viewLabel(target[0]).toLowerCase()} view.`);
     if (matchMedia('(max-width: 820px)').matches) {
       setDetailsOpen(false);
       document.getElementById('diagram-workspace').focus({ preventScroll: true });
@@ -289,13 +282,13 @@ function Review() {
     if (metadata.beforeScene) validate(metadata.beforeScene);
     if (metadata.proposalScene) validate(metadata.proposalScene);
     cancelTransition(); resetReadiness(); setWorkingApi(null); setFocusedItem(null); focusRef.current = null;
-    setScene(value); setContext(metadata); setAgentBase(null); setAgentInstructions(''); setAgentPrompt(''); setSelection([]); setObjectsExpanded(false);
+    setScene(value); setContext(metadata); setObjectsExpanded(false);
     const base = metadata.beforeScene || value;
     lastDownload.current = JSON.stringify(base);
     updateWorking(metadata.review ? null : structuredClone(base)); setBaseline(structuredClone(base));
     setProposal(metadata.beforeScene && !metadata.review ? { base: structuredClone(base), scene: structuredClone(value) } : null);
     setView(metadata.beforeScene || metadata.review ? 'after' : 'working');
-    setDocumentId(id => id + 1); setRevision(id => id + 1); setError(''); setNotice('');
+    setDocumentId(id => id + 1); setRevision(id => id + 1); setError('');
   }
   useEffect(() => {
     let cancelled = false;
@@ -307,18 +300,17 @@ function Review() {
       }));
       let draft;
       try { storage.current = await draftStore(); draft = await storage.current.read(); }
-      catch { setSaveStatus('Browser storage unavailable. Download your diagram to keep changes.'); }
+      catch { setSaveError('Browser storage unavailable. Download your diagram to keep changes.'); }
       if (cancelled) return;
       initialize(value, metadata);
       if (draft) {
         try {
           validate(draft.working); validate(draft.baseline);
           if (draft.proposal) { validate(draft.proposal.base); validate(draft.proposal.scene); }
-          if (draft.agentBase) validate(draft.agentBase);
-          updateWorking(draft.working); setBaseline(draft.baseline); setProposal(draft.proposal); setAgentBase(draft.agentBase);
-          setContext(draft.context); setAgentPrompt(draft.agentPrompt || ''); setAgentInstructions(draft.agentInstructions || '');
-          setView('working'); setNotice('Restored your working diagram from this browser.');
-        } catch { setSaveStatus('The saved draft could not be read. Your original diagram is open.'); }
+          updateWorking(draft.working); setBaseline(draft.baseline); setProposal(draft.proposal);
+          setContext(draft.context);
+          setView('working');
+        } catch { setSaveError('The saved draft could not be read. Your original diagram is open.'); }
       }
       setLoaded(true);
     })().catch(error => reportError(error.message));
@@ -327,26 +319,26 @@ function Review() {
   useEffect(() => {
     if (!loaded || !working || !storage.current) return;
     const sequence = ++draftSequence.current;
-    setSaveStatus('Saving in this browser…');
+    setDraftSaved(false);
     const timeout = setTimeout(() => {
-      storage.current.write({ working, baseline, proposal, agentBase, agentPrompt, agentInstructions, context }).then(() => {
-        if (draftSequence.current === sequence) setSaveStatus('Saved in this browser');
+      storage.current.write({ working, baseline, proposal, context }).then(() => {
+        if (draftSequence.current === sequence) { setDraftSaved(true); setSaveError(''); }
       }).catch(() => {
-        if (draftSequence.current === sequence) setSaveStatus('Draft could not be saved. Download your diagram to keep changes.');
+        if (draftSequence.current === sequence) setSaveError('Draft could not be saved. Download your diagram to keep changes.');
       });
     }, 250);
     return () => clearTimeout(timeout);
-  }, [loaded, working, baseline, proposal, agentBase, agentPrompt, agentInstructions, context]);
+  }, [loaded, working, baseline, proposal, context]);
   useEffect(() => {
-    const warn = event => { if (working && saveStatus !== 'Saved in this browser') { event.preventDefault(); event.returnValue = ''; } };
+    const warn = event => { if (working && !draftSaved) { event.preventDefault(); event.returnValue = ''; } };
     window.addEventListener('beforeunload', warn);
     return () => window.removeEventListener('beforeunload', warn);
-  }, [working, saveStatus]);
+  }, [working, draftSaved]);
   useEffect(() => { document.title = `${title} · Excalidraw Toolkit`; }, [title]);
   useEffect(() => {
     if (!api || !ready || !focusedItem) return;
     if (!focusElements(api.getSceneElements(), focusedItem.elementId).length) {
-      setFocusedItem(null); setNotice('This element is not present in this view.'); return;
+      setFocusedItem(null); return;
     }
     if (view === 'working') api.updateScene({ appState: { selectedElementIds: { [focusedItem.elementId]: true } }, captureUpdate: CaptureUpdateAction.NEVER });
     fitDiagram(true);
@@ -387,7 +379,7 @@ function Review() {
       const metadata = { title: file.name.replace(/\.(excalidraw|json)$/i, '') };
       if (workingRef.current && JSON.stringify(workingRef.current) !== lastDownload.current && JSON.stringify(value) !== JSON.stringify(workingRef.current)) {
         setPendingFile({ value, metadata });
-      } else { initialize(value, metadata); setLoaded(true); setNotice('Opened as a working diagram.'); }
+      } else { initialize(value, metadata); setLoaded(true); }
     } catch (error) { setError(error instanceof SyntaxError ? 'This file contains invalid JSON. Choose a valid .excalidraw file.' : error.message); }
     event.target.value = '';
   }
@@ -415,7 +407,7 @@ function Review() {
     cancelTransition();
     snapshot.current.hidden = !dissolve;
     pendingView.current = { view: next };
-    resetReadiness(); setError(''); setNotice('');
+    resetReadiness(); setError('');
     setView(next); setRevision(value => value + 1);
   }
   async function exportPng() {
@@ -429,7 +421,6 @@ function Review() {
         setTimeout(() => URL.revokeObjectURL(url), 1000);
       } else url = await png();
       download(url, `${filename}${view !== 'working' ? `-${view}` : ''}.png`);
-      setNotice('PNG download started.');
     }
     catch (error) { setError(`PNG export failed: ${error.message}`); }
     finally { setExporting(false); }
@@ -438,34 +429,16 @@ function Review() {
     if (view === 'working') lastDownload.current = JSON.stringify(displayed);
     const url = URL.createObjectURL(new Blob([JSON.stringify(displayed, null, 2)], { type: 'application/json' }));
     download(url, `${filename}${view !== 'working' ? `-${view}` : ''}.excalidraw`);
-    setTimeout(() => URL.revokeObjectURL(url), 1000); setNotice(view === 'working' ? 'Working diagram download started.' : 'Snapshot download started.');
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 
   function downloadScene(value, name) {
     const url = URL.createObjectURL(new Blob([JSON.stringify(value, null, 2)], { type: 'application/json' }));
     download(url, name); setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-  function prepareAgentEdit() {
-    const base = structuredClone(workingRef.current);
-    setAgentBase(base); setProposal(null); setError('');
-    const inputName = `${filename}-agent-input.excalidraw`;
-    const scope = selection.length ? `Limit changes to selected element IDs and required bound labels/connectors: ${selection.join(', ')}.` : 'No elements were selected. Preserve unrelated content and existing native IDs.';
-    setAgentInstructions(`Edit the attached ${inputName} with Excalidraw Toolkit.\n\n${agentPrompt.trim()}\n\n${scope}\nReturn the full edited .excalidraw file as a proposal. Keep the input unchanged. I will review and accept the proposal in the workspace.`);
-    downloadScene(base, inputName);
-    setNotice('Agent input downloaded. Use it with the instructions below, then load the returned diagram. You can keep drawing.');
-  }
-  async function loadProposal(event) {
-    const file = event.target.files?.[0]; if (!file) return;
-    try {
-      const value = validate(JSON.parse(await file.text()));
-      if (!agentBase) throw new Error('Prepare an agent edit first so the proposal has an exact starting point.');
-      setProposal({ base: structuredClone(agentBase), scene: value }); setError(''); selectView('after');
-    } catch (error) { setError(`Proposal could not be loaded: ${error.message}`); }
-    event.target.value = '';
-  }
   function acceptProposal() {
     const result = reconcile(proposal.base, workingRef.current, proposal.scene);
-    if (result.conflicts.length) { setError('This proposal conflicts with your drawing. Keep your work and prepare a new edit from Working.'); return; }
+    if (result.conflicts.length) { setError('This proposal conflicts with your drawing. Save Working and request a new proposal from your agent.'); return; }
     const previous = workingApi.getSceneElementsIncludingDeleted();
     const index = new Map(previous.map(element => [element.id, element]));
     const changed = new Map(deriveChanges(workingRef.current, result.scene).map(change => [change.id, Object.keys(change.properties)]));
@@ -482,12 +455,10 @@ function Review() {
     workingApi.addFiles(Object.values(result.scene.files || {}));
     updateWorking(result.scene);
     workingApi.updateScene({ elements: next, appState: { viewBackgroundColor: result.scene.appState?.viewBackgroundColor }, captureUpdate: CaptureUpdateAction.IMMEDIATELY });
-    setProposal(null); setAgentBase(null); setAgentInstructions(''); setError(''); selectView('working');
-    setNotice('Proposal accepted. Undo once to return to your previous working diagram.');
+    setProposal(null); setError(''); selectView('working');
   }
   function discardProposal() {
-    setProposal(null); setAgentBase(null); setAgentInstructions(''); setError(''); selectView('working');
-    setNotice('Proposal discarded. Your working diagram is unchanged.');
+    setProposal(null); setError(''); selectView('working');
   }
   function exitFullscreenOnEscape(event) {
     if (!fullscreen || event.key !== 'Escape' || event.target.closest('input, textarea, [contenteditable="true"], [role="dialog"], [role="menu"], [role="listbox"]')) return;
@@ -520,19 +491,6 @@ function Review() {
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
         <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : proposal ? 'Proposal ready to review' : 'Editable working diagram'}</p></div></div>
         {isReceipt ? <ReceiptDetails review={context.review} view={view} /> : <>
-        <section className="sidebar-section agent-section" aria-labelledby="agent-title">
-          <div className="section-heading"><h2 id="agent-title">Work with an agent</h2><Icon name="pen" size={15} /></div>
-          <p className="sidebar-note">Use your own agent with a saved copy. Keep drawing while it works.</p>
-          <label className="agent-label" htmlFor="agent-prompt">Describe the edit</label>
-          <textarea id="agent-prompt" aria-label="Describe the edit" placeholder="Connect this service to the queue…" value={agentPrompt} onChange={event => setAgentPrompt(event.target.value)} />
-          <p className="selection-note">{selection.length ? `${selection.length} selected ${selection.length === 1 ? 'element' : 'elements'}` : 'Select an area on Working to scope the edit.'}</p>
-          {!agentBase && !proposal && <button className="button button-outline" disabled={!ready || view !== 'working' || !agentPrompt.trim()} onClick={prepareAgentEdit}>Prepare agent edit</button>}
-          {agentBase && <><details className="agent-instructions" open={!proposal}><summary>Agent instructions</summary><p className="sidebar-note">Attach the downloaded input file to your agent.</p><textarea aria-label="Agent instructions" readOnly value={agentInstructions} /><button className="button button-quiet" onClick={async () => { try { await navigator.clipboard.writeText(agentInstructions); setNotice('Agent instructions copied.'); } catch { setError('Copy is unavailable. Select and copy the instructions above.'); } }}>Copy instructions</button></details>
-            <input ref={proposalInput} type="file" accept=".excalidraw,application/json" hidden onChange={loadProposal} />
-            <button className="button button-outline" onClick={() => proposalInput.current.click()}>Load proposal</button>
-            {!proposal && <button className="button button-quiet" onClick={discardProposal}>Cancel agent edit</button>}</>}
-          {proposal && <p className="sidebar-note proposal-note">Review the proposal beside your current work. Acceptance preserves independent manual edits.</p>}
-        </section>
         <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} disabled={!scene || !!error} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
@@ -542,8 +500,9 @@ function Review() {
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>{isReceipt ? 'Review a copy. Keep your original.' : 'Native files. Your drawing stays yours.'}</span></div>
       </aside>
       <main id="diagram-workspace" className="diagram-workspace" tabIndex={-1}>
-        <div className="workspace-heading"><div><p className="eyebrow">{isReceipt ? 'Compare & review' : 'Draw · refine · make it yours'}</p><h1>{title}</h1><p className="workspace-description">{isReceipt ? 'Inspect the preserved source review, or open an editable copy.' : 'Sketch freely. Review agent changes. Keep everything in one diagram.'}</p></div><span className="review-badge"><span />{view === 'working' ? 'Editable canvas' : 'Read-only snapshot'}</span>{isReceipt && <button className="button button-outline" onClick={() => initialize(structuredClone(displayed), { title })}>Edit copy</button>}</div>
+        <div className="workspace-heading"><div><p className="eyebrow">{isReceipt ? 'Compare & review' : 'Draw · refine · make it yours'}</p><h1>{title}</h1><p className="workspace-description">{isReceipt ? 'Inspect the preserved source review, or open an editable copy.' : 'Draw, refine, and save your diagram.'}</p></div>{isReceipt && <button className="button button-outline" onClick={() => initialize(structuredClone(displayed), { title })}>Edit copy</button>}</div>
         {error && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{error}</span>{scene && <button aria-label="Dismiss error" onClick={() => setError('')}>×</button>}</div>}
+        {saveError && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{saveError}</span></div>}
         <div className="canvas-card">
           <div className="canvas-toolbar"><div className="canvas-caption"><Icon name="layers" size={16} /><span>{viewLabel(view)}</span></div>
             {beforeScene && <div className="view-tabs" role="tablist" aria-label="Diagram version">{viewKeys.map((item, index) => <button key={item} ref={element => { tabs.current[index] = element; }} id={`${item}-tab`} role="tab" aria-selected={view === item} aria-controls="canvas-panel" tabIndex={view === item ? 0 : -1} onClick={() => selectView(item)} onKeyDown={event => { if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) { event.preventDefault(); const next = event.key === 'Home' ? 0 : event.key === 'End' ? viewKeys.length - 1 : (index + (event.key === 'ArrowRight' ? 1 : viewKeys.length - 1)) % viewKeys.length; selectView(viewKeys[next]); tabs.current[next]?.focus(); } }}>{viewLabel(item)}</button>)}</div>}
@@ -552,7 +511,7 @@ function Review() {
           </div>
           <div ref={canvasPanel} id="canvas-panel" className="canvas-panel" role={beforeScene ? 'tabpanel' : 'region'} aria-labelledby={beforeScene ? `${view}-tab` : undefined} aria-label={beforeScene ? undefined : 'Diagram canvas'} aria-busy={!ready && !error}>
             {working && <div className={`native-layer working-layer ${view !== 'working' ? 'layer-hidden' : ''}`} aria-hidden={view !== 'working'} {...(view !== 'working' ? { inert: '' } : {})}>
-              <CanvasBoundary key={documentId} onError={reportError}><WorkingCanvas key={documentId} scene={working} onScene={updateWorking} onApi={setWorkingApi} onSelection={updateSelection} /></CanvasBoundary>
+              <CanvasBoundary key={documentId} onError={reportError}><WorkingCanvas key={documentId} scene={working} onScene={updateWorking} onApi={setWorkingApi} /></CanvasBoundary>
             </div>}
             {view !== 'working' && displayed && <div className="native-layer snapshot-layer"><CanvasBoundary key={`${revision}-${view}`} onError={reportError}><Excalidraw key={`${revision}-${view}`} initialData={{ elements: structuredClone(displayed.elements), files: structuredClone(displayed.files || {}), appState: { ...displayed.appState, viewModeEnabled: true } }} excalidrawAPI={setReviewApi} viewModeEnabled={true} zenModeEnabled={true} theme="light" handleKeyboardGlobally={false} /></CanvasBoundary></div>}
             {!displayed && <div className="canvas-state"><span className={error ? '' : 'loading-symbol'}><Icon name={error ? 'info' : 'layers'} size={30} /></span><h2>{error ? 'Your diagram is waiting' : 'Opening your diagram'}</h2><p>{error ? 'Choose a file to start a new workspace.' : 'Preparing the native canvas…'}</p></div>}
@@ -562,7 +521,6 @@ function Review() {
           <div className="canvas-footer"><span id="status" role="status"><span className={`status-dot ${ready ? 'is-ready' : ''}`} />{ready ? `${elements.length} ${elements.length === 1 ? 'element' : 'elements'} · ${view === 'working' ? 'Draw and edit freely' : 'Viewing a read-only copy'}` : error ? 'Preview unavailable' : 'Preparing canvas…'}</span><span className="canvas-hint">{view === 'working' ? 'Space to pan · ⌘/Ctrl Z to undo' : 'Scroll to pan · Pinch to zoom'}</span></div>
         </div>
         {proposal && <div className="proposal-bar"><div><strong>{reconciliation?.conflicts.length ? 'Your work needs a fresh proposal' : 'Ready when you are'}</strong><p>{reconciliation?.conflicts.length ? reconciliation.conflicts.map(conflict => conflict.message).join(' ') : 'Accept these changes into Working, or keep your drawing as it is.'}</p></div><button className="button button-quiet" onClick={discardProposal}>Discard proposal</button><button className="button button-primary" disabled={!ready || !workingApi || !!reconciliation?.conflicts.length} onClick={acceptProposal}>Accept proposal</button></div>}
-        <div className="workspace-footer"><span>{isReceipt ? 'Made to stay editable.' : saveStatus || 'Download your diagram to keep a portable copy.'}</span><span role="status" aria-live="polite">{notice || (beforeScene ? `Exports use the ${viewLabel(view).toLowerCase()} view.` : 'PNG for sharing. Excalidraw for what comes next.')}</span></div>
       </main>
     </div>
   </div>;

--- a/test/editable-workspace.test.js
+++ b/test/editable-workspace.test.js
@@ -9,9 +9,10 @@ const readScene = page => page.evaluate(() => JSON.parse(JSON.stringify(window.s
 const live = scene => scene.elements.filter(element => !element.isDeleted);
 const tool = (page, name) => page.locator('.working-layer label').filter({ has: page.getByRole('radio', { name, exact: true }) });
 
-async function openWorkspace(t, init) {
+async function openWorkspace(t, init, propose) {
   const original = JSON.parse(readFileSync(fixture));
-  const preview = await servePreview(original);
+  const proposed = propose?.(structuredClone(original));
+  const preview = await servePreview(proposed || original, proposed ? { beforeScene: original } : {});
   t.after(() => preview.close());
   const browser = await chromium.launch();
   t.after(() => browser.close());
@@ -26,8 +27,9 @@ async function openWorkspace(t, init) {
   t.after(() => assert.deepEqual(errors, []));
   await page.goto(preview.url);
   await page.waitForFunction(() => window.previewReady);
+  if (proposed) await version(page, 'Working');
   assert.equal(await page.getByRole('tab', { name: 'Working', exact: true }).getAttribute('aria-selected'), 'true');
-  return { page, original };
+  return { page, original, proposal: proposed };
 }
 
 async function version(page, name) {
@@ -50,7 +52,7 @@ async function chooseScene(page, name, scene) {
 
 async function loadScene(page, name, scene) {
   await chooseScene(page, name, scene);
-  await page.waitForFunction(id => window.previewReady && document.getElementById(id)?.getAttribute('aria-selected') === 'true', name === 'Load proposal' ? 'after-tab' : 'working-tab');
+  await page.waitForFunction(id => window.previewReady && document.getElementById(id)?.getAttribute('aria-selected') === 'true', 'working-tab');
   if (name === 'Open file') await page.waitForFunction(() => document.title.startsWith('working ·'));
 }
 
@@ -102,16 +104,36 @@ async function insertImage(page, dataURL) {
   return live(await readScene(page)).find(element => element.type === 'image' && !ids.includes(element.id));
 }
 
-async function prepare(page, prompt) {
-  await page.getByRole('textbox', { name: 'Describe the edit', exact: true }).fill(prompt);
-  const captured = await downloadScene(page, page.getByRole('button', { name: 'Prepare agent edit', exact: true }));
-  assert.match(captured.name, /-agent-input\.excalidraw$/);
-  return captured.scene;
+async function waitForDraft(page, scene) {
+  // waitForFunction treats a returned Promise as truthy; await each IndexedDB
+  // read explicitly so reload cannot race a pending autosave transaction.
+  await page.evaluate(async expected => {
+    const db = await new Promise((resolve, reject) => {
+      const open = indexedDB.open('excalidraw-toolkit', 1);
+      open.onsuccess = () => resolve(open.result);
+      open.onerror = () => reject(open.error);
+    });
+    try {
+      const deadline = Date.now() + 10000;
+      while (Date.now() < deadline) {
+        const draft = await new Promise((resolve, reject) => {
+          const read = db.transaction('drafts').objectStore('drafts').get(location.pathname);
+          read.onsuccess = () => resolve(read.result);
+          read.onerror = () => reject(read.error);
+        });
+        if (JSON.stringify(draft?.working) === expected) return;
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+      throw new Error('The current working diagram was not saved to IndexedDB.');
+    } finally { db.close(); }
+  }, JSON.stringify(scene));
 }
 
 test('native drawing, text, and freehand survive review, browser recovery, and exact save/reopen', async t => {
   const { page, original } = await openWorkspace(t);
   assert.deepEqual(await readScene(page), original);
+  assert.doesNotMatch(await page.locator('body').innerText(), /Work with an agent|Editable canvas|Saved in this browser|Agent input downloaded/);
+  assert.equal(await page.getByRole('textbox', { name: 'Describe the edit', exact: true }).count(), 0);
   const rectangle = (await draw(page, 'rectangle')).element;
   const freehand = (await draw(page, 'freedraw', { x: 0.79, y: 0.64 })).element;
   assert.ok(freehand.points.length > 2);
@@ -151,7 +173,7 @@ test('native drawing, text, and freehand survive review, browser recovery, and e
   const png = readFileSync(await (await pngDownload).path());
   assert.equal(png.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');
   assert.ok(png.readUInt32BE(16) > 600);
-  await page.getByText('Saved in this browser', { exact: true }).waitFor();
+  await waitForDraft(page, saved);
   await page.reload();
   await page.waitForFunction(() => window.previewReady);
   assert.deepEqual(await readScene(page), saved, 'a completed local draft survives reload');
@@ -162,28 +184,27 @@ test('native drawing, text, and freehand survive review, browser recovery, and e
   assert.deepEqual(await readScene(page), saved, 'a native download reopens without dropping drawings, bindings, files, or metadata');
 });
 
-test('agent proposal merges over later manual work and acceptance is one native undo action', async t => {
-  const { page, original } = await openWorkspace(t);
+test('receipt proposal merges over later manual work and acceptance is one native undo action', async t => {
+  const { page, original, proposal } = await openWorkspace(t, undefined, proposal => {
+    proposal.elements.find(element => element.id === 'service').backgroundColor = '#a5d8ff';
+    proposal.elements.find(element => element.id === 'worker').backgroundColor = '#d0ebff';
+    proposal.elements.push(
+      { ...structuredClone(proposal.elements.find(element => element.id === 'service')), id: 'agent-component', x: 850, y: 100, groupIds: [], boundElements: null },
+      { ...structuredClone(proposal.elements.find(element => element.id === 'image')), id: 'agent-image', x: 850, y: 300, fileId: 'agent-asset' },
+    );
+    proposal.files['agent-asset'] = { ...structuredClone(proposal.files.asset), id: 'agent-asset' };
+    return proposal;
+  });
   const rectangle = (await draw(page, 'rectangle')).element;
   await page.keyboard.press('Escape');
-  const base = await prepare(page, 'Give the API service and worker blue fills, keeping all annotations.');
-  assert.ok(base.elements.some(element => element.id === rectangle.id), 'the agent receives the live canvas');
   const note = await writeText(page, 'Keep this later manual decision');
   const beforeAcceptance = await readScene(page);
-  const proposal = structuredClone(base);
-  proposal.elements.find(element => element.id === 'service').backgroundColor = '#a5d8ff';
-  proposal.elements.find(element => element.id === 'worker').backgroundColor = '#d0ebff';
-  proposal.elements.push(
-    { ...structuredClone(original.elements.find(element => element.id === 'service')), id: 'agent-component', x: 850, y: 100, groupIds: [], boundElements: null },
-    { ...structuredClone(original.elements.find(element => element.id === 'image')), id: 'agent-image', x: 850, y: 300, fileId: 'agent-asset' },
-  );
-  proposal.files['agent-asset'] = { ...structuredClone(original.files.asset), id: 'agent-asset' };
-  await loadScene(page, 'Load proposal', proposal);
+  await version(page, 'Agent proposal');
   assert.equal(await page.getByRole('tab', { name: 'Agent proposal', exact: true }).getAttribute('aria-selected'), 'true');
   assert.equal(live(await readScene(page)).some(element => element.id === note.id), false, 'the imported proposal remains an inspectable snapshot');
   await version(page, 'Before');
-  assert.ok(live(await readScene(page)).some(element => element.id === rectangle.id));
-  assert.equal(live(await readScene(page)).some(element => element.id === note.id), false, 'Before is the captured agent base');
+  assert.deepEqual(await readScene(page), original, 'Before is the preserved receipt input');
+  assert.equal(live(await readScene(page)).some(element => element.id === note.id), false, 'Before excludes later manual edits');
   await version(page, 'Agent proposal');
   assert.equal(await page.getByRole('button', { name: 'Accept proposal', exact: true }).isEnabled(), true, await page.locator('.proposal-bar').innerText());
   await page.getByRole('button', { name: 'Accept proposal', exact: true }).click();
@@ -217,19 +238,18 @@ test('agent proposal merges over later manual work and acceptance is one native 
   assert.deepEqual((await readScene(page)).files['agent-asset'], proposal.files['agent-asset'], 'redo keeps the added image bytes available');
 });
 
-test('a conflicting agent proposal cannot overwrite a manual edit and can be discarded', async t => {
-  const { page } = await openWorkspace(t);
-  const { element, point } = await draw(page, 'rectangle');
-  const base = await prepare(page, 'Move the selected component to the right.');
-  assert.ok((await page.getByRole('textbox', { name: 'Agent instructions', exact: true }).inputValue()).includes(element.id), 'agent instructions retain the native selection IDs');
-  await tool(page, 'Selection').click();
-  await page.mouse.click(point.x + 3, point.y + 30);
-  await page.keyboard.press('ArrowRight');
+test('a conflicting receipt proposal cannot overwrite a manual edit and can be discarded', async t => {
+  const { page, original } = await openWorkspace(t, undefined, proposal => {
+    proposal.elements.find(element => element.id === 'service').x += 100;
+    return proposal;
+  });
+  const element = original.elements.find(element => element.id === 'service');
+  await page.locator('.object-list').getByRole('button', { name: 'Show API service', exact: true }).click();
+  await page.locator('.working-layer').getByRole('button', { name: 'Delete', exact: true }).waitFor();
+  await page.locator('.working-layer .excalidraw').press('ArrowRight');
   await page.waitForFunction(({ id, x }) => window.sceneForPreview().elements.find(element => element.id === id)?.x !== x, { id: element.id, x: element.x });
   const manual = await readScene(page);
-  const proposal = structuredClone(base);
-  proposal.elements.find(value => value.id === element.id).x += 100;
-  await loadScene(page, 'Load proposal', proposal);
+  await version(page, 'Agent proposal');
   assert.equal(await page.getByRole('button', { name: 'Accept proposal', exact: true }).isEnabled(), false);
   assert.match(await page.locator('body').innerText(), /Both versions changed/);
   await version(page, 'Working');
@@ -264,20 +284,18 @@ test('opening another file can be cancelled or save the exact working diagram fi
   assert.deepEqual(await readScene(page), replacement, 'replacement opens a new document with its own preserved snapshot');
 });
 
-test('unrenderable proposals fail before acceptance and leave Working recoverable', async t => {
-  const { page, original } = await openWorkspace(t);
-  const base = await prepare(page, 'Add another component beside the worker.');
+test('unrenderable receipt proposals fail before acceptance and leave Working recoverable', async t => {
   for (const [id, fields] of [['zero-size', { type: 'rectangle', width: 0, height: 0 }], ['unsupported', { type: 'not-a-native-shape' }]]) {
-    const proposal = structuredClone(base);
-    proposal.elements.push({ ...structuredClone(original.elements.find(element => element.id === 'service')), id, x: 850, y: 100, groupIds: [], boundElements: null, ...fields });
-    await loadScene(page, 'Load proposal', proposal);
+    const { page, original } = await openWorkspace(t, undefined, proposal => {
+      proposal.elements.push({ ...structuredClone(proposal.elements.find(element => element.id === 'service')), id, x: 850, y: 100, groupIds: [], boundElements: null, ...fields });
+      return proposal;
+    });
     assert.equal(await page.getByRole('button', { name: 'Accept proposal', exact: true }).isEnabled(), false);
     assert.match(await page.locator('.proposal-bar').innerText(), /cannot display|supported|native type/i);
-    await version(page, 'Working');
     assert.deepEqual(await readScene(page), original);
+    await page.getByRole('button', { name: 'Discard proposal', exact: true }).click();
+    assert.deepEqual((await downloadScene(page, page.locator('#native'))).scene, original);
   }
-  await page.getByRole('button', { name: 'Discard proposal', exact: true }).click();
-  assert.deepEqual((await downloadScene(page, page.locator('#native'))).scene, original);
 });
 
 test('browser draft storage failure is visible while native saving remains available', async t => {
@@ -289,7 +307,7 @@ test('browser draft storage failure is visible while native saving remains avail
     };
   });
   await draw(page, 'rectangle');
-  await page.getByText('Draft could not be saved. Download your diagram to keep changes.', { exact: true }).waitFor();
+  await page.getByRole('alert').filter({ hasText: 'Draft could not be saved. Download your diagram to keep changes.' }).waitFor();
   assert.equal(await page.getByText('Saved in this browser', { exact: true }).count(), 0);
   const working = await readScene(page);
   assert.deepEqual((await downloadScene(page, page.locator('#native'))).scene, working);

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -249,10 +249,10 @@ test('expanded objects toggle native detail and fitted overview across Working a
   }
   const lastObject = objectList.getByRole('button', { name: 'Show Component 14', exact: true });
   await lastObject.click();
-  await page.locator('.selection-note').filter({ hasText: '1 selected element' }).waitFor();
+  await page.locator('.working-layer').getByRole('button', { name: 'Delete', exact: true }).waitFor();
   assert.equal(await lastObject.getAttribute('aria-pressed'), 'true');
   await lastObject.click();
-  await page.locator('.selection-note').filter({ hasText: 'Select an area on Working' }).waitFor();
+  await page.locator('.working-layer').getByRole('button', { name: 'Delete', exact: true }).waitFor({ state: 'hidden' });
   assert.equal(await lastObject.getAttribute('aria-pressed'), 'false');
   await overviewVisible();
   for (const name of ['Before', 'Agent proposal', 'Working']) {
@@ -261,13 +261,13 @@ test('expanded objects toggle native detail and fitted overview across Working a
     await overviewVisible();
   }
   await lastObject.click();
-  await page.locator('.selection-note').filter({ hasText: '1 selected element' }).waitFor();
+  await page.locator('.working-layer').getByRole('button', { name: 'Delete', exact: true }).waitFor();
   await page.getByRole('tab', { name: 'Before', exact: true }).click();
   await page.waitForFunction(() => window.previewReady);
   await lastObject.click();
   await page.getByRole('tab', { name: 'Working', exact: true }).click();
   await page.waitForFunction(() => window.previewReady);
-  await page.locator('.selection-note').filter({ hasText: 'Select an area on Working' }).waitFor();
+  await page.locator('.working-layer').getByRole('button', { name: 'Delete', exact: true }).waitFor({ state: 'hidden' });
   await overviewVisible();
   assert.deepEqual(await page.evaluate(() => window.sceneForPreview()), before, 'sidebar navigation preserves the working document');
 });


### PR DESCRIPTION
The sidebar prompt implied an in-page agent, but only prepared a manual file handoff. Remove that panel and its unused state, along with the editable/read-only badge and routine save/download footer messages. Autosave runs silently; storage failures remain visible and native downloads remain available.

Receipt-based proposal review, manual drawing, object navigation, and full screen remain supported. Update the workspace guide and browser tests to use the actual receipt workflow.

Validation: preview build and all 13 affected browser tests passed, including exact save/reopen, proposal conflicts and undo, failed storage, expanded objects, version switching, and mobile full screen. Computer-use checks covered the real 61-element architecture diagram, sidebar focus/overview, Before/Working, full screen, and native/PNG downloads.
