### PR TITLE
[Workspace]: make the document title editable and expand the canvas

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -47,6 +47,11 @@ unrelated manual drawings are retained.
 
 ## Save, export, and recover
 
+Click the document title in the sidebar to rename it. Enter or clicking away saves
+the name; Escape cancels. Native and PNG downloads use that name, with a version
+suffix for snapshots. Renaming Working also stores the name inside the native
+file. Renaming a receipt changes its download name without rewriting its snapshots.
+
 **Save diagram** downloads the live Working canvas as a native `.excalidraw` file,
 including manual additions and image data. **Open file** reopens that file here;
 it also remains usable in Excalidraw. Saving or exporting a snapshot uses that

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -33,7 +33,15 @@ svg { flex-shrink: 0; }
 .file-badge { color: #7d776b; font-size: 10px; padding: 3px 6px; border: 1px solid var(--line); border-radius: 4px; }
 .document-card { display: flex; align-items: flex-start; gap: 12px; margin: 22px 0 28px; }
 .document-icon { display: grid; place-items: center; width: 39px; height: 45px; background: #f0ece2; border: 1px solid #e4ddcd; border-radius: 6px; color: #9a8468; flex-shrink: 0; }
-.document-card h2 { font-size: 13px; font-weight: 550; line-height: 1.45; margin: 2px 0 5px; overflow-wrap: anywhere; }
+.document-card > div { flex: 1; min-width: 0; }
+.document-name h1 { margin: 0; font-size: 13px; font-weight: 550; line-height: 1.45; }
+.document-name-button { display: flex; align-items: flex-start; gap: 6px; width: 100%; margin: -4px -5px 1px; padding: 6px 5px; border: 0; border-radius: 5px; background: transparent; color: inherit; text-align: left; }
+.document-name-button > span { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.document-name-button svg { margin-top: 3px; color: #998a75; }
+.document-name-button:hover:not(:disabled) { background: #eee8dd; color: #805039; }
+.document-name-input { display: block; width: 100%; resize: vertical; min-height: 65px; margin: 0 0 7px; padding: 5px 6px; border: 1px solid #b89b7d; border-radius: 5px; background: #fffefa; color: var(--ink); font-size: 13px; line-height: 1.45; }
+.document-name-input:focus { outline: 2px solid #a25a3c; outline-offset: 2px; }
+.edit-copy { align-self: flex-start; margin: -12px 0 24px; }
 .document-card p { margin: 0; font-size: 11px; color: #827b6d; }
 .sidebar-section { border-top: 1px solid var(--line); padding-top: 22px; margin-bottom: 25px; }
 .section-heading { margin-bottom: 14px; }
@@ -79,11 +87,7 @@ svg { flex-shrink: 0; }
 .technical-changes pre { margin: 12px 0 0; padding: 12px; max-height: 260px; overflow: auto; border: 1px solid var(--line); border-radius: 5px; background: #f3f0e8; font: 10px/1.65 ui-monospace, SFMono-Regular, Menlo, monospace; tab-size: 2; }
 .sidebar-footer { margin-top: auto; padding-top: 25px; font-size: 10px; line-height: 1.5; color: #857d6e; display: flex; align-items: center; gap: 7px; }
 .sidebar-footer svg { color: #918c74; }
-.diagram-workspace { padding: 38px 40px 22px; min-width: 0; min-height: 0; display: flex; flex-direction: column; outline: none; }
-.workspace-heading { display: flex; flex-shrink: 0; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 28px; }
-.workspace-heading .eyebrow { color: #a67f65; margin-bottom: 10px; }
-.workspace-heading h1 { font-family: Georgia, "Times New Roman", serif; font-size: clamp(26px, 2.45vw, 37px); letter-spacing: -.8px; font-weight: 400; line-height: 1.2; margin: 0; overflow-wrap: anywhere; }
-.workspace-description { margin: 12px 0 0; color: #81796d; font-size: 12px; line-height: 1.6; }
+.diagram-workspace { padding: 24px; min-width: 0; min-height: 0; display: flex; flex-direction: column; outline: none; }
 .canvas-card { min-height: 200px; flex: 1; display: flex; flex-direction: column; background: #fff; border: 1px solid #e1ded4; border-radius: 11px; overflow: hidden; box-shadow: 0 3px 7px #33270e03, 0 16px 40px #33270e03; }
 .canvas-toolbar { min-height: 52px; flex-shrink: 0; padding: 10px 17px; display: flex; align-items: center; gap: 20px; border-bottom: 1px solid #eeece5; background: #fffefa; }
 .canvas-caption { display: flex; align-items: center; gap: 8px; color: #82796c; font-size: 11px; }
@@ -116,12 +120,10 @@ svg { flex-shrink: 0; }
 .feedback > span { overflow-wrap: anywhere; }
 .feedback button { border: 0; background: transparent; color: inherit; margin-left: auto; font-size: 22px; }
 @keyframes breathe { 50% { opacity: .4; transform: translateY(-2px); } }
-@media (min-width: 1600px) { .diagram-workspace { padding-left: 64px; padding-right: 64px; } }
-@media (max-width: 1100px) { .review-header { padding: 16px 22px; gap: 18px; } .header-label, .header-divider { display: none; } .diagram-workspace { padding: 30px 26px 20px; } .review-body { grid-template-columns: 236px minmax(0, 1fr); } .review-sidebar { padding-left: 18px; padding-right: 18px; } .workspace-heading { align-items: flex-start; } }
-@media (max-width: 820px) { .review-app { height: auto; min-height: 100dvh; } .review-body { display: flex; flex-direction: column; } .diagram-workspace { min-height: 540px; flex: 1; } .sidebar-toggle { display: flex; align-items: center; gap: 8px; min-height: 43px; border: 0; border-bottom: 1px solid var(--line); padding: 10px 24px; text-align: left; color: #7c7261; background: transparent; font-size: 11px; } .sidebar-toggle > span:last-child { margin-left: auto; font-size: 17px; } .review-sidebar { display: none; } .review-sidebar[data-open="true"] { display: flex; flex: none; max-height: 50dvh; padding: 20px 26px; border-right: 0; border-bottom: 1px solid var(--line); } .review-sidebar .sidebar-footer { padding-top: 0; } .review-header { flex-wrap: wrap; gap: 14px; } .brand { font-size: 16px; } .header-actions { gap: 7px; } .button { padding: 8px 10px; } .action-divider { display: none; } .workspace-heading h1 { font-size: 31px; } .canvas-panel { min-height: 260px; } }
-@media (max-width: 560px) { .review-header { padding: 15px 18px; } .header-actions { width: 100%; margin-left: 0; justify-content: space-between; } .button { min-height: 40px; padding: 8px; font-size: 11px; } .button-quiet { padding-left: 0; } .diagram-workspace { padding: 26px 16px 18px; } .workspace-heading { margin-bottom: 22px; } .workspace-heading h1 { font-size: 29px; } .workspace-description { max-width: 275px; } .canvas-toolbar { gap: 10px; padding: 10px 12px; flex-wrap: wrap; } .canvas-caption { margin-right: auto; } .fit-button span { display: none; } .fit-button { margin-left: 0; } .view-tabs button { padding: 6px 11px; } .canvas-hint { display: none; } .canvas-footer { padding: 10px 12px; } }
+@media (max-width: 1100px) { .review-header { padding: 16px 22px; gap: 18px; } .header-label, .header-divider { display: none; } .diagram-workspace { padding: 20px; } .review-body { grid-template-columns: 236px minmax(0, 1fr); } .review-sidebar { padding-left: 18px; padding-right: 18px; } }
+@media (max-width: 820px) { .review-app { height: auto; min-height: 100dvh; } .review-body { display: flex; flex-direction: column; } .diagram-workspace { min-height: 540px; flex: 1; } .sidebar-toggle { display: flex; align-items: center; gap: 8px; min-height: 43px; border: 0; border-bottom: 1px solid var(--line); padding: 10px 24px; text-align: left; color: #7c7261; background: transparent; font-size: 11px; } .sidebar-toggle > span:last-child { margin-left: auto; font-size: 17px; } .review-sidebar { display: none; } .review-sidebar[data-open="true"] { display: flex; flex: none; max-height: 50dvh; padding: 20px 26px; border-right: 0; border-bottom: 1px solid var(--line); } .review-sidebar .sidebar-footer { padding-top: 0; } .review-header { flex-wrap: wrap; gap: 14px; } .brand { font-size: 16px; } .header-actions { gap: 7px; } .button { padding: 8px 10px; } .action-divider { display: none; } .canvas-panel { min-height: 260px; } }
+@media (max-width: 560px) { .review-header { padding: 15px 18px; } .header-actions { width: 100%; margin-left: 0; justify-content: space-between; } .button { min-height: 40px; padding: 8px; font-size: 11px; } .button-quiet { padding-left: 0; } .diagram-workspace { padding: 16px; } .canvas-toolbar { gap: 10px; padding: 10px 12px; flex-wrap: wrap; } .canvas-caption { margin-right: auto; } .fit-button span { display: none; } .fit-button { margin-left: 0; } .view-tabs button { padding: 6px 11px; } .canvas-hint { display: none; } .canvas-footer { padding: 10px 12px; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; transition: none !important; } }
-
 /* The working editor remains mounted and keeps native history while snapshots
    are inspected. Visibility preserves its dimensions without exposing controls. */
 .native-layer { position: absolute; inset: 0; }
@@ -131,29 +133,22 @@ svg { flex-shrink: 0; }
 .proposal-bar > div { flex: 1; min-width: 0; }
 .proposal-bar strong { font-weight: 550; font-size: 12px; color: #594936; }
 .proposal-bar p { margin: 5px 0 0; color: #87755e; font-size: 11px; line-height: 1.5; }
-.review-app:has(.working-layer) .diagram-workspace { padding-top: 24px; }
-.review-app:has(.working-layer) .workspace-heading { margin-bottom: 20px; }
-.review-app:has(.working-layer) .workspace-heading h1 { font-size: clamp(25px, 2.2vw, 33px); }
 @media (max-width: 820px) {
   .review-app:has(.working-layer) { height: 100dvh; min-height: 680px; }
   .review-app:has(.working-layer) .diagram-workspace { min-height: 0; }
-  .review-app:has(.working-layer) .workspace-heading { margin-bottom: 16px; }
-  .review-app:has(.working-layer) .workspace-description { display: none; }
   .review-app:has(.working-layer) .canvas-panel { min-height: 300px; }
   .proposal-bar { flex-wrap: wrap; padding: 11px; gap: 8px; }
   .proposal-bar > div { flex-basis: 100%; }
   .proposal-bar .button { flex: 1; }
 }
-
 .replace-dialog::backdrop { background: #26251f55; }
 .replace-dialog { width: min(480px, 100%); padding: 27px; border-radius: 13px; border: 1px solid #e0d9cc; background: var(--paper); box-shadow: 0 20px 70px #26251f33; }
 .replace-dialog h2 { font: 26px Georgia, serif; margin: 0 0 12px; }
 .replace-dialog p { color: var(--muted); font-size: 13px; line-height: 1.7; }
 .replace-dialog > div { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 8px; margin-top: 22px; }
-
 .review-app.is-fullscreen { height: 100dvh; min-height: 0; }
 .review-app.is-fullscreen .review-header, .review-app.is-fullscreen .sidebar-toggle, .review-app.is-fullscreen .review-sidebar,
-.review-app.is-fullscreen .workspace-heading, .review-app.is-fullscreen .proposal-bar { display: none; }
+.review-app.is-fullscreen .proposal-bar { display: none; }
 .review-app.is-fullscreen .review-body { display: flex; }
 .review-app.is-fullscreen .diagram-workspace { flex: 1; min-height: 0; padding: 0; }
 .review-app.is-fullscreen .canvas-card { min-height: 0; border: 0; border-radius: 0; box-shadow: none; }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -180,6 +180,26 @@ function ElementFocus({ api, elementId }) {
   return style && <div className="element-focus" data-element-id={elementId} style={style} aria-hidden="true" />;
 }
 
+function DocumentTitle({ title, onRename, disabled }) {
+  const [editing, setEditing] = useState(false);
+  return <div className="document-name">
+    {editing ? <textarea className="document-name-input" aria-label="Diagram name" defaultValue={title} rows={3} maxLength={180} autoFocus
+      onFocus={event => event.target.select()}
+      onBlur={event => {
+        const next = event.target.value.replace(/[\r\n\t]+/g, ' ').trim().replace(/\.(excalidraw|png)$/i, '').trim();
+        if (event.target.value !== title && next && next !== title) onRename(next);
+        setEditing(false);
+      }} onKeyDown={event => {
+        if (event.nativeEvent.isComposing) return;
+        if (event.key === 'Enter' || event.key === 'Escape') {
+          event.preventDefault(); event.stopPropagation();
+          if (event.key === 'Escape') event.currentTarget.value = title;
+          event.currentTarget.blur();
+        }
+      }} /> : <h1 aria-label={title}><button className="document-name-button" aria-label="Rename diagram" title="Rename diagram" disabled={disabled} onClick={() => setEditing(true)}><span>{title}</span><Icon name="pen" size={13} /></button></h1>}
+  </div>;
+}
+
 function Review() {
   const [scene, setScene] = useState(null);
   const [context, setContext] = useState({});
@@ -222,7 +242,7 @@ function Review() {
   activeScene = displayed;
   const elements = useMemo(() => displayed?.elements.filter(e => !e.isDeleted) || [], [displayed]);
   const title = context.title?.trim() || (typeof working?.appState?.name === 'string' && working.appState.name) || 'Untitled diagram';
-  const filename = title.replace(/[<>:"/\\|?*\x00-\x1f]/g, '-').trim() || 'diagram';
+  const filename = title.replace(/[<>:"/\\|?*\x00-\x1f]/g, '-').replace(/[. ]+$/, '').trim() || 'diagram';
   const changes = useMemo(() => isReceipt ? context.changes : beforeScene && (proposal?.scene || working) ? deriveChanges(beforeScene, proposal?.scene || working) : null, [isReceipt, context.changes, beforeScene, proposal, working]);
   const summary = useMemo(() => summarizeEdits(beforeScene, proposal?.scene || working || scene, changes), [beforeScene, proposal, working, scene, changes]);
   function reconcile(base, current, proposed) {
@@ -239,6 +259,13 @@ function Review() {
   }
   const reconciliation = useMemo(() => proposal && working ? reconcile(proposal.base, working, proposal.scene) : null, [proposal, working]);
   function updateWorking(value) { workingRef.current = value; setWorking(value); }
+  function renameDocument(name) {
+    setContext(current => ({ ...current, title: name }));
+    if (workingRef.current) {
+      updateWorking({ ...workingRef.current, appState: { ...workingRef.current.appState, name } });
+      workingApi?.updateScene({ appState: { name }, captureUpdate: CaptureUpdateAction.NEVER });
+    }
+  }
   const objects = elements.filter(e => e.type !== 'text' && !['arrow', 'line'].includes(e.type));
   const categories = [['shape', 'Shapes', ['rectangle', 'ellipse', 'diamond']], ['arrow', 'Connections', ['arrow', 'line']], ['text', 'Labels', ['text']], ['frame', 'Frames', ['frame', 'magicframe']], ['image', 'Images', ['image']], ['pen', 'Freehand', ['freedraw']]].map(([icon, label, types]) => ({ icon, label, count: elements.filter(e => types.includes(e.type)).length })).filter(item => item.count);
   const otherCount = elements.length - categories.reduce((count, item) => count + item.count, 0);
@@ -303,7 +330,7 @@ function Review() {
       catch { setSaveError('Browser storage unavailable. Download your diagram to keep changes.'); }
       if (cancelled) return;
       initialize(value, metadata);
-      if (draft) {
+      if (draft && Object.hasOwn(draft, 'working')) {
         try {
           validate(draft.working); validate(draft.baseline);
           if (draft.proposal) { validate(draft.proposal.base); validate(draft.proposal.scene); }
@@ -311,29 +338,31 @@ function Review() {
           setContext(draft.context);
           setView('working');
         } catch { setSaveError('The saved draft could not be read. Your original diagram is open.'); }
+      } else if (typeof draft?.title === 'string') {
+        setContext(current => ({ ...current, title: draft.title }));
       }
       setLoaded(true);
     })().catch(error => reportError(error.message));
     return () => { cancelled = true; storage.current?.close(); };
   }, []);
   useEffect(() => {
-    if (!loaded || !working || !storage.current) return;
+    if (!loaded || (!working && !isReceipt) || !storage.current) return;
     const sequence = ++draftSequence.current;
     setDraftSaved(false);
     const timeout = setTimeout(() => {
-      storage.current.write({ working, baseline, proposal, context }).then(() => {
+      storage.current.write(working ? { working, baseline, proposal, context } : { title: context.title }).then(() => {
         if (draftSequence.current === sequence) { setDraftSaved(true); setSaveError(''); }
       }).catch(() => {
         if (draftSequence.current === sequence) setSaveError('Draft could not be saved. Download your diagram to keep changes.');
       });
     }, 250);
     return () => clearTimeout(timeout);
-  }, [loaded, working, baseline, proposal, context]);
+  }, [loaded, working, baseline, proposal, context, isReceipt]);
   useEffect(() => {
-    const warn = event => { if (working && !draftSaved) { event.preventDefault(); event.returnValue = ''; } };
+    const warn = event => { if ((working || isReceipt) && !draftSaved) { event.preventDefault(); event.returnValue = ''; } };
     window.addEventListener('beforeunload', warn);
     return () => window.removeEventListener('beforeunload', warn);
-  }, [working, draftSaved]);
+  }, [working, isReceipt, draftSaved]);
   useEffect(() => { document.title = `${title} · Excalidraw Toolkit`; }, [title]);
   useEffect(() => {
     if (!api || !ready || !focusedItem) return;
@@ -489,7 +518,8 @@ function Review() {
       <button className="sidebar-toggle" aria-expanded={detailsOpen} aria-controls="scene-details" onClick={() => setDetailsOpen(value => !value)}><Icon name="layers" size={16} /><span>Diagram details</span><span aria-hidden="true">{detailsOpen ? '−' : '+'}</span></button>
       <aside id="scene-details" className="review-sidebar" data-open={detailsOpen} aria-label="Diagram details">
         <div className="sidebar-heading"><span className="eyebrow">Workspace</span><span className="file-badge">.excalidraw</span></div>
-        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><h2>{title}</h2><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : proposal ? 'Proposal ready to review' : 'Editable working diagram'}</p></div></div>
+        <div className="document-card"><span className="document-icon"><Icon name="file" size={23} /></span><div><DocumentTitle key={documentId} title={title} onRename={renameDocument} disabled={!ready} /><p>{context.review?.kind === 'source-refresh' ? 'Staged refresh review' : proposal ? 'Proposal ready to review' : 'Editable working diagram'}</p></div></div>
+        {isReceipt && <button className="button button-outline edit-copy" onClick={() => initialize(structuredClone(displayed), { title })}>Edit copy</button>}
         {isReceipt ? <ReceiptDetails review={context.review} view={view} /> : <>
         <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} disabled={!scene || !!error} />
         <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
@@ -500,7 +530,6 @@ function Review() {
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>{isReceipt ? 'Review a copy. Keep your original.' : 'Native files. Your drawing stays yours.'}</span></div>
       </aside>
       <main id="diagram-workspace" className="diagram-workspace" tabIndex={-1}>
-        <div className="workspace-heading"><div><p className="eyebrow">{isReceipt ? 'Compare & review' : 'Draw · refine · make it yours'}</p><h1>{title}</h1><p className="workspace-description">{isReceipt ? 'Inspect the preserved source review, or open an editable copy.' : 'Draw, refine, and save your diagram.'}</p></div>{isReceipt && <button className="button button-outline" onClick={() => initialize(structuredClone(displayed), { title })}>Edit copy</button>}</div>
         {error && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{error}</span>{scene && <button aria-label="Dismiss error" onClick={() => setError('')}>×</button>}</div>}
         {saveError && <div className="feedback feedback-error" role="alert"><Icon name="info" /><span>{saveError}</span></div>}
         <div className="canvas-card">

--- a/test/editable-workspace.test.js
+++ b/test/editable-workspace.test.js
@@ -9,10 +9,10 @@ const readScene = page => page.evaluate(() => JSON.parse(JSON.stringify(window.s
 const live = scene => scene.elements.filter(element => !element.isDeleted);
 const tool = (page, name) => page.locator('.working-layer label').filter({ has: page.getByRole('radio', { name, exact: true }) });
 
-async function openWorkspace(t, init, propose) {
+async function openWorkspace(t, init, propose, metadata = {}) {
   const original = JSON.parse(readFileSync(fixture));
   const proposed = propose?.(structuredClone(original));
-  const preview = await servePreview(proposed || original, proposed ? { beforeScene: original } : {});
+  const preview = await servePreview(proposed || original, { ...metadata, ...(proposed ? { beforeScene: original } : {}) });
   t.after(() => preview.close());
   const browser = await chromium.launch();
   t.after(() => browser.close());
@@ -27,8 +27,8 @@ async function openWorkspace(t, init, propose) {
   t.after(() => assert.deepEqual(errors, []));
   await page.goto(preview.url);
   await page.waitForFunction(() => window.previewReady);
-  if (proposed) await version(page, 'Working');
-  assert.equal(await page.getByRole('tab', { name: 'Working', exact: true }).getAttribute('aria-selected'), 'true');
+  if (proposed && !metadata.review) await version(page, 'Working');
+  if (!metadata.review) assert.equal(await page.getByRole('tab', { name: 'Working', exact: true }).getAttribute('aria-selected'), 'true');
   return { page, original, proposal: proposed };
 }
 
@@ -104,10 +104,10 @@ async function insertImage(page, dataURL) {
   return live(await readScene(page)).find(element => element.type === 'image' && !ids.includes(element.id));
 }
 
-async function waitForDraft(page, scene) {
+async function waitForDraft(page, scene, field = 'working') {
   // waitForFunction treats a returned Promise as truthy; await each IndexedDB
   // read explicitly so reload cannot race a pending autosave transaction.
-  await page.evaluate(async expected => {
+  await page.evaluate(async ({ expected, field }) => {
     const db = await new Promise((resolve, reject) => {
       const open = indexedDB.open('excalidraw-toolkit', 1);
       open.onsuccess = () => resolve(open.result);
@@ -121,12 +121,12 @@ async function waitForDraft(page, scene) {
           read.onsuccess = () => resolve(read.result);
           read.onerror = () => reject(read.error);
         });
-        if (JSON.stringify(draft?.working) === expected) return;
+        if (JSON.stringify(draft?.[field]) === expected) return;
         await new Promise(resolve => setTimeout(resolve, 25));
       }
       throw new Error('The current working diagram was not saved to IndexedDB.');
     } finally { db.close(); }
-  }, JSON.stringify(scene));
+  }, { expected: JSON.stringify(scene), field });
 }
 
 test('native drawing, text, and freehand survive review, browser recovery, and exact save/reopen', async t => {
@@ -388,4 +388,93 @@ test('full screen keeps native drawing and undo, with read-only snapshots and a 
   await exit.click();
   assert.equal(await page.locator('.review-header').isVisible(), true);
   assert.ok(live(await readScene(page)).some(element => element.id === rectangle.id));
+});
+
+
+test('sidebar rename saves export names and document metadata while the canvas uses the removed heading space', async t => {
+  const { page, original } = await openWorkspace(t);
+  assert.equal(await page.locator('.workspace-heading').count(), 0);
+  assert.doesNotMatch(await page.locator('body').innerText(), /Draw · refine · make it yours/i);
+  const header = await page.locator('.review-header').boundingBox();
+  const card = await page.locator('.canvas-card').boundingBox();
+  assert.ok(card.y - header.y - header.height <= 25, 'the canvas starts directly beneath the header');
+  const rectangle = (await draw(page, 'rectangle')).element;
+  const beforeRename = await readScene(page);
+  const rename = page.getByRole('button', { name: 'Rename diagram', exact: true });
+  const name = page.getByRole('textbox', { name: 'Diagram name', exact: true });
+  await rename.click();
+  await name.fill('Discarded name');
+  await name.press('Escape');
+  assert.deepEqual(await readScene(page), beforeRename);
+  assert.equal(await rename.innerText(), 'Untitled diagram');
+  await rename.click();
+  await name.fill('   ');
+  await name.press('Enter');
+  assert.equal(await rename.innerText(), 'Untitled diagram', 'an empty edit keeps the current name');
+
+  await rename.click();
+  await name.fill('Serving architecture v2.excalidraw');
+  await name.press('Enter');
+  assert.equal(await rename.innerText(), 'Serving architecture v2');
+  const expected = { ...beforeRename, appState: { ...beforeRename.appState, name: 'Serving architecture v2' } };
+  assert.deepEqual(await readScene(page), expected, 'renaming changes only the working document name');
+  assert.equal(await page.title(), 'Serving architecture v2 · Excalidraw Toolkit');
+  const saved = await downloadScene(page, page.locator('#native'));
+  assert.equal(saved.name, 'Serving architecture v2.excalidraw');
+  assert.deepEqual(saved.scene, expected);
+  const png = page.waitForEvent('download');
+  await page.locator('#png').click();
+  assert.equal((await png).suggestedFilename(), 'Serving architecture v2.png');
+  await version(page, 'Before');
+  assert.deepEqual(await readScene(page), original, 'renaming never rewrites the preserved snapshot');
+  assert.equal((await downloadScene(page, page.locator('#native'))).name, 'Serving architecture v2-before.excalidraw');
+  await version(page, 'Working');
+  await page.getByRole('button', { name: 'Undo', exact: true }).click();
+  await page.waitForFunction(id => !window.sceneForPreview().elements.some(e => e.id === id && !e.isDeleted), rectangle.id);
+  assert.equal((await readScene(page)).appState.name, 'Serving architecture v2', 'rename does not displace native drawing history');
+  await page.getByRole('button', { name: 'Redo', exact: true }).click();
+  await page.waitForFunction(id => window.sceneForPreview().elements.some(e => e.id === id && !e.isDeleted), rectangle.id);
+
+  await rename.click();
+  await name.fill('Architecture / deployment: v3');
+  const blurredSave = await downloadScene(page, page.locator('#native'));
+  assert.equal(blurredSave.name, 'Architecture - deployment- v3.excalidraw', 'clicking Save commits the title first and sanitizes filename separators');
+  assert.equal(blurredSave.scene.appState.name, 'Architecture / deployment: v3');
+  await waitForDraft(page, blurredSave.scene);
+  await page.reload();
+  await page.waitForFunction(() => window.previewReady);
+  assert.equal(await rename.innerText(), 'Architecture / deployment: v3');
+  assert.deepEqual(await readScene(page), blurredSave.scene);
+  await loadScene(page, 'Open file', blurredSave.scene);
+  assert.deepEqual(await readScene(page), blurredSave.scene, 'the exported document name survives native reopen');
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole('button', { name: 'Diagram details', exact: true }).click();
+  await rename.click();
+  await name.fill('Mobile architecture');
+  await name.press('Enter');
+  assert.equal(await rename.innerText(), 'Mobile architecture');
+  assert.equal((await readScene(page)).appState.name, 'Mobile architecture');
+});
+
+test('source receipt rename persists without modifying snapshots and Edit copy remains reachable', async t => {
+  const { page, original } = await openWorkspace(t, undefined, scene => scene, {
+    title: 'Original source title',
+    review: { kind: 'source-refresh', status: 'reconciliation-required', viewLabels: { before: 'Before', after: 'After' }, conflicts: [], overrides: [], changes: [], source: { revision: '0123456789abcdef', scope: { question: 'Review scoped changes', paths: ['src/service.js'], unknowns: [] } } },
+  });
+  const rename = page.getByRole('button', { name: 'Rename diagram', exact: true });
+  await rename.click();
+  await page.getByRole('textbox', { name: 'Diagram name', exact: true }).fill('Source review');
+  const downloaded = await downloadScene(page, page.locator('#native'));
+  assert.equal(downloaded.name, 'Source review-after.excalidraw');
+  assert.deepEqual(downloaded.scene, original, 'retained snapshots keep exact content');
+  await waitForDraft(page, 'Source review', 'title');
+  await page.reload();
+  await page.waitForFunction(() => window.previewReady);
+  assert.equal(await rename.innerText(), 'Source review');
+  assert.deepEqual(await readScene(page), original);
+  await page.getByRole('button', { name: 'Edit copy', exact: true }).click();
+  await page.waitForFunction(() => window.previewReady && document.querySelector('#working-tab')?.getAttribute('aria-selected') === 'true');
+  assert.equal(await rename.innerText(), 'Source review');
+  assert.deepEqual(await readScene(page), original);
 });


### PR DESCRIPTION
Remove the decorative heading above the canvas and use the sidebar document title as the rename control. Enter or clicking away commits the name; Escape cancels. Native and PNG downloads use the chosen name, and Working saves it inside the file. Snapshot contents remain unchanged.

The name survives browser reloads, including source receipt views. Move Edit copy into the sidebar and reduce canvas margins to reclaim the heading space.

Validation: preview build and 15 browser tests passed, including rename/cancel, export filenames, native save/reopen, draft recovery, snapshot preservation, native undo, proposal conflicts, object navigation, and mobile full screen. Final focused rename checks passed after accessibility adjustments. Computer-use validation covered the real 61-element diagram, title editing, save and PNG controls, and the expanded canvas layout.
