### PR TITLE
[Workspace]: make sidebar sections collapsible

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -14,7 +14,10 @@ so drawing and undo history survive both modes. Historical snapshots remain read
 - **Working** is your editable document. Click an object or edit in the sidebar to
   find it on the canvas. Click it again to clear the selection and fit the entire
   diagram; switching versions keeps that overview. Expand **more objects** to reach
-  the rest of the list. Native undo history stays available when you visit snapshots.
+  the rest of the list. Click **Edit summary**, **Scene overview**, or **In this
+  diagram** to fold that section independently; Enter and Space work too. Folding
+  preserves the expanded object list and your canvas selection. Native undo
+  history stays available when you visit snapshots.
 - **Before** is the preserved input file or the original input from an edit receipt.
 - **Agent proposal** is the returned diagram, displayed read-only. Accept merges its
   changes into your latest work. Discard leaves your working diagram unchanged.

--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -47,6 +47,15 @@ svg { flex-shrink: 0; }
 .section-heading { margin-bottom: 14px; }
 .section-heading h2 { font-size: 11px; font-weight: 600; margin: 0; color: #686459; }
 .section-heading > span { font-size: 11px; color: #7e7669; font-variant-numeric: tabular-nums; }
+.collapsible-section { padding-top: 14px; margin-bottom: 18px; }
+.collapsible-section > summary { min-height: 34px; margin: 0; padding: 5px 0; cursor: pointer; list-style: none; border-radius: 4px; }
+.collapsible-section > summary::-webkit-details-marker { display: none; }
+.collapsible-section > summary::before { content: ''; width: 6px; height: 6px; margin: 0 2px; border-right: 1.5px solid #968b7a; border-bottom: 1.5px solid #968b7a; transform: rotate(-45deg); transition: transform .16s ease; flex-shrink: 0; }
+.collapsible-section[open] > summary::before { transform: rotate(45deg); }
+.collapsible-section > summary h2 { flex: 1; }
+.collapsible-section > summary:hover { background: #eee8dd; }
+.collapsible-section > summary:focus-visible { outline: 2px solid #a25a3c; outline-offset: 4px; }
+.section-content { padding-top: 12px; }
 .scene-stats { margin: 0; display: grid; gap: 12px; }
 .scene-stats > div { display: flex; align-items: center; justify-content: space-between; font-size: 12px; }
 .scene-stats dt { display: flex; align-items: center; gap: 10px; color: #706d62; }

--- a/src/web/preview.jsx
+++ b/src/web/preview.jsx
@@ -522,10 +522,10 @@ function Review() {
         {isReceipt && <button className="button button-outline edit-copy" onClick={() => initialize(structuredClone(displayed), { title })}>Edit copy</button>}
         {isReceipt ? <ReceiptDetails review={context.review} view={view} /> : <>
         <EditSummary changes={changes} summary={summary} focusedId={focusedItem?.id} onFocus={focusItem} disabled={!scene || !!error} />
-        <section className="sidebar-section" aria-labelledby="overview-title"><div className="section-heading"><h2 id="overview-title">Scene overview</h2><span>{elements.length}</span></div>
+        <SidebarSection id="overview-title" title="Scene overview" count={<span>{elements.length}</span>}>
           {categories.length ? <dl className="scene-stats">{categories.map(item => <div key={item.label}><dt><Icon name={item.icon} size={16} />{item.label}</dt><dd>{item.count}</dd></div>)}</dl> : <p className="sidebar-note">{scene ? 'This scene has no visible elements.' : 'Waiting for the diagram…'}</p>}
-        </section>
-        {objects.length > 0 && <section className="sidebar-section object-section" aria-labelledby="objects-title"><div className="section-heading"><h2 id="objects-title">In this diagram</h2></div><ul id="object-list" className="object-list">{(objectsExpanded ? objects : objects.slice(0, 6)).map(element => <li key={element.id}><button className="object-link" disabled={!scene || !!error} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <button className="sidebar-note more-objects" aria-expanded={objectsExpanded} aria-controls="object-list" onClick={() => setObjectsExpanded(expanded => !expanded)}>{objectsExpanded ? 'Show fewer objects' : `+${objects.length - 6} more ${objects.length === 7 ? 'object' : 'objects'}`}</button>}</section>}
+        </SidebarSection>
+        {objects.length > 0 && <SidebarSection id="objects-title" title="In this diagram" className="object-section"><ul id="object-list" className="object-list">{(objectsExpanded ? objects : objects.slice(0, 6)).map(element => <li key={element.id}><button className="object-link" disabled={!scene || !!error} aria-label={`Show ${elementLabel(element, elements)}`} aria-pressed={focusedItem?.elementId === element.id} onClick={() => focusItem({ id: `object:${element.id}`, elementId: element.id, text: elementLabel(element, elements) })}><span className="object-dot" /><span title={elementLabel(element, elements)}>{elementLabel(element, elements)}</span></button></li>)}</ul>{objects.length > 6 && <button className="sidebar-note more-objects" aria-expanded={objectsExpanded} aria-controls="object-list" onClick={() => setObjectsExpanded(expanded => !expanded)}>{objectsExpanded ? 'Show fewer objects' : `+${objects.length - 6} more ${objects.length === 7 ? 'object' : 'objects'}`}</button>}</SidebarSection>}
         </>}
         <div className="sidebar-footer"><Icon name="check" size={15} /><span>{isReceipt ? 'Review a copy. Keep your original.' : 'Native files. Your drawing stays yours.'}</span></div>
       </aside>
@@ -554,10 +554,16 @@ function Review() {
     </div>
   </div>;
 }
+function SidebarSection({ id, title, count, className = '', children }) {
+  return <details open className={`sidebar-section collapsible-section ${className}`} aria-labelledby={id}>
+    <summary className="section-heading" aria-label={title}><h2 id={id}>{title}</h2>{count}</summary>
+    <div className="section-content">{children}</div>
+  </details>;
+}
+
 function EditSummary({ changes, summary, focusedId, onFocus, disabled }) {
   const fieldCount = changes?.reduce((count, change) => count + Object.keys(change.properties || {}).length, 0) || 0;
-  return <section className="sidebar-section changes-section" aria-labelledby="changes-title">
-    <div className="section-heading"><h2 id="changes-title">Edit summary</h2>{summary && <span className="change-count" aria-label={`${summary.length} summarized edits`}>{summary.length}</span>}</div>
+  return <SidebarSection id="changes-title" title="Edit summary" className="changes-section" count={summary && <span className="change-count" aria-label={`${summary.length} summarized edits`}>{summary.length}</span>}>
     {summary?.length ? <><p className="sidebar-note change-hint">Select an edit to find it on the canvas.</p><ul className="change-list">{summary.map(item => <li key={item.id}><button className="change-link" disabled={disabled} aria-label={`Show ${item.text}`} aria-describedby={item.details.length ? item.details.map((_, index) => `change-${encodeURIComponent(item.id)}-${index}`).join(' ') : undefined} aria-pressed={focusedId === item.id} onClick={() => onFocus(item)}>
       <span className={`change-mark change-mark--${item.kind}`} aria-hidden="true">{item.kind === 'added' ? '+' : item.kind === 'removed' ? '−' : '↗'}</span>
       <span className="change-description"><span className="change-title">{item.text}</span>{item.details.map((detail, index) => <span className="property-change" id={`change-${encodeURIComponent(item.id)}-${index}`} key={index}>
@@ -569,7 +575,7 @@ function EditSummary({ changes, summary, focusedId, onFocus, disabled }) {
       <p className="sidebar-note">Display values are rounded to two decimals. The editable copy keeps the original values.</p>
       <pre tabIndex={0} aria-label="Full element field changes">{formatTechnicalChanges(changes)}</pre>
     </details>}
-  </section>;
+  </SidebarSection>;
 }
 function StyleValue({ value, label }) {
   const color = typeof value === 'string' && /^(#[\da-f]{3,8}|transparent)$/i.test(value);

--- a/test/native-preview.test.js
+++ b/test/native-preview.test.js
@@ -176,7 +176,7 @@ test('edit summary buttons focus native elements across versions without changin
   assert.deepEqual(errors, []);
 });
 
-test('expanded objects toggle native detail and fitted overview across Working and snapshots', async t => {
+test('sidebar sections fold independently and expanded objects retain detail and overview navigation', async t => {
   const template = JSON.parse(readFileSync(fixture));
   const before = { ...template, files: {}, elements: [] };
   for (let index = 0; index < 14; index++) {
@@ -219,6 +219,25 @@ test('expanded objects toggle native detail and fitted overview across Working a
       });
     });
   };
+  const sections = ['changes', 'overview', 'objects'].map(id => page.locator(`details[aria-labelledby="${id}-title"]`));
+  const initialSidebarHeight = (await page.locator('.object-section').boundingBox()).y;
+  for (let index = 0; index < sections.length; index++) {
+    const section = sections[index];
+    assert.equal(await section.getAttribute('open'), '', 'sections start expanded');
+    await section.locator(':scope > summary').click();
+    assert.equal(await section.getAttribute('open'), null);
+    assert.equal(await section.locator('.section-content').isVisible(), false, 'folding hides the section body');
+    assert.equal(await section.locator(':scope > summary').isVisible(), true, 'the heading remains available');
+    if (index + 1 < sections.length) assert.equal(await sections[index + 1].getAttribute('open'), '', 'other sections remain open');
+  }
+  assert.ok((await page.locator('.object-section').boundingBox()).y < initialSidebarHeight - 100, 'folded sections reclaim sidebar space');
+  assert.equal(await page.getByRole('button', { name: 'Show Component 1', exact: true }).count(), 0, 'folded objects leave the accessibility and keyboard navigation surface');
+  assert.equal(await page.locator('.change-count').isVisible(), true, 'counts remain visible while folded');
+  await sections[2].locator(':scope > summary').press('Enter');
+  assert.equal(await sections[2].getAttribute('open'), '', 'Enter expands a section');
+  await sections[1].locator(':scope > summary').press('Space');
+  assert.equal(await sections[1].getAttribute('open'), '', 'Space expands a section');
+  // Keep Edit summary folded while native selection and version changes rerender.
   const objectList = page.locator('.object-list');
   assert.equal(await objectList.getByRole('button').count(), 6);
   const expand = page.getByRole('button', { name: '+8 more objects', exact: true });
@@ -226,6 +245,9 @@ test('expanded objects toggle native detail and fitted overview across Working a
   assert.equal(await expand.getAttribute('aria-expanded'), 'false');
   await expand.click();
   assert.equal(await objectList.getByRole('button').count(), 14);
+  await sections[2].locator(':scope > summary').click();
+  await sections[2].locator(':scope > summary').click();
+  assert.equal(await objectList.getByRole('button').count(), 14, 'reopening retains the expanded object list');
   const collapse = page.getByRole('button', { name: 'Show fewer objects', exact: true });
   assert.equal(await collapse.getAttribute('aria-expanded'), 'true');
   assert.equal(await collapse.getAttribute('aria-controls'), await objectList.getAttribute('id'));
@@ -270,6 +292,14 @@ test('expanded objects toggle native detail and fitted overview across Working a
   await page.locator('.working-layer').getByRole('button', { name: 'Delete', exact: true }).waitFor({ state: 'hidden' });
   await overviewVisible();
   assert.deepEqual(await page.evaluate(() => window.sceneForPreview()), before, 'sidebar navigation preserves the working document');
+  assert.equal(await sections[0].getAttribute('open'), null, 'version switches and object selection keep the chosen fold state');
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole('button', { name: 'Diagram details', exact: true }).click();
+  await sections[1].locator(':scope > summary').click();
+  assert.equal(await sections[1].locator('.section-content').isVisible(), false, 'mobile headings fold their own content');
+  await sections[1].locator(':scope > summary').click();
+  assert.equal(await sections[1].locator('.section-content').isVisible(), true);
+  assert.equal(await sections[0].getAttribute('open'), null);
 });
 
 test('review transitions wait for a fitted view, survive rapid keyboard changes, and retain exact exports', async t => {


### PR DESCRIPTION
Make Edit summary, Scene overview, and In this diagram independently collapsible. Each heading keeps its count visible and shows a rotating chevron. Native disclosure controls support click, Enter, and Space; hidden contents leave keyboard navigation.

Folding retains object-list expansion and canvas selection. Version switches keep the chosen fold states during the session.

Validation: preview build and all 15 browser tests passed, including independent folding, keyboard controls, mobile use, expanded-object recovery, version switching, and unchanged working scenes. Computer-use checks on the real 61-element architecture diagram confirmed the folded layout and selection preservation after reopening a section.
