### PR TITLE
[Workspace]: refine collapsible sidebar headers

### DIFF
--- a/src/web/preview.css
+++ b/src/web/preview.css
@@ -48,13 +48,15 @@ svg { flex-shrink: 0; }
 .section-heading h2 { font-size: 11px; font-weight: 600; margin: 0; color: #686459; }
 .section-heading > span { font-size: 11px; color: #7e7669; font-variant-numeric: tabular-nums; }
 .collapsible-section { padding-top: 14px; margin-bottom: 18px; }
-.collapsible-section > summary { min-height: 34px; margin: 0; padding: 5px 0; cursor: pointer; list-style: none; border-radius: 4px; }
+.collapsible-section > summary { min-height: 38px; margin: 0 -10px; padding: 8px 10px; gap: 10px; cursor: pointer; list-style: none; border-radius: 7px; transition: background .15s ease; }
 .collapsible-section > summary::-webkit-details-marker { display: none; }
-.collapsible-section > summary::before { content: ''; width: 6px; height: 6px; margin: 0 2px; border-right: 1.5px solid #968b7a; border-bottom: 1.5px solid #968b7a; transform: rotate(-45deg); transition: transform .16s ease; flex-shrink: 0; }
-.collapsible-section[open] > summary::before { transform: rotate(45deg); }
-.collapsible-section > summary h2 { flex: 1; }
-.collapsible-section > summary:hover { background: #eee8dd; }
-.collapsible-section > summary:focus-visible { outline: 2px solid #a25a3c; outline-offset: 4px; }
+.collapsible-section > summary::after { content: ''; width: 5px; height: 5px; margin: 0 3px; border-right: 1.5px solid #968b7a; border-bottom: 1.5px solid #968b7a; transform: rotate(-45deg); transition: transform .16s ease; flex-shrink: 0; }
+.collapsible-section[open] > summary::after { transform: rotate(45deg); }
+.collapsible-section > summary h2 { flex: 1; min-width: 0; font-size: 12px; line-height: 1.5; }
+.collapsible-section > summary > span { display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; min-width: 22px; min-height: 20px; padding: 1px 6px; border-radius: 5px; background: #eeece5; color: #7e7669; font-size: 10px; line-height: 1.5; }
+.collapsible-section > summary:hover { background: #f0ede6; }
+.collapsible-section > summary:active { background: #eae5da; }
+.collapsible-section > summary:focus-visible { outline: 2px solid #a25a3c; outline-offset: 2px; }
 .section-content { padding-top: 12px; }
 .scene-stats { margin: 0; display: grid; gap: 12px; }
 .scene-stats > div { display: flex; align-items: center; justify-content: space-between; font-size: 12px; }
@@ -71,7 +73,6 @@ svg { flex-shrink: 0; }
 .sidebar-note { font-size: 11px; line-height: 1.65; color: #81796b; margin: 0; }
 .more-objects { display: block; width: 100%; min-height: 32px; margin-top: 10px; padding: 6px 6px 6px 26px; border: 0; border-radius: 5px; background: transparent; text-align: left; }
 .more-objects:hover { color: #805039; background: #eee8dd; }
-.change-count { background: #eee3d8; border: 1px solid #e6d5c4; color: #9b6548 !important; border-radius: 5px; min-width: 20px; text-align: center; padding: 2px 5px; }
 .change-hint { margin: -3px 0 14px; font-size: 10px; }
 .change-list { display: grid; gap: 4px; }
 .change-link { display: flex; align-items: flex-start; gap: 9px; width: calc(100% + 16px); padding: 9px 8px; margin: 0 -8px; border: 1px solid transparent; border-radius: 7px; background: transparent; text-align: left; transition: background .15s ease, border-color .15s ease; }


### PR DESCRIPTION
Refine the collapsible sidebar headers with padded, rounded hover backgrounds, aligned labels, and smaller trailing chevrons. Give edit and scene counts the same quiet badge style.

Validation: `npm run build:preview` and `git diff --check` passed. Used computer use to inspect the live workspace and verify expanded, folded, and hover states.
